### PR TITLE
Release 4.0.0

### DIFF
--- a/client/oslc-client-base/pom.xml
+++ b/client/oslc-client-base/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.eclipse.lyo.clients</groupId>
     <artifactId>clients-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
   </parent>
 
   <artifactId>oslc-client-base</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0</version>
   <name>Lyo :: Client :: Base</name>
 
   <properties>

--- a/client/oslc-client/pom.xml
+++ b/client/oslc-client/pom.xml
@@ -5,12 +5,12 @@
     <parent>
       <groupId>org.eclipse.lyo.clients</groupId>
       <artifactId>clients-parent</artifactId>
-      <version>4.0.0-SNAPSHOT</version>
+      <version>4.0.0</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>oslc-client</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <name>Lyo :: Client :: OSLC JAX-RS 2.0 (new)</name>
     <description>Eclipse Lyo OSLC Java client based on OSLC4J and JAX-RS 2.0</description>
 

--- a/client/oslc-java-client-resources/pom.xml
+++ b/client/oslc-java-client-resources/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.eclipse.lyo.clients</groupId>
     <artifactId>clients-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
   </parent>
 
   <artifactId>oslc-java-client-resources</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0</version>
   <name>Lyo :: Client :: Resources (legacy)</name>
 
   <properties>

--- a/client/oslc-java-client/pom.xml
+++ b/client/oslc-java-client/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <groupId>org.eclipse.lyo.clients</groupId>
     <artifactId>clients-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
   </parent>
   <artifactId>oslc-java-client</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0</version>
   <name>Lyo :: Client :: OSLC Wink (legacy)</name>
 
   <description>Eclipse Lyo OSLC Java client based on OSLC4J and Apache Wink.</description>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,13 +6,13 @@
 
   <groupId>org.eclipse.lyo.clients</groupId>
   <artifactId>clients-parent</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0</version>
   <packaging>pom</packaging>
   <name>Lyo :: Client :: _Parent</name>
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Lyo Core changelog
 
-## [Unreleased/4.0.0]
+## [4.0.0]
 
 ### Added
 

--- a/core/oslc-query/pom.xml
+++ b/core/oslc-query/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
 

--- a/core/oslc-trs/pom.xml
+++ b/core/oslc-trs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
 

--- a/core/oslc4j-core-build/pom.xml
+++ b/core/oslc4j-core-build/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
   </parent>
 
   <properties>

--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
   <artifactId>oslc4j-core</artifactId>

--- a/core/oslc4j-jena-provider/pom.xml
+++ b/core/oslc4j-jena-provider/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core-build</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0</version>
         <relativePath>../oslc4j-core-build/pom.xml</relativePath>
     </parent>
     <artifactId>oslc4j-jena-provider</artifactId>

--- a/core/oslc4j-json4j-provider/pom.xml
+++ b/core/oslc4j-json4j-provider/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core-build</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0</version>
         <relativePath>../oslc4j-core-build/pom.xml</relativePath>
     </parent>
     <artifactId>oslc4j-json4j-provider</artifactId>

--- a/core/oslc4j-utils/pom.xml
+++ b/core/oslc4j-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core-build</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0</version>
         <relativePath>../oslc4j-core-build/pom.xml</relativePath>
     </parent>
     <name>Lyo :: Core :: Utilities</name>

--- a/core/shacl/pom.xml
+++ b/core/shacl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../oslc4j-core-build/pom.xml</relativePath>
   </parent>
 

--- a/domains/org.eclipse.lyo.tools.domainmodels/oslcDomainSpecifications.xml
+++ b/domains/org.eclipse.lyo.tools.domainmodels/oslcDomainSpecifications.xml
@@ -43,7 +43,7 @@
     <resourceProperties id="_tl7rcCKJEeuEW8NmTOtW7w" name="publisher" valueType="Resource" range="_nr5V8CKJEeuEW8NmTOtW7w" representation="inline"/>
     <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
       <generalConfiguration filesBasePath="" javaBasePackageName=""/>
-      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0-SNAPSHOT" groupId="" artifactId="Dublin Core" version="0.0.1-SNAPSHOT"/>
+      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0" groupId="" artifactId="Dublin Core" version="0.0.1-SNAPSHOT"/>
     </configuration>
   </domainSpecifications>
   <domainSpecifications name="FOAF" namespaceURI="http://xmlns.com/foaf/0.1/#" namespacePrefix="//@domainPrefixes[name='foaf']">
@@ -148,7 +148,7 @@
     <resourceProperties id="_kXjpACLZEeu9M4063qtrOA" name="domain" valueType="URI"/>
     <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
       <generalConfiguration doNotGenerate="true" filesBasePath="" javaBasePackageName="org.eclipse.lyo.oslc4j.core.model"/>
-      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0-SNAPSHOT" groupId="org.eclipse.lyo.oslc4j.core.model" artifactId="OSLC" version="0.0.1-SNAPSHOT"/>
+      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0" groupId="org.eclipse.lyo.oslc4j.core.model" artifactId="OSLC" version="0.0.1-SNAPSHOT"/>
     </configuration>
   </domainSpecifications>
   <domainSpecifications name="Change Management shapes" namespaceURI="http://open-services.net/ns/cm#" namespacePrefix="//@domainPrefixes[name='oslc_cm']">
@@ -221,7 +221,7 @@
     <resourceProperties id="_poKfdpUdEeq-KoPaR9_Cfg" name="authorizer" occurs="zeroOrMany" valueType="Resource" range="_posq85UdEeq-KoPaR9_Cfg"/>
     <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
       <generalConfiguration filesBasePath="" javaBasePackageName="org.eclipse.lyo.oslc.domains.cm"/>
-      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0-SNAPSHOT" groupId="org.eclipse.lyo.oslc.domains.cm" artifactId="Change Management shapes" version="0.0.1-SNAPSHOT"/>
+      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0" groupId="org.eclipse.lyo.oslc.domains.cm" artifactId="Change Management shapes" version="0.0.1-SNAPSHOT"/>
     </configuration>
   </domainSpecifications>
   <domainSpecifications name="Requirements Management shapes" namespaceURI="http://open-services.net/ns/rm#" namespacePrefix="//@domainPrefixes[name='oslc_rm']">
@@ -278,7 +278,7 @@
     </resourceProperties>
     <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
       <generalConfiguration filesBasePath="" javaBasePackageName="org.eclipse.lyo.oslc.domains.rm"/>
-      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0-SNAPSHOT" groupId="org.eclipse.lyo.oslc.domains.rm" artifactId="Requirements Management shapes" version="0.0.1-SNAPSHOT"/>
+      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0" groupId="org.eclipse.lyo.oslc.domains.rm" artifactId="Requirements Management shapes" version="0.0.1-SNAPSHOT"/>
     </configuration>
   </domainSpecifications>
   <domainSpecifications name="Quality Management" namespaceURI="http://open-services.net/ns/qm#" namespacePrefix="//@domainPrefixes[name='oslc_qm']">
@@ -345,7 +345,7 @@
     </resourceProperties>
     <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
       <generalConfiguration filesBasePath="" javaBasePackageName="org.eclipse.lyo.oslc.domains.qm"/>
-      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0-SNAPSHOT" groupId="org.eclipse.lyo.oslc.domains.qm" artifactId="Quality Management" version="0.0.1-SNAPSHOT"/>
+      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0" groupId="org.eclipse.lyo.oslc.domains.qm" artifactId="Quality Management" version="0.0.1-SNAPSHOT"/>
     </configuration>
   </domainSpecifications>
   <domainSpecifications name="Architecture Management" namespaceURI="http://open-services.net/ns/am#" namespacePrefix="//@domainPrefixes[name='oslc_am']">
@@ -353,7 +353,7 @@
     <resources id="_porc0ZUdEeq-KoPaR9_Cfg" name="LinkType" resourceProperties="_pna4kZUdEeq-KoPaR9_Cfg _pnXOMZUdEeq-KoPaR9_Cfg _pna4kJUdEeq-KoPaR9_Cfg _pnX1QJUdEeq-KoPaR9_Cfg _pnYcUJUdEeq-KoPaR9_Cfg _pnZqcpUdEeq-KoPaR9_Cfg _pnZqdJUdEeq-KoPaR9_Cfg _posD4JUdEeq-KoPaR9_Cfg _posD4ZUdEeq-KoPaR9_Cfg"/>
     <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
       <generalConfiguration filesBasePath="" javaBasePackageName="org.eclipse.lyo.oslc.domains.am"/>
-      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0-SNAPSHOT" groupId="org.eclipse.lyo.oslc.domains.am" artifactId="Architecture Management" version="0.0.1-SNAPSHOT"/>
+      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0" groupId="org.eclipse.lyo.oslc.domains.am" artifactId="Architecture Management" version="0.0.1-SNAPSHOT"/>
     </configuration>
   </domainSpecifications>
   <domainSpecifications name="Matlab Domain" namespaceURI="http://your.organisation.domain/nsp10#" namespacePrefix="//@domainPrefixes[name='nsp10']"/>
@@ -368,7 +368,7 @@
     <resourceProperties id="_pnZqcZUdEeq-KoPaR9_Cfg" name="versionId" description="A short human-readable identifier for the version of a resource. All versioned resources should have this property; where the property is present, this identifier must be unique amongst all currently existing versions of the same concept resource. The subject of this property should be the concept resource URI." valueType="String"/>
     <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
       <generalConfiguration filesBasePath="" javaBasePackageName="org.eclipse.lyo.oslc.domains.config"/>
-      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0-SNAPSHOT" groupId="org.eclipse.lyo.oslc.domains.config" artifactId="Configuration Management" version="0.0.1-SNAPSHOT"/>
+      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0" groupId="org.eclipse.lyo.oslc.domains.config" artifactId="Configuration Management" version="0.0.1-SNAPSHOT"/>
     </configuration>
   </domainSpecifications>
   <domainSpecifications name="Provenance" namespaceURI="http://www.w3.org/ns/prov#" namespacePrefix="//@domainPrefixes[name='prov']">
@@ -376,7 +376,7 @@
     <resourceProperties id="_pnaRg5UdEeq-KoPaR9_Cfg" name="wasDerivedFrom" description="A resource from which this version was derived. This is likely to reference a different concept resource; use of prov:wasRevisionOf is recommended to indicate an earlier version of the same concept resource. The subject of each instance of this property must be the concept resource URI; the object can be a version resource URI, or a concept resource URI (possibly for a non-versioned resource)." occurs="zeroOrMany" valueType="Resource" representation="reference"/>
     <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
       <generalConfiguration filesBasePath="" javaBasePackageName=""/>
-      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0-SNAPSHOT" groupId="" artifactId="Provenance" version="0.0.1-SNAPSHOT"/>
+      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0" groupId="" artifactId="Provenance" version="0.0.1-SNAPSHOT"/>
     </configuration>
   </domainSpecifications>
   <domainSpecifications name="Automation" namespaceURI="http://open-services.net/ns/auto#" namespacePrefix="//@domainPrefixes[name='oslc_auto']">
@@ -398,7 +398,7 @@
     <resourceProperties id="_poE_4JUdEeq-KoPaR9_Cfg" name="reportsOnAutomationPlan" description="Automation Plan which the Automation Result reports on. It is likely that the target resource will be an oslc_auto:AutomationPlan but that is not necessarily the case." valueType="Resource" range="_pn-SMJUdEeq-KoPaR9_Cfg" representation="reference"/>
     <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
       <generalConfiguration filesBasePath="" javaBasePackageName="org.eclipse.lyo.oslc.domains.auto"/>
-      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0-SNAPSHOT" groupId="org.eclipse.lyo.oslc.domains.auto" artifactId="Automation" version="0.0.1-SNAPSHOT"/>
+      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0" groupId="org.eclipse.lyo.oslc.domains.auto" artifactId="Automation" version="0.0.1-SNAPSHOT"/>
     </configuration>
   </domainSpecifications>
   <domainSpecifications name="Jazz Architecture Management " namespaceURI="http://jazz.net/ns/dm/linktypes#" namespacePrefix="//@domainPrefixes[name='jazz_am']">
@@ -410,7 +410,7 @@
     <resourceProperties id="_poq1wZUdEeq-KoPaR9_Cfg" title="trace" name="trace" occurs="zeroOrMany" valueType="Resource"/>
     <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
       <generalConfiguration filesBasePath="" javaBasePackageName="org.eclipse.lyo.oslc.domains.jazz_am"/>
-      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0-SNAPSHOT" groupId="jazz-architecture-management-" artifactId="jazz-architecture-management-" version="0.0.1-SNAPSHOT"/>
+      <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" doNotGenerateProjectConfigurationFiles="true" lyoVersion="4.0.0" groupId="jazz-architecture-management-" artifactId="jazz-architecture-management-" version="0.0.1-SNAPSHOT"/>
     </configuration>
   </domainSpecifications>
   <domainPrefixes name="dcterms"/>
@@ -429,6 +429,6 @@
   <domainPrefixes name="jazz_am"/>
   <configuration xsi:type="oslc4j_ai:MavenSpecificationConfiguration">
     <generalConfiguration filesBasePath="." javaBasePackageName="org.eclipse.lyo.oslc.domains"/>
-    <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" lyoVersion="4.0.0-SNAPSHOT" groupId="org.eclipse.lyo" artifactId="oslc-domains" version="4.0.0-SNAPSHOT"/>
+    <projectConfiguration xsi:type="oslc4j_ai:MavenProjectConfiguration" lyoVersion="4.0.0" groupId="org.eclipse.lyo" artifactId="oslc-domains" version="4.0.0"/>
   </configuration>
 </oslc4j_ai:Specification>

--- a/domains/org.eclipse.lyo.tools.domainmodels/representations.aird
+++ b/domains/org.eclipse.lyo.tools.domainmodels/representations.aird
@@ -475,7 +475,7 @@
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_O5spID4zEeqAQMi9WMAJGg" name="Properties">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_O5spID4zEeqAQMi9WMAJGg" name="Property Constraints">
         <target xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Configuration%20Management']"/>
         <semanticElements xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Configuration%20Management']"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -559,7 +559,7 @@
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']"/>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_Q5PfAD4zEeqAQMi9WMAJGg" name="Properties">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_Q5PfAD4zEeqAQMi9WMAJGg" name="Property Constraints">
         <target xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Provenance']"/>
         <semanticElements xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Provenance']"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -2439,13 +2439,13 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_elhzaj40EeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_elhzaz40EeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_elhzbz40EeqAQMi9WMAJGg" type="3010" element="_elCEID40EeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_elhzcD40EeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_elhzcT40EeqAQMi9WMAJGg"/>
-                </children>
                 <children xmi:type="notation:Node" xmi:id="_elhzbD40EeqAQMi9WMAJGg" type="3010" element="_elBdED40EeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_elhzbT40EeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_elhzbj40EeqAQMi9WMAJGg"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_elhzbz40EeqAQMi9WMAJGg" type="3010" element="_elCEID40EeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_elhzcD40EeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_elhzcT40EeqAQMi9WMAJGg"/>
                 </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_elglRT40EeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_elglRj40EeqAQMi9WMAJGg"/>
@@ -2552,13 +2552,13 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_eljBhD40EeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_eljBhT40EeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_eljBiT40EeqAQMi9WMAJGg" type="3010" element="_elG8oj40EeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_eljBij40EeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_eljBiz40EeqAQMi9WMAJGg"/>
-                </children>
                 <children xmi:type="notation:Node" xmi:id="_eljBhj40EeqAQMi9WMAJGg" type="3010" element="_elG8oD40EeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_eljBhz40EeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_eljBiD40EeqAQMi9WMAJGg"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_eljBiT40EeqAQMi9WMAJGg" type="3010" element="_elG8oj40EeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_eljBij40EeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_eljBiz40EeqAQMi9WMAJGg"/>
                 </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_elglTD40EeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_elglTT40EeqAQMi9WMAJGg"/>
@@ -2882,19 +2882,19 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_elCEID40EeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_elCEIT40EeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_elBdED40EeqAQMi9WMAJGg" name="dcterms:creator: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_elBdET40EeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_elBdED40EeqAQMi9WMAJGg" name="dcterms:creator: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_elBdET40EeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_elCEID40EeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_elCEIT40EeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -3103,19 +3103,19 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_elG8oj40EeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_elG8oz40EeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_elG8oD40EeqAQMi9WMAJGg" name="dcterms:creator: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_elG8oT40EeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_elG8oD40EeqAQMi9WMAJGg" name="dcterms:creator: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_elG8oT40EeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_elG8oj40EeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_elG8oz40EeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -3375,13 +3375,13 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_-8-jMT4xEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_-8-jMj4xEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_-8-jNj4xEeqAQMi9WMAJGg" type="3010" element="_-8eM4D4xEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_-8-jNz4xEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_-8-jOD4xEeqAQMi9WMAJGg"/>
-                </children>
                 <children xmi:type="notation:Node" xmi:id="_-8-jMz4xEeqAQMi9WMAJGg" type="3010" element="_-8c-wD4xEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_-8-jND4xEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_-8-jNT4xEeqAQMi9WMAJGg"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_-8-jNj4xEeqAQMi9WMAJGg" type="3010" element="_-8eM4D4xEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_-8-jNz4xEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_-8-jOD4xEeqAQMi9WMAJGg"/>
                 </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_-87f4T4xEeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_-87f4j4xEeqAQMi9WMAJGg"/>
@@ -3432,13 +3432,13 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_-8_xWj4xEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_-8_xWz4xEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_-8_xXz4xEeqAQMi9WMAJGg" type="3010" element="_-8ieUj4xEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_-8_xYD4xEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_-8_xYT4xEeqAQMi9WMAJGg"/>
-                </children>
                 <children xmi:type="notation:Node" xmi:id="_-8_xXD4xEeqAQMi9WMAJGg" type="3010" element="_-8ieUD4xEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_-8_xXT4xEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_-8_xXj4xEeqAQMi9WMAJGg"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_-8_xXz4xEeqAQMi9WMAJGg" type="3010" element="_-8ieUj4xEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_-8_xYD4xEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_-8_xYT4xEeqAQMi9WMAJGg"/>
                 </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_-87f6D4xEeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_-87f6T4xEeqAQMi9WMAJGg"/>
@@ -3530,13 +3530,13 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_-9BmkD4xEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_-9BmkT4xEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_-9CNkD4xEeqAQMi9WMAJGg" type="3010" element="_-8pzED4xEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_-9CNkT4xEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_-9CNkj4xEeqAQMi9WMAJGg"/>
-                </children>
                 <children xmi:type="notation:Node" xmi:id="_-9Bmkj4xEeqAQMi9WMAJGg" type="3010" element="_-8ok8D4xEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_-9Bmkz4xEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_-9BmlD4xEeqAQMi9WMAJGg"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_-9CNkD4xEeqAQMi9WMAJGg" type="3010" element="_-8pzED4xEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_-9CNkT4xEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_-9CNkj4xEeqAQMi9WMAJGg"/>
                 </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_-88G-T4xEeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_-88G-j4xEeqAQMi9WMAJGg"/>
@@ -3856,19 +3856,19 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8eM4D4xEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8eM4T4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8c-wD4xEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8dl0D4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8c-wD4xEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8dl0D4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8eM4D4xEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8eM4T4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -3965,19 +3965,19 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8ieUj4xEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8ieUz4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8ieUD4xEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8ieUT4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8ieUD4xEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8ieUT4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8ieUj4xEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8ieUz4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -4149,19 +4149,19 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8pzED4xEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8pzET4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8ok8D4xEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8pMAD4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8ok8D4xEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8pMAD4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_-8pzED4xEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_-8pzET4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -4485,21 +4485,21 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_anx2UT4yEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2Uj4yEeqAQMi9WMAJGg"/>
                 </children>
+                <children xmi:type="notation:Node" xmi:id="_anx2XD4yEeqAQMi9WMAJGg" type="3010" element="_am2CMz4yEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2XT4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2Xj4yEeqAQMi9WMAJGg"/>
+                </children>
                 <children xmi:type="notation:Node" xmi:id="_anydYz4yEeqAQMi9WMAJGg" type="3010" element="_am3QUT4yEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_anydZD4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_anydZT4yEeqAQMi9WMAJGg"/>
                 </children>
+                <children xmi:type="notation:Node" xmi:id="_anx2WT4yEeqAQMi9WMAJGg" type="3010" element="_am2CMT4yEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2Wj4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2Wz4yEeqAQMi9WMAJGg"/>
+                </children>
                 <children xmi:type="notation:Node" xmi:id="_anx2Xz4yEeqAQMi9WMAJGg" type="3010" element="_am2pQT4yEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_anx2YD4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2YT4yEeqAQMi9WMAJGg"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_anx2Uz4yEeqAQMi9WMAJGg" type="3010" element="_am1bID4yEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2VD4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2VT4yEeqAQMi9WMAJGg"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_anx2XD4yEeqAQMi9WMAJGg" type="3010" element="_am2CMz4yEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2XT4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2Xj4yEeqAQMi9WMAJGg"/>
                 </children>
                 <children xmi:type="notation:Node" xmi:id="_anx2Vj4yEeqAQMi9WMAJGg" type="3010" element="_am1bIj4yEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_anx2Vz4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
@@ -4509,9 +4509,9 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_anx2Yz4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2ZD4yEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_anx2WT4yEeqAQMi9WMAJGg" type="3010" element="_am2CMT4yEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2Wj4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2Wz4yEeqAQMi9WMAJGg"/>
+                <children xmi:type="notation:Node" xmi:id="_anx2Uz4yEeqAQMi9WMAJGg" type="3010" element="_am1bID4yEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2VD4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2VT4yEeqAQMi9WMAJGg"/>
                 </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_anuzAj4yEeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_anuzAz4yEeqAQMi9WMAJGg"/>
@@ -4696,6 +4696,14 @@
             <children xmi:type="notation:Node" xmi:id="_bhGrBz4yEeqAQMi9WMAJGg" type="3009" element="_bggOED4yEeqAQMi9WMAJGg">
               <children xmi:type="notation:Node" xmi:id="_bhGrCj4yEeqAQMi9WMAJGg" type="5004"/>
               <children xmi:type="notation:Node" xmi:id="_bhHSED4yEeqAQMi9WMAJGg" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_udnaoUBHEeuwb5aqDturqw" type="3010" element="_ub7_kEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udnaokBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udnao0BHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udnapEBHEeuwb5aqDturqw" type="3010" element="_ub7_kkBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udnapUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udnapkBHEeuwb5aqDturqw"/>
+                </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_bhHSET4yEeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_bhHSEj4yEeqAQMi9WMAJGg"/>
               </children>
@@ -4897,6 +4905,74 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_bhJuYD4yEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_bhJuYT4yEeqAQMi9WMAJGg"/>
                 </children>
+                <children xmi:type="notation:Node" xmi:id="_udoBoEBHEeuwb5aqDturqw" type="3010" element="_ucDUUEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udoBoUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udoBokBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udoBo0BHEeuwb5aqDturqw" type="3010" element="_ucD7YUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udoBpEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udoBpUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udoBpkBHEeuwb5aqDturqw" type="3010" element="_ucD7Y0BHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udoBp0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udoBqEBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udoBqUBHEeuwb5aqDturqw" type="3010" element="_ucEicUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udoBqkBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udoBq0BHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udoosEBHEeuwb5aqDturqw" type="3010" element="_ucEic0BHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udoosUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udooskBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udoos0BHEeuwb5aqDturqw" type="3010" element="_ucFJgEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udootEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udootUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udootkBHEeuwb5aqDturqw" type="3010" element="_ucFJgkBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udoot0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udoouEBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udpPwEBHEeuwb5aqDturqw" type="3010" element="_ucFJhEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udpPwUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udpPwkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udpPw0BHEeuwb5aqDturqw" type="3010" element="_ucFwkUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udpPxEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udpPxUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udpPxkBHEeuwb5aqDturqw" type="3010" element="_ucGXoUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udpPx0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udpPyEBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udpPyUBHEeuwb5aqDturqw" type="3010" element="_ucGXo0BHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udpPykBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udpPy0BHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udp20EBHEeuwb5aqDturqw" type="3010" element="_ucGXpUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udp20UBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udp20kBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udp200BHEeuwb5aqDturqw" type="3010" element="_ucGXp0BHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udp21EBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udp21UBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udp21kBHEeuwb5aqDturqw" type="3010" element="_ucGXqUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udp210BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udp22EBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udp22UBHEeuwb5aqDturqw" type="3010" element="_ucG-sEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udp22kBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udp220BHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udp23EBHEeuwb5aqDturqw" type="3010" element="_ucG-skBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udp23UBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udp23kBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udrE8EBHEeuwb5aqDturqw" type="3010" element="_ucG-tEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udrE8UBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udrE8kBHEeuwb5aqDturqw"/>
+                </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_bhH5Ij4yEeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_bhH5Iz4yEeqAQMi9WMAJGg"/>
               </children>
@@ -4919,6 +4995,160 @@
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_8LlEW2eLEeqWubhHVdX5HA" fontName="Segoe UI" fontHeight="12" italic="true" underline="true"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8LlEXGeLEeqWubhHVdX5HA" x="30" y="29"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_udllYEBHEeuwb5aqDturqw" type="3009" element="_ubxAcEBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_udllY0BHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_udllZEBHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_udrE80BHEeuwb5aqDturqw" type="3010" element="_uby1o0BHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udrE9EBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udrE9UBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udrE9kBHEeuwb5aqDturqw" type="3010" element="_ubzcsEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udrE90BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udrE-EBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udrE-UBHEeuwb5aqDturqw" type="3010" element="_ubzcskBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udrE-kBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udrE-0BHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_udllZUBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_udllZkBHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_udllYUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udllYkBHEeuwb5aqDturqw" x="795" y="849"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_udllZ0BHEeuwb5aqDturqw" type="3009" element="_ubxAckBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_udllakBHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_udlla0BHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_udrE_EBHEeuwb5aqDturqw" type="3010" element="_ub0DwEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udrE_UBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udrE_kBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udrE_0BHEeuwb5aqDturqw" type="3010" element="_ub0q0UBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udrFAEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udrFAUBHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_udllbEBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_udllbUBHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_udllaEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udllaUBHEeuwb5aqDturqw" x="930" y="719"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_udmMcEBHEeuwb5aqDturqw" type="3009" element="_ubyOkUBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_udmMc0BHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_udmMdEBHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_udrFAkBHEeuwb5aqDturqw" type="3010" element="_ub1R4EBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udrFA0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udrFBEBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udrFBUBHEeuwb5aqDturqw" type="3010" element="_ub1R4kBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udrFBkBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udrFB0BHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udsTEEBHEeuwb5aqDturqw" type="3010" element="_ub148EBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udsTEUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udsTEkBHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_udmMdUBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_udmMdkBHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_udmMcUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udmMckBHEeuwb5aqDturqw" x="730" y="719"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_udmMd0BHEeuwb5aqDturqw" type="3009" element="_ubyOk0BHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_udmMekBHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_udnakEBHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_uds6IEBHEeuwb5aqDturqw" type="3010" element="_ub148kBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_uds6IUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uds6IkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_uds6I0BHEeuwb5aqDturqw" type="3010" element="_ub2gAUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_uds6JEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uds6JUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_uds6JkBHEeuwb5aqDturqw" type="3010" element="_ub2gA0BHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_uds6J0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uds6KEBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_uds6KUBHEeuwb5aqDturqw" type="3010" element="_ub2gBUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_uds6KkBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uds6K0BHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_uds6LEBHEeuwb5aqDturqw" type="3010" element="_ub3HEEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_uds6LUBHEeuwb5aqDturqw" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uds6LkBHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_udnakUBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_udnakkBHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_udmMeEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udmMeUBHEeuwb5aqDturqw" x="-137" y="-136"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_udnak0BHEeuwb5aqDturqw" type="3009" element="_ubyOlUBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_udnalkBHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_udnal0BHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_uds6L0BHEeuwb5aqDturqw" type="3010" element="_ub3uIEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_uds6MEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uds6MUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_uds6MkBHEeuwb5aqDturqw" type="3010" element="_ub3uIkBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_uds6M0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uds6NEBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udthMEBHEeuwb5aqDturqw" type="3010" element="_ub3uJEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udthMUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udthMkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udthM0BHEeuwb5aqDturqw" type="3010" element="_ub4VMUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udthNEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udthNUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udthNkBHEeuwb5aqDturqw" type="3010" element="_ub4VM0BHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udthN0BHEeuwb5aqDturqw" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udthOEBHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_udnamEBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_udnamUBHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_udnalEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udnalUBHEeuwb5aqDturqw" x="-340" y="-136"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_udnamkBHEeuwb5aqDturqw" type="3009" element="_uby1oUBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_udnanUBHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_udnankBHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_udthOUBHEeuwb5aqDturqw" type="3010" element="_ub48QUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udthOkBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udthO0BHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udthPEBHEeuwb5aqDturqw" type="3010" element="_ub5jUUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udthPUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udthPkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udthP0BHEeuwb5aqDturqw" type="3010" element="_ub6KYEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udthQEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udthQUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_udthQkBHEeuwb5aqDturqw" type="3010" element="_ub6KYkBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_udthQ0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_udthREBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_uduIQEBHEeuwb5aqDturqw" type="3010" element="_ub6KZEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_uduIQUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uduIQkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_uduIQ0BHEeuwb5aqDturqw" type="3010" element="_ub6KZkBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_uduIREBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uduIRUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_uduIRkBHEeuwb5aqDturqw" type="3010" element="_ub7YgEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_uduIR0BHEeuwb5aqDturqw" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_uduISEBHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_udnan0BHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_udnaoEBHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_udnam0BHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udnanEBHEeuwb5aqDturqw" x="-540" y="-130"/>
             </children>
             <styles xmi:type="notation:SortingStyle" xmi:id="_bhGrBT4yEeqAQMi9WMAJGg"/>
             <styles xmi:type="notation:FilteringStyle" xmi:id="_bhGrBj4yEeqAQMi9WMAJGg"/>
@@ -5152,6 +5382,166 @@
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YGaPJUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YGaPZUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
         </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_udvWYEBHEeuwb5aqDturqw" type="4001" element="_udYKAEBHEeuwb5aqDturqw" source="_bhGrBz4yEeqAQMi9WMAJGg" target="_udmMcEBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udvWZEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udvWZUBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udvWZkBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udvWZ0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udvWaEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udvWaUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udvWYUBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udvWYkBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udvWY0BHEeuwb5aqDturqw" points="[-1, 0, 84, 60]$[-86, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udv9cEBHEeuwb5aqDturqw" id="(0.5028248587570622,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udv9cUBHEeuwb5aqDturqw" id="(0.5071428571428571,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_udv9ckBHEeuwb5aqDturqw" type="4001" element="_udYxE0BHEeuwb5aqDturqw" source="_udllYEBHEeuwb5aqDturqw" target="_bhGrBz4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_udv9dkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9d0BHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udv9eEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9eUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udv9ekBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9e0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udv9c0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udv9dEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udv9dUBHEeuwb5aqDturqw" points="[-1, 0, -1, 60]$[-1, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udv9fEBHEeuwb5aqDturqw" id="(0.5028248587570622,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udv9fUBHEeuwb5aqDturqw" id="(0.5028248587570622,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_udv9fkBHEeuwb5aqDturqw" type="4001" element="_udZYIEBHEeuwb5aqDturqw" source="_bhGrBz4yEeqAQMi9WMAJGg" target="_udllZ0BHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udv9gkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9g0BHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udv9hEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9hUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udv9hkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9h0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udv9f0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udv9gEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udv9gUBHEeuwb5aqDturqw" points="[-1, 0, -86, 60]$[84, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udwkgEBHEeuwb5aqDturqw" id="(0.5028248587570622,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udwkgUBHEeuwb5aqDturqw" id="(0.5131578947368421,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_udwkgkBHEeuwb5aqDturqw" type="4001" element="_udZYJEBHEeuwb5aqDturqw" source="_udllZ0BHEeuwb5aqDturqw" target="_udmMd0BHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udwkhkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwkh0BHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udwkiEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwkiUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udwkikBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwki0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udwkg0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udwkhEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udwkhUBHEeuwb5aqDturqw" points="[-1, 0, -250, 60]$[248, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udwkjEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udwkjUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_udwkjkBHEeuwb5aqDturqw" type="4001" element="_udZ_MEBHEeuwb5aqDturqw" source="_udllZ0BHEeuwb5aqDturqw" target="_udnak0BHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udwkkkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwkk0BHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udwklEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwklUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udwklkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwkl0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udwkj0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udwkkEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udwkkUBHEeuwb5aqDturqw" points="[-1, 0, -50, 60]$[48, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLkEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLkUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_udxLkkBHEeuwb5aqDturqw" type="4001" element="_udZ_NEBHEeuwb5aqDturqw" source="_udllZ0BHEeuwb5aqDturqw" target="_udnamkBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udxLlkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLl0BHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udxLmEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLmUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udxLmkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLm0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udxLk0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udxLlEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udxLlUBHEeuwb5aqDturqw" points="[-1, 0, 150, 60]$[-152, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLnEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLnUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_udxLnkBHEeuwb5aqDturqw" type="4001" element="_udamQEBHEeuwb5aqDturqw" source="_udllZ0BHEeuwb5aqDturqw" target="_udnamkBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udxLokBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLo0BHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udxLpEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLpUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udxLpkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLp0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udxLn0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udxLoEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udxLoUBHEeuwb5aqDturqw" points="[-1, 0, 150, 60]$[-152, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLqEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLqUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_udxLqkBHEeuwb5aqDturqw" type="4001" element="_udbNUEBHEeuwb5aqDturqw" source="_udmMd0BHEeuwb5aqDturqw" target="_bhHSEz4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_udxyo0BHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxypEBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udxypUBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxypkBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udxyp0BHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxyqEBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udxyoEBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udxyoUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udxyokBHEeuwb5aqDturqw" points="[-1, 0, 199, 60]$[-201, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxyqUBHEeuwb5aqDturqw" id="(0.5072463768115942,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxyqkBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_udxyq0BHEeuwb5aqDturqw" type="4001" element="_udb0YEBHEeuwb5aqDturqw" source="_udnak0BHEeuwb5aqDturqw" target="_bhHSEz4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_udxyr0BHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxysEBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udxysUBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxyskBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udxys0BHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxytEBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udxyrEBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udxyrUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udxyrkBHEeuwb5aqDturqw" points="[-1, 0, -1, 60]$[-1, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxytUBHEeuwb5aqDturqw" id="(0.5072463768115942,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxytkBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_udyZsEBHEeuwb5aqDturqw" type="4001" element="_udcbcEBHEeuwb5aqDturqw" source="_udnamkBHEeuwb5aqDturqw" target="_bhHSEz4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_udyZtEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udyZtUBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udyZtkBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udyZt0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_udyZuEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udyZuUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udyZsUBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udyZskBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udyZs0BHEeuwb5aqDturqw" points="[-1, 0, -201, 60]$[199, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udyZukBHEeuwb5aqDturqw" id="(0.5072463768115942,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udyZu0BHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
       </data>
     </ownedAnnotationEntries>
     <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_alun4D4yEeqAQMi9WMAJGg" name="Change Management shapes (oslc_cm)" width="40" height="30">
@@ -5326,6 +5716,15 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_am2CMz4yEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_am2pQD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
+        </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_am3QUT4yEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
@@ -5335,28 +5734,19 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_am2CMT4yEeqAQMi9WMAJGg" name="authorizer: Agent []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_am2CMj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
+        </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_am2pQT4yEeqAQMi9WMAJGg" name="implementsRequirement: Requirement []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
           <ownedStyle xmi:type="diagram:Square" xmi:id="_am2pQj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-            <labelFormat>italic</labelFormat>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
-          </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
-        </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_am1bID4yEeqAQMi9WMAJGg" name="affectsRequirement: Requirement []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_am1bIT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-            <labelFormat>italic</labelFormat>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
-          </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
-        </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_am2CMz4yEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_am2pQD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -5380,10 +5770,10 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_am2CMT4yEeqAQMi9WMAJGg" name="authorizer: Agent []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_am2CMj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_am1bID4yEeqAQMi9WMAJGg" name="affectsRequirement: Requirement []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_am1bIT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -5708,7 +6098,7 @@
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']"/>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_bggOED4yEeqAQMi9WMAJGg" name="ServiceProvider">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_bggOED4yEeqAQMi9WMAJGg" name="ServiceProvider" outgoingEdges="_udYKAEBHEeuwb5aqDturqw _udZYIEBHEeuwb5aqDturqw" incomingEdges="_udYxE0BHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8JUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8JUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -5718,8 +6108,24 @@
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub7_kEBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub7_kUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub7_kkBHEeuwb5aqDturqw" name="dcterms:description: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub8moEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_bgg1IT4yEeqAQMi9WMAJGg" name="ResourceShape" outgoingEdges="_3XpHMJUdEeq-KoPaR9_Cfg" incomingEdges="_3X4-1JUdEeq-KoPaR9_Cfg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_bgg1IT4yEeqAQMi9WMAJGg" name="ResourceShape" outgoingEdges="_3XpHMJUdEeq-KoPaR9_Cfg" incomingEdges="_3X4-1JUdEeq-KoPaR9_Cfg _udbNUEBHEeuwb5aqDturqw _udb0YEBHEeuwb5aqDturqw _udcbcEBHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8ZUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8ZUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -6086,6 +6492,142 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucDUUEBHEeuwb5aqDturqw" name="serviceProvider: ServiceProvider []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucD7YEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucD7YUBHEeuwb5aqDturqw" name="domain: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucD7YkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucD7Y0BHEeuwb5aqDturqw" name="service: Service []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucEicEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucEicUBHEeuwb5aqDturqw" name="creationFactory: CreationFactory">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucEickBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucEic0BHEeuwb5aqDturqw" name="queryCapability: QueryCapability">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucEidEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucFJgEBHEeuwb5aqDturqw" name="creationDialog: Dialog">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucFJgUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucFJgkBHEeuwb5aqDturqw" name="selectionDialog: Dialog">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucFJg0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucFJhEBHEeuwb5aqDturqw" name="usage: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucFwkEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucFwkUBHEeuwb5aqDturqw" name="creation: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucGXoEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucGXoUBHEeuwb5aqDturqw" name="resourceShape: ResourceShape []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucGXokBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucGXo0BHEeuwb5aqDturqw" name="resourceType: Class">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucGXpEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucGXpUBHEeuwb5aqDturqw" name="queryBase: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucGXpkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucGXp0BHEeuwb5aqDturqw" name="dialog: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucGXqEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucGXqUBHEeuwb5aqDturqw" name="hintHeight: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucGXqkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucG-sEBHEeuwb5aqDturqw" name="hintWidth: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucG-sUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucG-skBHEeuwb5aqDturqw" name="label: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucG-s0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ucG-tEBHEeuwb5aqDturqw" name="domain: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ucHlwEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
       </ownedDiagramElements>
       <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_8LCRwGeLEeqWubhHVdX5HA" name="Configuration">
         <target xmi:type="oslc4j_ai:MavenSpecificationConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration"/>
@@ -6111,6 +6653,257 @@
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_ubxAcEBHEeuwb5aqDturqw" name="ServiceProviderCatalog" outgoingEdges="_udYxE0BHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEiKJEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEiKJEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_ubxAcUBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_uby1o0BHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_uby1pEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ubzcsEBHEeuwb5aqDturqw" name="dcterms:description: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ubzcsUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ubzcskBHEeuwb5aqDturqw" name="domain: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ubzcs0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_ubxAckBHEeuwb5aqDturqw" name="Service" outgoingEdges="_udZYJEBHEeuwb5aqDturqw _udZ_MEBHEeuwb5aqDturqw _udZ_NEBHEeuwb5aqDturqw _udamQEBHEeuwb5aqDturqw" incomingEdges="_udZYIEBHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEyKJEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEyKJEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_ubyOkEBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub0DwEBHEeuwb5aqDturqw" name="usage: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub0q0EBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub0q0UBHEeuwb5aqDturqw" name="domain: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub0q0kBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_ubyOkUBHEeuwb5aqDturqw" name="Publisher" incomingEdges="_udYKAEBHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_nr5V8CKJEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_nr5V8CKJEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_ubyOkkBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub1R4EBHEeuwb5aqDturqw" name="dcterms:identifier: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnX1QJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnX1QJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub1R4UBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub1R4kBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub1R40BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub148EBHEeuwb5aqDturqw" name="label: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub148UBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_ubyOk0BHEeuwb5aqDturqw" name="CreationFactory" outgoingEdges="_udbNUEBHEeuwb5aqDturqw" incomingEdges="_udZYJEBHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-8yKKEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-8yKKEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_ubyOlEBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub148kBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub2gAEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub2gAUBHEeuwb5aqDturqw" name="creation: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub2gAkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub2gA0BHEeuwb5aqDturqw" name="usage: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub2gBEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub2gBUBHEeuwb5aqDturqw" name="label: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub2gBkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub3HEEBHEeuwb5aqDturqw" name="resourceType: Class">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub3HEUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_ubyOlUBHEeuwb5aqDturqw" name="QueryCapability" outgoingEdges="_udb0YEBHEeuwb5aqDturqw" incomingEdges="_udZ_MEBHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9CKKEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9CKKEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_uby1oEBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub3uIEBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub3uIUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub3uIkBHEeuwb5aqDturqw" name="queryBase: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub3uI0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub3uJEBHEeuwb5aqDturqw" name="usage: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub4VMEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub4VMUBHEeuwb5aqDturqw" name="label: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub4VMkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub4VM0BHEeuwb5aqDturqw" name="resourceType: Class">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub48QEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_uby1oUBHEeuwb5aqDturqw" name="Dialog" outgoingEdges="_udcbcEBHEeuwb5aqDturqw" incomingEdges="_udZ_NEBHEeuwb5aqDturqw _udamQEBHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9SKKEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9SKKEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_uby1okBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub48QUBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub5jUEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub5jUUBHEeuwb5aqDturqw" name="dialog: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub5jUkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub6KYEBHEeuwb5aqDturqw" name="usage: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub6KYUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub6KYkBHEeuwb5aqDturqw" name="hintHeight: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub6KY0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub6KZEBHEeuwb5aqDturqw" name="hintWidth: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub6KZUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub6KZkBHEeuwb5aqDturqw" name="label: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub6xcEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_ub7YgEBHEeuwb5aqDturqw" name="resourceType: Class">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_ub7YgUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
       </ownedDiagramElements>
     </ownedDiagramElements>
@@ -6217,6 +7010,106 @@
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
         <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_3X7bEZUdEeq-KoPaR9_Cfg" showIcon="false"/>
         <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_3X7bEpUdEeq-KoPaR9_Cfg" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_udYKAEBHEeuwb5aqDturqw" name="publisher" sourceNode="_bggOED4yEeqAQMi9WMAJGg" targetNode="_ubyOkUBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_tl7rcCKJEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_tl7rcCKJEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_udYxEEBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_udYxEUBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_udYxEkBHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_udYxE0BHEeuwb5aqDturqw" name="serviceProvider" sourceNode="_ubxAcEBHEeuwb5aqDturqw" targetNode="_bggOED4yEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_udYxFEBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_udYxFUBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_udYxFkBHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_udZYIEBHEeuwb5aqDturqw" name="service" sourceNode="_bggOED4yEeqAQMi9WMAJGg" targetNode="_ubxAckBHEeuwb5aqDturqw" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_udZYIUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_udZYIkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_udZYI0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_udZYJEBHEeuwb5aqDturqw" name="creationFactory" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_ubyOk0BHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_udZYJUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_udZYJkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_udZYJ0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_udZ_MEBHEeuwb5aqDturqw" name="queryCapability" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_ubyOlUBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_udZ_MUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_udZ_MkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_udZ_M0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_udZ_NEBHEeuwb5aqDturqw" name="creationDialog" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_uby1oUBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_udZ_NUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_udZ_NkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_udZ_N0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_udamQEBHEeuwb5aqDturqw" name="selectionDialog" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_uby1oUBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_udamQUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_udamQkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_udamQ0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_udbNUEBHEeuwb5aqDturqw" name="resourceShape" sourceNode="_ubyOk0BHEeuwb5aqDturqw" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_udbNUUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_udbNUkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_udbNU0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_udb0YEBHEeuwb5aqDturqw" name="resourceShape" sourceNode="_ubyOlUBHEeuwb5aqDturqw" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_udb0YUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_udb0YkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_udb0Y0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_udcbcEBHEeuwb5aqDturqw" name="resourceShape" sourceNode="_uby1oUBHEeuwb5aqDturqw" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_udcbcUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_udcbckBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_udcbc0BHEeuwb5aqDturqw" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
@@ -7999,13 +8892,13 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t2PYD4zEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_1t2PYT4zEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_1t22WT4zEeqAQMi9WMAJGg" type="3010" element="_1sx4QT4zEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_1t22Wj4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t22Wz4zEeqAQMi9WMAJGg"/>
-                </children>
                 <children xmi:type="notation:Node" xmi:id="_1t22Uz4zEeqAQMi9WMAJGg" type="3010" element="_1sxRMT4zEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t22VD4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_1t22VT4zEeqAQMi9WMAJGg"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_1t22WT4zEeqAQMi9WMAJGg" type="3010" element="_1sx4QT4zEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_1t22Wj4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t22Wz4zEeqAQMi9WMAJGg"/>
                 </children>
                 <children xmi:type="notation:Node" xmi:id="_1t22Vj4zEeqAQMi9WMAJGg" type="3010" element="_1sxRMz4zEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t22Vz4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
@@ -8060,9 +8953,9 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t3daj4zEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_1t3daz4zEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_1t3ddT4zEeqAQMi9WMAJGg" type="3010" element="_1s07kT4zEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_1t3ddj4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t3ddz4zEeqAQMi9WMAJGg"/>
+                <children xmi:type="notation:Node" xmi:id="_1t3dbz4zEeqAQMi9WMAJGg" type="3010" element="_1s0Ugj4zEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_1t3dcD4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t3dcT4zEeqAQMi9WMAJGg"/>
                 </children>
                 <children xmi:type="notation:Node" xmi:id="_1t3deD4zEeqAQMi9WMAJGg" type="3010" element="_1s07kz4zEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t3deT4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
@@ -8072,9 +8965,9 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t3dcz4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_1t3ddD4zEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_1t3dbz4zEeqAQMi9WMAJGg" type="3010" element="_1s0Ugj4zEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_1t3dcD4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t3dcT4zEeqAQMi9WMAJGg"/>
+                <children xmi:type="notation:Node" xmi:id="_1t3ddT4zEeqAQMi9WMAJGg" type="3010" element="_1s07kT4zEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_1t3ddj4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t3ddz4zEeqAQMi9WMAJGg"/>
                 </children>
                 <children xmi:type="notation:Node" xmi:id="_1t3dbD4zEeqAQMi9WMAJGg" type="3010" element="_1s0UgD4zEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t3dbT4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
@@ -8121,6 +9014,10 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t4Eej4zEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_1t4Eez4zEeqAQMi9WMAJGg"/>
                 </children>
+                <children xmi:type="notation:Node" xmi:id="_1t4Egj4zEeqAQMi9WMAJGg" type="3010" element="_1s4l9D4zEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_1t4Egz4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t4EhD4zEeqAQMi9WMAJGg"/>
+                </children>
                 <children xmi:type="notation:Node" xmi:id="_1t4EhT4zEeqAQMi9WMAJGg" type="3010" element="_1s5NAT4zEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t4Ehj4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_1t4Ehz4zEeqAQMi9WMAJGg"/>
@@ -8128,10 +9025,6 @@
                 <children xmi:type="notation:Node" xmi:id="_1t4Efz4zEeqAQMi9WMAJGg" type="3010" element="_1s4l8j4zEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t4EgD4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_1t4EgT4zEeqAQMi9WMAJGg"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_1t4Egj4zEeqAQMi9WMAJGg" type="3010" element="_1s4l9D4zEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_1t4Egz4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t4EhD4zEeqAQMi9WMAJGg"/>
                 </children>
                 <children xmi:type="notation:Node" xmi:id="_1t4EfD4zEeqAQMi9WMAJGg" type="3010" element="_1s4l8D4zEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t4EfT4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
@@ -8182,17 +9075,17 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t4rmT4zEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_1t4rmj4zEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_1t5Slj4zEeqAQMi9WMAJGg" type="3010" element="_1s8QUT4zEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_1t5Slz4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t5SmD4zEeqAQMi9WMAJGg"/>
+                <children xmi:type="notation:Node" xmi:id="_1t5SkD4zEeqAQMi9WMAJGg" type="3010" element="_1s7pQj4zEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_1t5SkT4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t5Skj4zEeqAQMi9WMAJGg"/>
                 </children>
                 <children xmi:type="notation:Node" xmi:id="_1t5Skz4zEeqAQMi9WMAJGg" type="3010" element="_1s7pRD4zEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t5SlD4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_1t5SlT4zEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_1t5SkD4zEeqAQMi9WMAJGg" type="3010" element="_1s7pQj4zEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_1t5SkT4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t5Skj4zEeqAQMi9WMAJGg"/>
+                <children xmi:type="notation:Node" xmi:id="_1t5Slj4zEeqAQMi9WMAJGg" type="3010" element="_1s8QUT4zEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_1t5Slz4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_1t5SmD4zEeqAQMi9WMAJGg"/>
                 </children>
                 <children xmi:type="notation:Node" xmi:id="_1t4rmz4zEeqAQMi9WMAJGg" type="3010" element="_1s7pQD4zEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_1t4rnD4zEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
@@ -8585,19 +9478,19 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1sx4QT4zEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_1sx4Qj4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1sxRMT4zEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_1sxRMj4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1sxRMT4zEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_1sxRMj4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1sx4QT4zEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_1sx4Qj4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -8704,10 +9597,10 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s07kT4zEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_1s07kj4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s0Ugj4zEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_1s0Ugz4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -8731,10 +9624,10 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s0Ugj4zEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_1s0Ugz4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s07kT4zEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_1s07kj4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -8824,6 +9717,15 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s4l9D4zEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_1s5NAD4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
+        </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s5NAT4zEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
@@ -8837,15 +9739,6 @@
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poi58ZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poi58ZUdEeq-KoPaR9_Cfg"/>
           <ownedStyle xmi:type="diagram:Square" xmi:id="_1s4l8z4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-            <labelFormat>italic</labelFormat>
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
-          </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
-        </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s4l9D4zEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_1s5NAD4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -8943,10 +9836,10 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s8QUT4zEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_1s8QUj4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s7pQj4zEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_1s7pQz4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -8961,10 +9854,10 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s7pQj4zEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_1s7pQz4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1s8QUT4zEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_1s8QUj4zEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
             <labelFormat>italic</labelFormat>
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
@@ -9563,6 +10456,14 @@
             <children xmi:type="notation:Node" xmi:id="_kJcPQD4xEeqAQMi9WMAJGg" type="3009" element="_kI3ngD4xEeqAQMi9WMAJGg">
               <children xmi:type="notation:Node" xmi:id="_kJcPQz4xEeqAQMi9WMAJGg" type="5004"/>
               <children xmi:type="notation:Node" xmi:id="_kJcPRD4xEeqAQMi9WMAJGg" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_nHe6gEBHEeuwb5aqDturqw" type="3010" element="_nFLNYEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHe6gUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHe6gkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHe6g0BHEeuwb5aqDturqw" type="3010" element="_nFL0cUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHe6hEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHe6hUBHEeuwb5aqDturqw"/>
+                </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_kJcPRT4xEeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_kJcPRj4xEeqAQMi9WMAJGg"/>
               </children>
@@ -9764,6 +10665,74 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_kJiV8D4xEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_kJiV8T4xEeqAQMi9WMAJGg"/>
                 </children>
+                <children xmi:type="notation:Node" xmi:id="_nHfhkEBHEeuwb5aqDturqw" type="3010" element="_nFXaoEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHfhkUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHfhkkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHgIoEBHEeuwb5aqDturqw" type="3010" element="_nFXaokBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHgIoUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHgIokBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHgIo0BHEeuwb5aqDturqw" type="3010" element="_nFYBsEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHgIpEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHgIpUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHgvsEBHEeuwb5aqDturqw" type="3010" element="_nFYBskBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHgvsUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHgvskBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHgvs0BHEeuwb5aqDturqw" type="3010" element="_nFYowUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHgvtEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHgvtUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHgvtkBHEeuwb5aqDturqw" type="3010" element="_nFZP0EBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHgvt0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHgvuEBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHgvuUBHEeuwb5aqDturqw" type="3010" element="_nFZP0kBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHgvukBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHgvu0BHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHhWwEBHEeuwb5aqDturqw" type="3010" element="_nFZ24EBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHhWwUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHhWwkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHhWw0BHEeuwb5aqDturqw" type="3010" element="_nFZ24kBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHhWxEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHhWxUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHh90EBHEeuwb5aqDturqw" type="3010" element="_nFZ25EBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHh90UBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHh90kBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHh900BHEeuwb5aqDturqw" type="3010" element="_nFad8UBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHh91EBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHh91UBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHh91kBHEeuwb5aqDturqw" type="3010" element="_nFad80BHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHh910BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHh92EBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHik4EBHEeuwb5aqDturqw" type="3010" element="_nFad9UBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHik4UBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHik4kBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHik40BHEeuwb5aqDturqw" type="3010" element="_nFbFAUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHik5EBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHik5UBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHjL8EBHEeuwb5aqDturqw" type="3010" element="_nFbFA0BHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHjL8UBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHjL8kBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHjL80BHEeuwb5aqDturqw" type="3010" element="_nFbFBUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHjL9EBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHjL9UBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHjL9kBHEeuwb5aqDturqw" type="3010" element="_nFbsEUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHjL90BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHjL-EBHEeuwb5aqDturqw"/>
+                </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_kJddaT4xEeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_kJddaj4xEeqAQMi9WMAJGg"/>
               </children>
@@ -9786,6 +10755,148 @@
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_5ZtZoWeLEeqWubhHVdX5HA" fontName="Segoe UI" fontHeight="12" italic="true" underline="true"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5ZtZomeLEeqWubhHVdX5HA" x="115" y="119"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_nHapEEBHEeuwb5aqDturqw" type="3009" element="_nE6usEBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_nHbQIEBHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_nHbQIUBHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_nHjzAEBHEeuwb5aqDturqw" type="3010" element="_nE9yAEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHjzAUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHjzAkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHjzA0BHEeuwb5aqDturqw" type="3010" element="_nE-ZEUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHjzBEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHjzBUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHjzBkBHEeuwb5aqDturqw" type="3010" element="_nE_AIEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHjzB0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHjzCEBHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_nHbQIkBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_nHbQI0BHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nHapEUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHapEkBHEeuwb5aqDturqw" x="-160" y="549"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_nHbQJEBHEeuwb5aqDturqw" type="3009" element="_nE780EBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_nHb3MEBHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_nHb3MUBHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_nHkaEEBHEeuwb5aqDturqw" type="3010" element="_nE_nMEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHkaEUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHkaEkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHkaE0BHEeuwb5aqDturqw" type="3010" element="_nFAOQUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHkaFEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHkaFUBHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_nHb3MkBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_nHb3M0BHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nHbQJUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHbQJkBHEeuwb5aqDturqw" x="1000" y="679"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_nHb3NEBHEeuwb5aqDturqw" type="3009" element="_nE8j4EBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_nHceQEBHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_nHceQUBHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_nHkaFkBHEeuwb5aqDturqw" type="3010" element="_nFA1UEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHkaF0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHkaGEBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHkaGUBHEeuwb5aqDturqw" type="3010" element="_nFBcYUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHlBIEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHlBIUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHlBIkBHEeuwb5aqDturqw" type="3010" element="_nFCDcEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHlBI0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHlBJEBHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_nHceQkBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_nHceQ0BHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nHb3NUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHb3NkBHEeuwb5aqDturqw" x="800" y="679"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_nHceREBHEeuwb5aqDturqw" type="3009" element="_nE8j4kBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_nHceR0BHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_nHceSEBHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_nHlBJUBHEeuwb5aqDturqw" type="3010" element="_nFCqgEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHlBJkBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHlBJ0BHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHlBKEBHEeuwb5aqDturqw" type="3010" element="_nFCqgkBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHlBKUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHlBKkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHloMEBHEeuwb5aqDturqw" type="3010" element="_nFDRkUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHloMUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHloMkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHloM0BHEeuwb5aqDturqw" type="3010" element="_nFD4oUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHloNEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHloNUBHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_nHceSUBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_nHceSkBHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nHceRUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHceRkBHEeuwb5aqDturqw" x="-55"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_nHceS0BHEeuwb5aqDturqw" type="3009" element="_nE8j5EBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_nHdsYEBHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_nHdsYUBHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_nHmPQEBHEeuwb5aqDturqw" type="3010" element="_nFFt0EBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHmPQUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHmPQkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHmPQ0BHEeuwb5aqDturqw" type="3010" element="_nFGU4UBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHmPREBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHmPRUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHmPRkBHEeuwb5aqDturqw" type="3010" element="_nFG78EBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHmPR0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHmPSEBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHmPSUBHEeuwb5aqDturqw" type="3010" element="_nFG78kBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHmPSkBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHmPS0BHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_nHdsYkBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_nHdsY0BHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nHceTEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHceTUBHEeuwb5aqDturqw" x="270"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_nHdsZEBHEeuwb5aqDturqw" type="3009" element="_nE9K8UBHEeuwb5aqDturqw">
+              <children xmi:type="notation:Node" xmi:id="_nHeTcEBHEeuwb5aqDturqw" type="5004"/>
+              <children xmi:type="notation:Node" xmi:id="_nHeTcUBHEeuwb5aqDturqw" type="7003">
+                <children xmi:type="notation:Node" xmi:id="_nHm2UEBHEeuwb5aqDturqw" type="3010" element="_nFIKEEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHm2UUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHm2UkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHm2U0BHEeuwb5aqDturqw" type="3010" element="_nFIxIEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHm2VEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHm2VUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHndYEBHEeuwb5aqDturqw" type="3010" element="_nFIxIkBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHndYUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHndYkBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHndY0BHEeuwb5aqDturqw" type="3010" element="_nFJYMUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHndZEBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHndZUBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHndZkBHEeuwb5aqDturqw" type="3010" element="_nFJYM0BHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHndZ0BHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHndaEBHEeuwb5aqDturqw"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHndaUBHEeuwb5aqDturqw" type="3010" element="_nFJ_QUBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHndakBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHnda0BHEeuwb5aqDturqw"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_nHeTckBHEeuwb5aqDturqw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_nHeTc0BHEeuwb5aqDturqw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_nHdsZUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHdsZkBHEeuwb5aqDturqw" x="450" y="-141"/>
             </children>
             <styles xmi:type="notation:SortingStyle" xmi:id="_kJboNT4xEeqAQMi9WMAJGg"/>
             <styles xmi:type="notation:FilteringStyle" xmi:id="_kJboNj4xEeqAQMi9WMAJGg"/>
@@ -9905,6 +11016,10 @@
                 <children xmi:type="notation:Node" xmi:id="_ukD0CT4xEeqAQMi9WMAJGg" type="3010" element="_ujz8Yj4xEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_ukD0Cj4xEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_ukD0Cz4xEeqAQMi9WMAJGg"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_nHoEcEBHEeuwb5aqDturqw" type="3010" element="_nFhysEBHEeuwb5aqDturqw">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_nHoEcUBHEeuwb5aqDturqw" fontName="Segoe UI"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_nHoEckBHEeuwb5aqDturqw"/>
                 </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_ukCl4j4xEeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_ukCl4z4xEeqAQMi9WMAJGg"/>
@@ -10139,6 +11254,214 @@
           <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uQhxwZUdEeq-KoPaR9_Cfg" points="[0, 0, 275, -62]$[-275, 62, 0, 0]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uQiYwpUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_uQiYw5UdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHp5oEBHEeuwb5aqDturqw" type="4001" element="_nHBAcEBHEeuwb5aqDturqw" source="_kJcPQD4xEeqAQMi9WMAJGg" target="_nHb3NEBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_nHp5pEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHp5pUBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHp5pkBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHp5p0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHp5qEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHp5qUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHp5oUBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHp5okBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHp5o0BHEeuwb5aqDturqw" points="[-1, 0, 84, 60]$[-86, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHqgsEBHEeuwb5aqDturqw" id="(0.5028248587570622,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHqgsUBHEeuwb5aqDturqw" id="(0.5071428571428571,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHqgskBHEeuwb5aqDturqw" type="4001" element="_nHBngEBHEeuwb5aqDturqw" source="_nHapEEBHEeuwb5aqDturqw" target="_kJcPQD4xEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_nHrHwEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHrHwUBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHru0EBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHru0UBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHsV4EBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHsV4UBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHqgs0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHqgtEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHqgtUBHEeuwb5aqDturqw" points="[-1, 0, -1, 60]$[-1, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHsV4kBHEeuwb5aqDturqw" id="(0.5028248587570622,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHsV40BHEeuwb5aqDturqw" id="(0.5028248587570622,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHsV5EBHEeuwb5aqDturqw" type="4001" element="_nHCOkEBHEeuwb5aqDturqw" source="_kJcPQD4xEeqAQMi9WMAJGg" target="_nHbQJEBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_nHs88EBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHs88UBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHs88kBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHs880BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHs89EBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHs89UBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHsV5UBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHsV5kBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHsV50BHEeuwb5aqDturqw" points="[-1, 0, -86, 60]$[84, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHs89kBHEeuwb5aqDturqw" id="(0.5028248587570622,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHs890BHEeuwb5aqDturqw" id="(0.5131578947368421,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHs8-EBHEeuwb5aqDturqw" type="4001" element="_nHC1oEBHEeuwb5aqDturqw" source="_nHbQJEBHEeuwb5aqDturqw" target="_nHceREBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_nHs8_EBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHs8_UBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHs8_kBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHs8_0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHtkAEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHtkAUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHs8-UBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHs8-kBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHs8-0BHEeuwb5aqDturqw" points="[-1, 0, 248, 60]$[-250, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHtkAkBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHtkA0BHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHtkBEBHEeuwb5aqDturqw" type="4001" element="_nHDcsEBHEeuwb5aqDturqw" source="_nHbQJEBHEeuwb5aqDturqw" target="_nHceS0BHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_nHtkCEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHtkCUBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHtkCkBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHtkC0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHtkDEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHtkDUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHtkBUBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHtkBkBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHtkB0BHEeuwb5aqDturqw" points="[-1, 0, 48, 60]$[-50, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHuLEEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHuLEUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHuLEkBHEeuwb5aqDturqw" type="4001" element="_nHEDwEBHEeuwb5aqDturqw" source="_nHbQJEBHEeuwb5aqDturqw" target="_nHdsZEBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_nHuLFkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHuLF0BHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHuLGEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHuLGUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHuLGkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHuLG0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHuLE0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHuLFEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHuLFUBHEeuwb5aqDturqw" points="[-1, 0, -152, 60]$[150, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHuLHEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHuLHUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHuLHkBHEeuwb5aqDturqw" type="4001" element="_nHEq00BHEeuwb5aqDturqw" source="_nHbQJEBHEeuwb5aqDturqw" target="_nHdsZEBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_nHuyIEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHuyIUBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHuyIkBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHuyI0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHuyJEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHuyJUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHuLH0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHuLIEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHuLIUBHEeuwb5aqDturqw" points="[-1, 0, -152, 60]$[150, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHvZMEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHvZMUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHvZMkBHEeuwb5aqDturqw" type="4001" element="_nHF480BHEeuwb5aqDturqw" source="_nHceREBHEeuwb5aqDturqw" target="_kJcPRz4xEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_nHvZNkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHvZN0BHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHwAQEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwAQUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHwAQkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwAQ0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHvZM0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHvZNEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHvZNUBHEeuwb5aqDturqw" points="[-1, 0, -201, 60]$[199, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHwAREBHEeuwb5aqDturqw" id="(0.5072463768115942,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHwARUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHwARkBHEeuwb5aqDturqw" type="4001" element="_nHHHEEBHEeuwb5aqDturqw" source="_nHceS0BHEeuwb5aqDturqw" target="_kJcPRz4xEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_nHwASkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwAS0BHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHwATEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwATUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHwATkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwAT0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHwAR0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHwASEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHwASUBHEeuwb5aqDturqw" points="[-1, 0, -1, 60]$[-1, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHwAUEBHEeuwb5aqDturqw" id="(0.5072463768115942,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHwAUUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHwAUkBHEeuwb5aqDturqw" type="4001" element="_nHHuIEBHEeuwb5aqDturqw" source="_nHdsZEBHEeuwb5aqDturqw" target="_kJcPRz4xEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_nHwAVkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwAV0BHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHwAWEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwAWUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHwnUEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwnUUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHwAU0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHwAVEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHwAVUBHEeuwb5aqDturqw" points="[-1, 0, 199, 60]$[-201, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHwnUkBHEeuwb5aqDturqw" id="(0.5072463768115942,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHwnU0BHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHwnVEBHEeuwb5aqDturqw" type="4001" element="_nHI8Q0BHEeuwb5aqDturqw" source="_nHceREBHEeuwb5aqDturqw" target="_k27nYD4xEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_nHwnWEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwnWUBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHwnWkBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwnW0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHwnXEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwnXUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHwnVUBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHwnVkBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHwnV0BHEeuwb5aqDturqw" points="[0, 0, -615, -736]$[615, 736, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHwnXkBHEeuwb5aqDturqw" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHwnX0BHEeuwb5aqDturqw" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHwnYEBHEeuwb5aqDturqw" type="4001" element="_nHKKYEBHEeuwb5aqDturqw" source="_nHceS0BHEeuwb5aqDturqw" target="_k27nYD4xEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_nHwnZEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHwnZUBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHxOYEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHxOYUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHxOYkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHxOY0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHwnYUBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHwnYkBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHwnY0BHEeuwb5aqDturqw" points="[0, 0, -615, -736]$[615, 736, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHxOZEBHEeuwb5aqDturqw" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHxOZUBHEeuwb5aqDturqw" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_nHxOZkBHEeuwb5aqDturqw" type="4001" element="_nHKxcEBHEeuwb5aqDturqw" source="_nHdsZEBHEeuwb5aqDturqw" target="_k27nYD4xEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_nHx1cEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHx1cUBHEeuwb5aqDturqw" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHx1ckBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHx1c0BHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_nHx1dEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nHx1dUBHEeuwb5aqDturqw" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nHxOZ0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_nHxOaEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nHxOaUBHEeuwb5aqDturqw" points="[0, 0, -615, -736]$[615, 736, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHx1dkBHEeuwb5aqDturqw" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nHx1d0BHEeuwb5aqDturqw" id="(0.5,0.5)"/>
         </edges>
       </data>
     </ownedAnnotationEntries>
@@ -10511,7 +11834,7 @@
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']"/>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_kI3ngD4xEeqAQMi9WMAJGg" name="ServiceProvider">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_kI3ngD4xEeqAQMi9WMAJGg" name="ServiceProvider" outgoingEdges="_nHBAcEBHEeuwb5aqDturqw _nHCOkEBHEeuwb5aqDturqw" incomingEdges="_nHBngEBHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8JUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8JUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -10521,8 +11844,24 @@
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFLNYEBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFL0cEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFL0cUBHEeuwb5aqDturqw" name="dcterms:description: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFL0ckBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_kI4OkD4xEeqAQMi9WMAJGg" name="ResourceShape" outgoingEdges="_uQIwIJUdEeq-KoPaR9_Cfg" incomingEdges="_uQO2w5UdEeq-KoPaR9_Cfg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_kI4OkD4xEeqAQMi9WMAJGg" name="ResourceShape" outgoingEdges="_uQIwIJUdEeq-KoPaR9_Cfg" incomingEdges="_uQO2w5UdEeq-KoPaR9_Cfg _nHF480BHEeuwb5aqDturqw _nHHHEEBHEeuwb5aqDturqw _nHHuIEBHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8ZUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8ZUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -10889,6 +12228,142 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFXaoEBHEeuwb5aqDturqw" name="serviceProvider: ServiceProvider []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFXaoUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFXaokBHEeuwb5aqDturqw" name="domain: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFXao0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFYBsEBHEeuwb5aqDturqw" name="service: Service []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFYBsUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFYBskBHEeuwb5aqDturqw" name="creationFactory: CreationFactory">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFYowEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFYowUBHEeuwb5aqDturqw" name="queryCapability: QueryCapability">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFYowkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFZP0EBHEeuwb5aqDturqw" name="creationDialog: Dialog">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFZP0UBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFZP0kBHEeuwb5aqDturqw" name="selectionDialog: Dialog">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFZP00BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFZ24EBHEeuwb5aqDturqw" name="usage: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFZ24UBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFZ24kBHEeuwb5aqDturqw" name="creation: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFZ240BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFZ25EBHEeuwb5aqDturqw" name="resourceShape: ResourceShape []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFad8EBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFad8UBHEeuwb5aqDturqw" name="resourceType: Class">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFad8kBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFad80BHEeuwb5aqDturqw" name="queryBase: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFad9EBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFad9UBHEeuwb5aqDturqw" name="dialog: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFbFAEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFbFAUBHEeuwb5aqDturqw" name="hintHeight: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFbFAkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFbFA0BHEeuwb5aqDturqw" name="hintWidth: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFbFBEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFbFBUBHEeuwb5aqDturqw" name="label: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFbsEEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFbsEUBHEeuwb5aqDturqw" name="domain: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFbsEkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
       </ownedDiagramElements>
       <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_5ZUYEGeLEeqWubhHVdX5HA" name="Configuration">
         <target xmi:type="oslc4j_ai:MavenSpecificationConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration"/>
@@ -10916,6 +12391,230 @@
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_nE6usEBHEeuwb5aqDturqw" name="ServiceProviderCatalog" outgoingEdges="_nHBngEBHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEiKJEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEiKJEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_nE7VwEBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nE9yAEBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nE-ZEEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nE-ZEUBHEeuwb5aqDturqw" name="dcterms:description: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nE-ZEkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nE_AIEBHEeuwb5aqDturqw" name="domain: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nE_AIUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_nE780EBHEeuwb5aqDturqw" name="Service" outgoingEdges="_nHC1oEBHEeuwb5aqDturqw _nHDcsEBHEeuwb5aqDturqw _nHEDwEBHEeuwb5aqDturqw _nHEq00BHEeuwb5aqDturqw" incomingEdges="_nHCOkEBHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEyKJEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEyKJEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_nE780UBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nE_nMEBHEeuwb5aqDturqw" name="usage: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFAOQEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFAOQUBHEeuwb5aqDturqw" name="domain: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFAOQkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_nE8j4EBHEeuwb5aqDturqw" name="Publisher" incomingEdges="_nHBAcEBHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_nr5V8CKJEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_nr5V8CKJEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_nE8j4UBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFA1UEBHEeuwb5aqDturqw" name="dcterms:identifier: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnX1QJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnX1QJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFBcYEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFBcYUBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFBcYkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFCDcEBHEeuwb5aqDturqw" name="label: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFCDcUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_nE8j4kBHEeuwb5aqDturqw" name="CreationFactory" outgoingEdges="_nHF480BHEeuwb5aqDturqw _nHI8Q0BHEeuwb5aqDturqw" incomingEdges="_nHC1oEBHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-8yKKEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-8yKKEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_nE8j40BHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFCqgEBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFCqgUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFCqgkBHEeuwb5aqDturqw" name="creation: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFDRkEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFDRkUBHEeuwb5aqDturqw" name="usage: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFD4oEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFD4oUBHEeuwb5aqDturqw" name="label: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFD4okBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_nE8j5EBHEeuwb5aqDturqw" name="QueryCapability" outgoingEdges="_nHHHEEBHEeuwb5aqDturqw _nHKKYEBHEeuwb5aqDturqw" incomingEdges="_nHDcsEBHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9CKKEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9CKKEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_nE9K8EBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFFt0EBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFGU4EBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFGU4UBHEeuwb5aqDturqw" name="queryBase: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFGU4kBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFG78EBHEeuwb5aqDturqw" name="usage: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFG78UBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFG78kBHEeuwb5aqDturqw" name="label: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFG780BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_nE9K8UBHEeuwb5aqDturqw" name="Dialog" outgoingEdges="_nHHuIEBHEeuwb5aqDturqw _nHKxcEBHEeuwb5aqDturqw" incomingEdges="_nHEDwEBHEeuwb5aqDturqw _nHEq00BHEeuwb5aqDturqw">
+        <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9SKKEeuEW8NmTOtW7w"/>
+        <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9SKKEeuEW8NmTOtW7w"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_nE9K8kBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFIKEEBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFIKEUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFIxIEBHEeuwb5aqDturqw" name="dialog: URI">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFIxIUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFIxIkBHEeuwb5aqDturqw" name="usage: URI []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFJYMEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFJYMUBHEeuwb5aqDturqw" name="hintHeight: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFJYMkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFJYM0BHEeuwb5aqDturqw" name="hintWidth: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFJ_QEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFJ_QUBHEeuwb5aqDturqw" name="label: String">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:Square" xmi:id="_nFJ_QkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
+        </ownedElements>
+      </ownedDiagramElements>
     </ownedDiagramElements>
     <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_k133cD4xEeqAQMi9WMAJGg" name="RDFS (rdfs)" width="40" height="30">
       <target xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='RDFS']"/>
@@ -10927,7 +12626,7 @@
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']"/>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_k2m3QD4xEeqAQMi9WMAJGg" name="Class" outgoingEdges="_uQIJEJUdEeq-KoPaR9_Cfg" incomingEdges="_uQIJEJUdEeq-KoPaR9_Cfg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_k2m3QD4xEeqAQMi9WMAJGg" name="Class" outgoingEdges="_uQIJEJUdEeq-KoPaR9_Cfg" incomingEdges="_uQIJEJUdEeq-KoPaR9_Cfg _nHI8Q0BHEeuwb5aqDturqw _nHKKYEBHEeuwb5aqDturqw _nHKxcEBHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poyKgJUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poyKgJUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -11125,6 +12824,14 @@
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poqOsZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poqOsZUdEeq-KoPaR9_Cfg"/>
           <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_ujz8Yz4xEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_nFhysEBHEeuwb5aqDturqw" name="publisher: Publisher">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_tl7rcCKJEeuEW8NmTOtW7w"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_tl7rcCKJEeuEW8NmTOtW7w"/>
+          <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_nFiZwEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
@@ -11363,6 +13070,136 @@
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
         <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_uQPd0ZUdEeq-KoPaR9_Cfg" showIcon="false"/>
         <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_uQPd0pUdEeq-KoPaR9_Cfg" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHBAcEBHEeuwb5aqDturqw" name="publisher" sourceNode="_kI3ngD4xEeqAQMi9WMAJGg" targetNode="_nE8j4EBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_tl7rcCKJEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_tl7rcCKJEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHBAcUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHBAckBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHBAc0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHBngEBHEeuwb5aqDturqw" name="serviceProvider" sourceNode="_nE6usEBHEeuwb5aqDturqw" targetNode="_kI3ngD4xEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHBngUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHBngkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHBng0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHCOkEBHEeuwb5aqDturqw" name="service" sourceNode="_kI3ngD4xEeqAQMi9WMAJGg" targetNode="_nE780EBHEeuwb5aqDturqw" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHCOkUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHCOkkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHCOk0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHC1oEBHEeuwb5aqDturqw" name="creationFactory" sourceNode="_nE780EBHEeuwb5aqDturqw" targetNode="_nE8j4kBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHC1oUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHC1okBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHC1o0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHDcsEBHEeuwb5aqDturqw" name="queryCapability" sourceNode="_nE780EBHEeuwb5aqDturqw" targetNode="_nE8j5EBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHDcsUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHDcskBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHDcs0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHEDwEBHEeuwb5aqDturqw" name="creationDialog" sourceNode="_nE780EBHEeuwb5aqDturqw" targetNode="_nE9K8UBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHEq0EBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHEq0UBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHEq0kBHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHEq00BHEeuwb5aqDturqw" name="selectionDialog" sourceNode="_nE780EBHEeuwb5aqDturqw" targetNode="_nE9K8UBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHF48EBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHF48UBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHF48kBHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHF480BHEeuwb5aqDturqw" name="resourceShape" sourceNode="_nE8j4kBHEeuwb5aqDturqw" targetNode="_kI4OkD4xEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHGgAEBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHGgAUBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHGgAkBHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHHHEEBHEeuwb5aqDturqw" name="resourceShape" sourceNode="_nE8j5EBHEeuwb5aqDturqw" targetNode="_kI4OkD4xEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHHHEUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHHHEkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHHHE0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHHuIEBHEeuwb5aqDturqw" name="resourceShape" sourceNode="_nE9K8UBHEeuwb5aqDturqw" targetNode="_kI4OkD4xEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHI8QEBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHI8QUBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHI8QkBHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHI8Q0BHEeuwb5aqDturqw" name="resourceType" sourceNode="_nE8j4kBHEeuwb5aqDturqw" targetNode="_k2m3QD4xEeqAQMi9WMAJGg" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHI8REBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHI8RUBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHI8RkBHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHKKYEBHEeuwb5aqDturqw" name="resourceType" sourceNode="_nE8j5EBHEeuwb5aqDturqw" targetNode="_k2m3QD4xEeqAQMi9WMAJGg" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHKKYUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHKKYkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHKKY0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_nHKxcEBHEeuwb5aqDturqw" name="resourceType" sourceNode="_nE9K8UBHEeuwb5aqDturqw" targetNode="_k2m3QD4xEeqAQMi9WMAJGg" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nHKxcUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nHKxckBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_nHKxc0BHEeuwb5aqDturqw" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>

--- a/domains/oslc-domains/pom.xml
+++ b/domains/oslc-domains/pom.xml
@@ -9,14 +9,14 @@
     <parent>
         <groupId>org.eclipse.lyo</groupId>
         <artifactId>lyo-parent</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <!-- End of user code
     -->
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>oslc-domains</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <packaging>jar</packaging>
     <name>Lyo :: Domains</name>
     <properties>

--- a/domains/oslc-domains/pom.xml
+++ b/domains/oslc-domains/pom.xml
@@ -18,42 +18,18 @@
     <artifactId>oslc-domains</artifactId>
     <version>4.0.0</version>
     <packaging>jar</packaging>
-    <name>oslc-domains</name>
+    <name>Lyo :: Domains</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <version.lyo>4.0.0</version.lyo>
         <!-- Start of user code properties
             -->
             <!-- TODO: Add additional properties here to avoid them be overrriden upon future re-generation -->
             <!-- End of user code
         -->
     </properties>
-    <repositories>
-        <!-- Start of user code repositories
-        -->
-        <!-- TODO: Add additional repositories here to avoid them be overrriden upon future re-generation -->
-        <!-- End of user code
-        -->
-        <repository>
-            <id>lyo-releases</id>
-            <name>Eclipse Lyo Releases</name>
-            <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>lyo-snapshots</id>
-            <name>Eclipse Lyo Snapshots</name>
-            <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
     <!-- Start of user code pre_dependencies
     -->
     <!-- End of user code
@@ -67,29 +43,20 @@
         -->
         <!-- General dependencies -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.21</version>
-            <scope>runtime</scope>
-        </dependency>
-        <!-- Servlet dependencies -->
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-            <version>1.2</version>
+            <groupId>javax.servlet.jsp.jstl</groupId>
+            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
+            <scope>provided</scope>
         </dependency>
-        
+
         <!-- Lyo dependencies -->
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-core</artifactId>
-            <version>${version.lyo}</version>
         </dependency>
         
     </dependencies>

--- a/domains/oslc-domains/pom.xml
+++ b/domains/oslc-domains/pom.xml
@@ -18,18 +18,42 @@
     <artifactId>oslc-domains</artifactId>
     <version>4.0.0</version>
     <packaging>jar</packaging>
-    <name>Lyo :: Domains</name>
+    <name>oslc-domains</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <version.lyo>4.0.0</version.lyo>
         <!-- Start of user code properties
             -->
             <!-- TODO: Add additional properties here to avoid them be overrriden upon future re-generation -->
             <!-- End of user code
         -->
     </properties>
+    <repositories>
+        <!-- Start of user code repositories
+        -->
+        <!-- TODO: Add additional repositories here to avoid them be overrriden upon future re-generation -->
+        <!-- End of user code
+        -->
+        <repository>
+            <id>lyo-releases</id>
+            <name>Eclipse Lyo Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>lyo-snapshots</id>
+            <name>Eclipse Lyo Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
     <!-- Start of user code pre_dependencies
     -->
     <!-- End of user code
@@ -43,20 +67,29 @@
         -->
         <!-- General dependencies -->
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.21</version>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Servlet dependencies -->
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>javax.servlet.jsp.jstl-api</artifactId>
-            <scope>provided</scope>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+            <version>1.2</version>
         </dependency>
-
+        
         <!-- Lyo dependencies -->
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-core</artifactId>
+            <version>${version.lyo}</version>
         </dependency>
         
     </dependencies>

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/IRdfsClass.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/IRdfsClass.java
@@ -55,7 +55,6 @@ import org.eclipse.lyo.oslc.domains.RdfsDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfsDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfsVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.IRdfsClass;
-
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfsClass.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfsClass.java
@@ -61,7 +61,6 @@ import org.eclipse.lyo.oslc.domains.RdfsDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfsDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfsVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.RdfsClass;
-
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/ILinkType.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/ILinkType.java
@@ -57,11 +57,8 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfsDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfsVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/IResource.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/IResource.java
@@ -58,8 +58,6 @@ import org.eclipse.lyo.oslc.domains.jazz_am.Jazz_amDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/LinkType.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/LinkType.java
@@ -63,11 +63,8 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfsDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfsVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Resource.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Resource.java
@@ -64,8 +64,6 @@ import org.eclipse.lyo.oslc.domains.jazz_am.Jazz_amDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationPlan.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationPlan.java
@@ -64,11 +64,8 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationRequest.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationRequest.java
@@ -64,13 +64,10 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
 import org.eclipse.lyo.oslc.domains.auto.AutomationPlan;
 import org.eclipse.lyo.oslc.domains.auto.ParameterInstance;
-
+import org.eclipse.lyo.oslc.domains.Person;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationResult.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationResult.java
@@ -64,15 +64,11 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.auto.ParameterInstance;
-import org.eclipse.lyo.oslc.domains.auto.ParameterInstance;
-import org.eclipse.lyo.oslc.domains.auto.AutomationRequest;
 import org.eclipse.lyo.oslc.domains.auto.AutomationPlan;
-
+import org.eclipse.lyo.oslc.domains.auto.AutomationRequest;
+import org.eclipse.lyo.oslc.domains.auto.ParameterInstance;
+import org.eclipse.lyo.oslc.domains.Person;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationPlan.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationPlan.java
@@ -58,11 +58,8 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationRequest.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationRequest.java
@@ -58,13 +58,10 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
 import org.eclipse.lyo.oslc.domains.auto.IAutomationPlan;
 import org.eclipse.lyo.oslc.domains.auto.IParameterInstance;
-
+import org.eclipse.lyo.oslc.domains.IPerson;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationResult.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IAutomationResult.java
@@ -58,15 +58,11 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.auto.IParameterInstance;
-import org.eclipse.lyo.oslc.domains.auto.IParameterInstance;
-import org.eclipse.lyo.oslc.domains.auto.IAutomationRequest;
 import org.eclipse.lyo.oslc.domains.auto.IAutomationPlan;
-
+import org.eclipse.lyo.oslc.domains.auto.IAutomationRequest;
+import org.eclipse.lyo.oslc.domains.auto.IParameterInstance;
+import org.eclipse.lyo.oslc.domains.IPerson;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IParameterInstance.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/IParameterInstance.java
@@ -57,9 +57,7 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.FoafVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
 
 // Start of user code imports

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/ParameterInstance.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/ParameterInstance.java
@@ -63,9 +63,7 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.FoafVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
 
 // Start of user code imports

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ChangeNotice.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ChangeNotice.java
@@ -59,19 +59,16 @@ import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
 
 
-import org.eclipse.lyo.oslc.domains.cm.Defect;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
-import org.eclipse.lyo.oslc.domains.Agent;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc4j.core.model.Discussion;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
-import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.Priority;
-import org.eclipse.lyo.oslc.domains.cm.State;
-import org.eclipse.lyo.oslc.domains.config.ChangeSet;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
 
+import org.eclipse.lyo.oslc.domains.Agent;
+import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
+import org.eclipse.lyo.oslc.domains.config.ChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.Defect;
+import org.eclipse.lyo.oslc4j.core.model.Discussion;
+import org.eclipse.lyo.oslc.domains.Person;
+import org.eclipse.lyo.oslc.domains.cm.Priority;
+import org.eclipse.lyo.oslc.domains.rm.Requirement;
+import org.eclipse.lyo.oslc.domains.cm.State;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ChangeRequest.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ChangeRequest.java
@@ -65,21 +65,16 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.Oslc_cmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.cm.Defect;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
 import org.eclipse.lyo.oslc.domains.Agent;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc4j.core.model.Discussion;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.Priority;
-import org.eclipse.lyo.oslc.domains.cm.State;
 import org.eclipse.lyo.oslc.domains.config.ChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.Defect;
+import org.eclipse.lyo.oslc4j.core.model.Discussion;
+import org.eclipse.lyo.oslc.domains.Person;
+import org.eclipse.lyo.oslc.domains.cm.Priority;
 import org.eclipse.lyo.oslc.domains.rm.Requirement;
-
+import org.eclipse.lyo.oslc.domains.cm.State;
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_cmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Defect.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Defect.java
@@ -59,19 +59,16 @@ import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
 
 
-import org.eclipse.lyo.oslc.domains.cm.Defect;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
-import org.eclipse.lyo.oslc.domains.Agent;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc4j.core.model.Discussion;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
-import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.Priority;
-import org.eclipse.lyo.oslc.domains.cm.State;
-import org.eclipse.lyo.oslc.domains.config.ChangeSet;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
 
+import org.eclipse.lyo.oslc.domains.Agent;
+import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
+import org.eclipse.lyo.oslc.domains.config.ChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.Defect;
+import org.eclipse.lyo.oslc4j.core.model.Discussion;
+import org.eclipse.lyo.oslc.domains.Person;
+import org.eclipse.lyo.oslc.domains.cm.Priority;
+import org.eclipse.lyo.oslc.domains.rm.Requirement;
+import org.eclipse.lyo.oslc.domains.cm.State;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Enhancement.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Enhancement.java
@@ -59,19 +59,16 @@ import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
 
 
-import org.eclipse.lyo.oslc.domains.cm.Defect;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
-import org.eclipse.lyo.oslc.domains.Agent;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc4j.core.model.Discussion;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
-import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.Priority;
-import org.eclipse.lyo.oslc.domains.cm.State;
-import org.eclipse.lyo.oslc.domains.config.ChangeSet;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
 
+import org.eclipse.lyo.oslc.domains.Agent;
+import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
+import org.eclipse.lyo.oslc.domains.config.ChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.Defect;
+import org.eclipse.lyo.oslc4j.core.model.Discussion;
+import org.eclipse.lyo.oslc.domains.Person;
+import org.eclipse.lyo.oslc.domains.cm.Priority;
+import org.eclipse.lyo.oslc.domains.rm.Requirement;
+import org.eclipse.lyo.oslc.domains.cm.State;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IChangeNotice.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IChangeNotice.java
@@ -53,19 +53,16 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
 import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 
-import org.eclipse.lyo.oslc.domains.cm.IDefect;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-import org.eclipse.lyo.oslc.domains.IAgent;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.IPriority;
-import org.eclipse.lyo.oslc.domains.cm.IState;
-import org.eclipse.lyo.oslc.domains.config.IChangeSet;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
 
+import org.eclipse.lyo.oslc.domains.IAgent;
+import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
+import org.eclipse.lyo.oslc.domains.config.IChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.IDefect;
+import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
+import org.eclipse.lyo.oslc.domains.IPerson;
+import org.eclipse.lyo.oslc.domains.cm.IPriority;
+import org.eclipse.lyo.oslc.domains.rm.IRequirement;
+import org.eclipse.lyo.oslc.domains.cm.IState;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IChangeRequest.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IChangeRequest.java
@@ -59,21 +59,16 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.Oslc_cmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.cm.IDefect;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
 import org.eclipse.lyo.oslc.domains.IAgent;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
 import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.IPriority;
-import org.eclipse.lyo.oslc.domains.cm.IState;
 import org.eclipse.lyo.oslc.domains.config.IChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.IDefect;
+import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
+import org.eclipse.lyo.oslc.domains.IPerson;
+import org.eclipse.lyo.oslc.domains.cm.IPriority;
 import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-
+import org.eclipse.lyo.oslc.domains.cm.IState;
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_cmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IDefect.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IDefect.java
@@ -53,19 +53,16 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
 import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 
-import org.eclipse.lyo.oslc.domains.cm.IDefect;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-import org.eclipse.lyo.oslc.domains.IAgent;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.IPriority;
-import org.eclipse.lyo.oslc.domains.cm.IState;
-import org.eclipse.lyo.oslc.domains.config.IChangeSet;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
 
+import org.eclipse.lyo.oslc.domains.IAgent;
+import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
+import org.eclipse.lyo.oslc.domains.config.IChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.IDefect;
+import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
+import org.eclipse.lyo.oslc.domains.IPerson;
+import org.eclipse.lyo.oslc.domains.cm.IPriority;
+import org.eclipse.lyo.oslc.domains.rm.IRequirement;
+import org.eclipse.lyo.oslc.domains.cm.IState;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IEnhancement.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IEnhancement.java
@@ -53,19 +53,16 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
 import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 
-import org.eclipse.lyo.oslc.domains.cm.IDefect;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-import org.eclipse.lyo.oslc.domains.IAgent;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.IPriority;
-import org.eclipse.lyo.oslc.domains.cm.IState;
-import org.eclipse.lyo.oslc.domains.config.IChangeSet;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
 
+import org.eclipse.lyo.oslc.domains.IAgent;
+import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
+import org.eclipse.lyo.oslc.domains.config.IChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.IDefect;
+import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
+import org.eclipse.lyo.oslc.domains.IPerson;
+import org.eclipse.lyo.oslc.domains.cm.IPriority;
+import org.eclipse.lyo.oslc.domains.rm.IRequirement;
+import org.eclipse.lyo.oslc.domains.cm.IState;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IPriority.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IPriority.java
@@ -54,6 +54,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 
 
+
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IReviewTask.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IReviewTask.java
@@ -53,19 +53,16 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
 import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 
-import org.eclipse.lyo.oslc.domains.cm.IDefect;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-import org.eclipse.lyo.oslc.domains.IAgent;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.IPriority;
-import org.eclipse.lyo.oslc.domains.cm.IState;
-import org.eclipse.lyo.oslc.domains.config.IChangeSet;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
 
+import org.eclipse.lyo.oslc.domains.IAgent;
+import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
+import org.eclipse.lyo.oslc.domains.config.IChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.IDefect;
+import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
+import org.eclipse.lyo.oslc.domains.IPerson;
+import org.eclipse.lyo.oslc.domains.cm.IPriority;
+import org.eclipse.lyo.oslc.domains.rm.IRequirement;
+import org.eclipse.lyo.oslc.domains.cm.IState;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IState.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/IState.java
@@ -54,6 +54,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 
 
+
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ITask.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ITask.java
@@ -53,19 +53,16 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
 import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 
-import org.eclipse.lyo.oslc.domains.cm.IDefect;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-import org.eclipse.lyo.oslc.domains.IAgent;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.IPriority;
-import org.eclipse.lyo.oslc.domains.cm.IState;
-import org.eclipse.lyo.oslc.domains.config.IChangeSet;
-import org.eclipse.lyo.oslc.domains.rm.IRequirement;
 
+import org.eclipse.lyo.oslc.domains.IAgent;
+import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
+import org.eclipse.lyo.oslc.domains.config.IChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.IDefect;
+import org.eclipse.lyo.oslc4j.core.model.IDiscussion;
+import org.eclipse.lyo.oslc.domains.IPerson;
+import org.eclipse.lyo.oslc.domains.cm.IPriority;
+import org.eclipse.lyo.oslc.domains.rm.IRequirement;
+import org.eclipse.lyo.oslc.domains.cm.IState;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Priority.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Priority.java
@@ -60,6 +60,7 @@ import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 
 
 
+
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ReviewTask.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ReviewTask.java
@@ -59,19 +59,16 @@ import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 import org.eclipse.lyo.oslc.domains.cm.Task;
 
 
-import org.eclipse.lyo.oslc.domains.cm.Defect;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
-import org.eclipse.lyo.oslc.domains.Agent;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc4j.core.model.Discussion;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
-import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.Priority;
-import org.eclipse.lyo.oslc.domains.cm.State;
-import org.eclipse.lyo.oslc.domains.config.ChangeSet;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
 
+import org.eclipse.lyo.oslc.domains.Agent;
+import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
+import org.eclipse.lyo.oslc.domains.config.ChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.Defect;
+import org.eclipse.lyo.oslc4j.core.model.Discussion;
+import org.eclipse.lyo.oslc.domains.Person;
+import org.eclipse.lyo.oslc.domains.cm.Priority;
+import org.eclipse.lyo.oslc.domains.rm.Requirement;
+import org.eclipse.lyo.oslc.domains.cm.State;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/State.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/State.java
@@ -60,6 +60,7 @@ import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 
 
 
+
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Task.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Task.java
@@ -59,19 +59,16 @@ import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
 
 
-import org.eclipse.lyo.oslc.domains.cm.Defect;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
-import org.eclipse.lyo.oslc.domains.Agent;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc4j.core.model.Discussion;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
-import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.Priority;
-import org.eclipse.lyo.oslc.domains.cm.State;
-import org.eclipse.lyo.oslc.domains.config.ChangeSet;
-import org.eclipse.lyo.oslc.domains.rm.Requirement;
 
+import org.eclipse.lyo.oslc.domains.Agent;
+import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
+import org.eclipse.lyo.oslc.domains.config.ChangeSet;
+import org.eclipse.lyo.oslc.domains.cm.Defect;
+import org.eclipse.lyo.oslc4j.core.model.Discussion;
+import org.eclipse.lyo.oslc.domains.Person;
+import org.eclipse.lyo.oslc.domains.cm.Priority;
+import org.eclipse.lyo.oslc.domains.rm.Requirement;
+import org.eclipse.lyo.oslc.domains.cm.State;
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/ChangeSet.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/ChangeSet.java
@@ -60,6 +60,7 @@ import org.eclipse.lyo.oslc.domains.config.Oslc_configDomainConstants;
 
 
 
+
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/IChangeSet.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/IChangeSet.java
@@ -54,6 +54,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 import org.eclipse.lyo.oslc.domains.config.Oslc_configDomainConstants;
 
 
+
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/IVersionResource.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/IVersionResource.java
@@ -59,11 +59,8 @@ import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.ProvDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/VersionResource.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/VersionResource.java
@@ -65,11 +65,8 @@ import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.ProvDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-
 // Start of user code imports
 // End of user code
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestCase.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestCase.java
@@ -60,17 +60,12 @@ import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
 import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.qm.ITestScript;
+import org.eclipse.lyo.oslc.domains.IPerson;
 import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-
+import org.eclipse.lyo.oslc.domains.qm.ITestScript;
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestExecutionRecord.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestExecutionRecord.java
@@ -59,17 +59,12 @@ import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
 import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.qm.ITestPlan;
 import org.eclipse.lyo.oslc.domains.qm.ITestCase;
-
+import org.eclipse.lyo.oslc.domains.qm.ITestPlan;
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestPlan.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestPlan.java
@@ -60,16 +60,12 @@ import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
 import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.qm.ITestCase;
+import org.eclipse.lyo.oslc.domains.IPerson;
 import org.eclipse.lyo.oslc.domains.rm.IRequirementCollection;
-
+import org.eclipse.lyo.oslc.domains.qm.ITestCase;
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestResult.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestResult.java
@@ -58,16 +58,13 @@ import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
-import org.eclipse.lyo.oslc.domains.qm.ITestScript;
-import org.eclipse.lyo.oslc.domains.qm.ITestExecutionRecord;
 import org.eclipse.lyo.oslc.domains.qm.ITestCase;
+import org.eclipse.lyo.oslc.domains.qm.ITestExecutionRecord;
 import org.eclipse.lyo.oslc.domains.qm.ITestPlan;
-
+import org.eclipse.lyo.oslc.domains.qm.ITestScript;
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestScript.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/ITestScript.java
@@ -60,15 +60,11 @@ import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
 import org.eclipse.lyo.oslc.domains.cm.IChangeRequest;
+import org.eclipse.lyo.oslc.domains.IPerson;
 import org.eclipse.lyo.oslc.domains.rm.IRequirement;
-
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestCase.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestCase.java
@@ -66,17 +66,12 @@ import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.qm.TestScript;
+import org.eclipse.lyo.oslc.domains.Person;
 import org.eclipse.lyo.oslc.domains.rm.Requirement;
-
+import org.eclipse.lyo.oslc.domains.qm.TestScript;
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestExecutionRecord.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestExecutionRecord.java
@@ -65,17 +65,12 @@ import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
 import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.qm.TestPlan;
 import org.eclipse.lyo.oslc.domains.qm.TestCase;
-
+import org.eclipse.lyo.oslc.domains.qm.TestPlan;
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestPlan.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestPlan.java
@@ -66,16 +66,12 @@ import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.qm.TestCase;
+import org.eclipse.lyo.oslc.domains.Person;
 import org.eclipse.lyo.oslc.domains.rm.RequirementCollection;
-
+import org.eclipse.lyo.oslc.domains.qm.TestCase;
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestResult.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestResult.java
@@ -64,16 +64,13 @@ import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
-import org.eclipse.lyo.oslc.domains.qm.TestScript;
-import org.eclipse.lyo.oslc.domains.qm.TestExecutionRecord;
 import org.eclipse.lyo.oslc.domains.qm.TestCase;
+import org.eclipse.lyo.oslc.domains.qm.TestExecutionRecord;
 import org.eclipse.lyo.oslc.domains.qm.TestPlan;
-
+import org.eclipse.lyo.oslc.domains.qm.TestScript;
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestScript.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestScript.java
@@ -66,15 +66,11 @@ import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
 import org.eclipse.lyo.oslc.domains.RdfDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.RdfVocabularyConstants;
-import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
 import org.eclipse.lyo.oslc.domains.cm.ChangeRequest;
+import org.eclipse.lyo.oslc.domains.Person;
 import org.eclipse.lyo.oslc.domains.rm.Requirement;
-
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_qmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/IRequirement.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/IRequirement.java
@@ -57,11 +57,8 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_rmVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_rmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/IRequirementCollection.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/IRequirementCollection.java
@@ -57,11 +57,8 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_rmVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.IPerson;
-import org.eclipse.lyo.oslc.domains.IPerson;
-
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_rmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Requirement.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Requirement.java
@@ -63,11 +63,8 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_rmVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_rmVocabularyConstants;
 // End of user code

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/RequirementCollection.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/RequirementCollection.java
@@ -63,11 +63,8 @@ import org.eclipse.lyo.oslc.domains.FoafDomainConstants;
 import org.eclipse.lyo.oslc4j.core.model.OslcDomainConstants;
 import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
 import org.eclipse.lyo.oslc.domains.DctermsVocabularyConstants;
-
 import org.eclipse.lyo.oslc.domains.Oslc_rmVocabularyConstants;
 import org.eclipse.lyo.oslc.domains.Person;
-import org.eclipse.lyo.oslc.domains.Person;
-
 // Start of user code imports
 import org.eclipse.lyo.oslc.domains.Oslc_rmVocabularyConstants;
 // End of user code

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.lyo</groupId>
   <artifactId>lyo-parent</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0</version>
   <packaging>pom</packaging>
   <name>Lyo :: _Parent</name>
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Lyo Server Changelog
 
-## 4.0.0 (WIP)
+## [4.0.0]
 
 ### Changed
 

--- a/server/oauth-consumer-store/pom.xml
+++ b/server/oauth-consumer-store/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.server</groupId>

--- a/server/oauth-core/pom.xml
+++ b/server/oauth-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.server</groupId>

--- a/server/oauth-webapp/pom.xml
+++ b/server/oauth-webapp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.server</groupId>
         <artifactId>lyo-server-build</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.server</groupId>

--- a/server/oslc4j-registry/pom.xml
+++ b/server/oslc4j-registry/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.server</groupId>
     <artifactId>lyo-server-build</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.lyo.oslc4j.core</groupId>

--- a/server/oslc4j-wink/pom.xml
+++ b/server/oslc4j-wink/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.server</groupId>
     <artifactId>lyo-server-build</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.lyo.oslc4j.core</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -4,14 +4,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.lyo.oslc4j.server</groupId>
   <artifactId>lyo-server-build</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0</version>
   <packaging>pom</packaging>
   <name>Lyo :: OAuth :: _Parent</name>
 
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/store/CHANGELOG.md
+++ b/store/CHANGELOG.md
@@ -1,20 +1,12 @@
 # Lyo Store changelog
 
-## [Unreleased/4.0.0]
+## [4.0.0]
 
-### Added
-### Changed
 ### Deprecated
 
 - `JenaTdbStoreImpl` has been lagging behind in functionality and will be deprecated in this release.
   - `StoreFactory#inMemory` and `StoreFactory#onDisk` are also deprecated as they rely on this implementation.
   - Use `SparqlStoreImpl#SparqlStoreImpl(JenaQueryExecutor)` to pass a `DatasetQueryExecutorImpl` instance instead.
-
-
-
-### Removed
-### Fixed
-### Security
 
 ---
 

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -6,14 +6,14 @@
 
   <groupId>org.eclipse.lyo.store</groupId>
   <artifactId>store-parent</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0</version>
   <packaging>pom</packaging>
   <name>Lyo :: Store :: _Parent</name>
 
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
   </parent>
 
   <properties>

--- a/store/store-core/pom.xml
+++ b/store/store-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.lyo.store</groupId>
     <artifactId>store-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/trs/client/client-source-mqtt/pom.xml
+++ b/trs/client/client-source-mqtt/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.lyo.trs</groupId>
     <artifactId>trs-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
   </parent>
 
   <artifactId>client-source-mqtt</artifactId>

--- a/trs/client/pom.xml
+++ b/trs/client/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/trs/client/trs-client/pom.xml
+++ b/trs/client/trs-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.lyo.trs</groupId>
     <artifactId>trs-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
   </parent>
 
   <artifactId>trs-client</artifactId>

--- a/trs/server/pom.xml
+++ b/trs/server/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.lyo.trs</groupId>
   <artifactId>trs-server</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0</version>
   <name>Lyo :: TRS :: Server</name>
 
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
   </parent>
 
   <properties>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <!--	<groupId>org.eclipse.lyo</groupId>-->
   <artifactId>lyo-validation</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0</version>
   <name>Lyo :: Validation</name>
 
   <parent>
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
# Description

## Major changes

- EPL 2.0 license upgrade
- Maven Central deployment
- JAX-RS 2.0 upgrade and removal of Wink dependencies
- New OSLC Client
- Many updates to Lyo Designer, including  RootServices, OAuth, TRS, and a standalone IDE.

## Overall

- Switch from `EPL-1.0 OR BSD-3-Simple` license (and in some cases only EPL-1.0) to `EPL-2.0 OR BSD-3-Simple` for all library code and `BSD-3-Simple` for the generated code. EPL still gives you patent protection if you choose so but generated code now does not contain any mention of EPL "mild" copyleft license and should make it easy for you to get the code included in your project or relicense it under another OSS license (not a legal advice).
- Switch from deep code scanning release process (Type B) to lightweight deep license check process (Type A). Great reduction in time overhead.
- Monorepo migration. Will help us to make milestone/RC releases in a single pull request among other things. Also, version mismatches should not occur any more thanks to a single parent and generation of the Dependency Convergence reports via Maven.
- Lyo is now on Maven Central!

## Core

- Wink is now removed from the critical path and Lyo has upgaded from JAX-RS 1.1 to JAX-RS 2.0. Apache has retired Wink to attic more than 5 years ago and it had some bespoke APIs. **This is the main breaking change.** 

## Domains

- Domain classes are now generated via a Lyo Designer model and are up to date with the OSLC specs.


## Client

- New client written using JAX-RS API (as well as some necessary dependencies on Jersey client and Apache HttpClient directly, unfortunately) is here! The reason is that Wink client was not JAX-RS based at all and this was the most troublesome part of the migration.
- Single interface for OAuth and non-OAuth clients.
- Old client is deprecated but still shipped in case you need to use it. Using the old client inside the new JAX-RS based OSLC Server is strongly discouraged. The recommended use-case is a standalone Java SE app (due to a potential JAX-RS 1.1 and JAX-2.0 conflict)
- Old client's domain classes are extracted into a separate package (in a rare case you need to use them from the new client) and marked deprecated (you should give the new domains package a try!).

## Designer

* LyoDesigner is now available as a stand-alone Eclipse RCP (Rich Client Platform) application
* Support for the generation of complete maven projects (including project files).
* Improve modelling & generation for resource C.R.U.D. operations.
* Modelling and generation support for authentication, rootservices, OAuth1.0
* Modelling and generation support for Lyo.store
* Modelling and generation support for In-memory TRS
* Automated support for swagger documentation
* Support for an embedded Swagger-ui Editor.
* OSLC4J Core & Client available as osgi bundles

## Validation

- Due to a change in license check policy, we can now release the Lyo Validation library for OSLC Shape and SHACL validation. :tada: This was not possible before due to the IP review delay of nearly 100 Scala dependencies.

## Sample code

- Lyo now keeps track of all known sample code and OSS OSLC Servers: https://github.com/eclipse/lyo/blob/master/README.md#test-and-sample-repositories 

# Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [ ] This PR does NOT break the API

# Issues

Closes #7
