### PR TITLE
Exclude JCL from core

### DIFF
--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -44,10 +44,20 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,14 +164,6 @@
         <artifactId>httpclient</artifactId>
         <version>${v.httpclient}</version>
       </dependency>
-      <!--
-            <dependency>
-              &lt;!&ndash;Manual enforcement due to security issues and lack of convergence transitively&ndash;&gt;
-              <groupId>org.apache.httpcomponents</groupId>
-              <artifactId>httpcore</artifactId>
-              <version>${v.httpclient}</version>
-            </dependency>
-      -->
 
       <dependency>
         <groupId>javax.servlet.jsp.jstl</groupId>
@@ -233,6 +225,11 @@
         <!--CQ 13717-->
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
+        <version>${v.slf4j}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
         <version>${v.slf4j}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
## Description

Prevents warnings like

> [WARNING] org.apache.commons.logging.impl.NoOpLog scanned from multiple locations: jar:file:///Users/ezandbe/git/oslc/lyo/xMisc/lyo-adaptor-sample-modelling/adaptor-rm-webapp/target/adaptor-rm/WEB-INF/lib/commons-logging-1.2.jar!/org/apache/commons/logging/impl/NoOpLog.class, jar:file:///Users/ezandbe/git/oslc/lyo/xMisc/lyo-adaptor-sample-modelling/adaptor-rm-webapp/target/adaptor-rm/WEB-INF/lib/jcl-over-slf4j-1.7.26.jar!/org/apache/commons/logging/impl/NoOpLog.class

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #62