### PR TITLE
Eliminate xerces and xml-apis from Lyo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Removed
 
+- Xerces and xml-apis dependencies are removed and banned via maven-enforcer-plugin
+
 ### Fixed
 
 

--- a/client/oslc-client/pom.xml
+++ b/client/oslc-client/pom.xml
@@ -1,163 +1,160 @@
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-      <groupId>org.eclipse.lyo.clients</groupId>
-      <artifactId>clients-parent</artifactId>
-      <version>4.1.0-SNAPSHOT</version>
-      <relativePath>../pom.xml</relativePath>
-    </parent>
-
-    <artifactId>oslc-client</artifactId>
+  <parent>
+    <groupId>org.eclipse.lyo.clients</groupId>
+    <artifactId>clients-parent</artifactId>
     <version>4.1.0-SNAPSHOT</version>
-    <name>Lyo :: Client :: OSLC JAX-RS 2.0 (new)</name>
-    <description>Eclipse Lyo OSLC Java client based on OSLC4J and JAX-RS 2.0</description>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
+  <artifactId>oslc-client</artifactId>
+  <version>4.1.0-SNAPSHOT</version>
+  <name>Lyo :: Client :: OSLC JAX-RS 2.0 (new)</name>
+  <description>Eclipse Lyo OSLC Java client based on OSLC4J and JAX-RS 2.0</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.lyo.clients</groupId>
+      <artifactId>oslc-client-base</artifactId>
+      <version>${v.lyo}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${v.slf4j}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>apache-jena-libs</artifactId>
+      <type>pom</type>
+      <version>${v.jena}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${v.httpclient}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${v.slf4j}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.oauth.core</groupId>
+      <artifactId>oauth</artifactId>
+      <version>20100527</version>
+    </dependency>
+    <dependency>
+      <groupId>net.oauth.core</groupId>
+      <artifactId>oauth-consumer</artifactId>
+      <version>20100527</version>
+    </dependency>
+    <dependency>
+      <groupId>net.oauth.core</groupId>
+      <artifactId>oauth-httpclient4</artifactId>
+      <version>20090913</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.lyo.oslc4j.core</groupId>
+      <artifactId>oslc4j-core</artifactId>
+      <version>${v.lyo}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.lyo.oslc4j.core</groupId>
+      <artifactId>oslc4j-jena-provider</artifactId>
+      <version>${v.lyo}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.lyo.oslc4j.core</groupId>
+      <artifactId>oslc4j-json4j-provider</artifactId>
+      <version>${v.lyo}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <!--FIXME https://bugs.eclipse.org/bugs/show_bug.cgi?id=513048-->
+      <!--          <scope>provided</scope>-->
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!--TEST-->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${v.slf4j}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!--CQ 13719-->
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
+      <version>${v.jersey}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.eclipse.lyo.clients</groupId>
-        <artifactId>oslc-client-base</artifactId>
-        <version>${v.lyo}</version>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
       </dependency>
-
       <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${v.slf4j}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>apache-jena-libs</artifactId>
-            <type>pom</type>
-            <version>${v.jena}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${v.httpclient}</version>
-            <exclusions>
-              <exclusion>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-              </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>jcl-over-slf4j</artifactId>
-          <version>${v.slf4j}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.oauth.core</groupId>
-            <artifactId>oauth</artifactId>
-            <version>20100527</version>
-        </dependency>
-        <dependency>
-            <groupId>net.oauth.core</groupId>
-            <artifactId>oauth-consumer</artifactId>
-            <version>20100527</version>
-        </dependency>
-        <dependency>
-            <groupId>net.oauth.core</groupId>
-            <artifactId>oauth-httpclient4</artifactId>
-            <version>20090913</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.lyo.oslc4j.core</groupId>
-            <artifactId>oslc4j-core</artifactId>
-            <version>${v.lyo}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.lyo.oslc4j.core</groupId>
-            <artifactId>oslc4j-jena-provider</artifactId>
-            <version>${v.lyo}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.lyo.oslc4j.core</groupId>
-            <artifactId>oslc4j-json4j-provider</artifactId>
-            <version>${v.lyo}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-          <!--FIXME https://bugs.eclipse.org/bugs/show_bug.cgi?id=513048-->
-          <!--          <scope>provided</scope>-->
-        </dependency>
-        <dependency>
-          <groupId>jakarta.ws.rs</groupId>
-          <artifactId>jakarta.ws.rs-api</artifactId>
-          <scope>provided</scope>
-        </dependency>
-
-      <!--TEST-->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${v.slf4j}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.23.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <!--CQ 13719-->
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-      <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${v.jersey}</version>
-            <scope>test</scope>
-        </dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+      </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-                <version>1.3.04</version>
-            </dependency>
-            <dependency>
-                <groupId>xerces</groupId>
-                <artifactId>xercesImpl</artifactId>
-                <version>2.12.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+  </dependencyManagement>
 </project>

--- a/client/oslc-java-client/pom.xml
+++ b/client/oslc-java-client/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eclipse.lyo.clients</groupId>
@@ -118,7 +117,7 @@
       <artifactId>oslc4j-json4j-provider</artifactId>
       <version>${lyo.version}</version>
     </dependency>
-<!--
+    <!--
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
@@ -147,7 +146,8 @@
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
     </dependency>
-    <dependency> <!--See https://bugs.eclipse.org/bugs/show_bug.cgi?id=513048-->
+    <dependency>
+      <!--See https://bugs.eclipse.org/bugs/show_bug.cgi?id=513048-->
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
@@ -230,7 +230,7 @@
   </build>
   <dependencyManagement>
     <dependencies>
-<!--
+      <!--
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.lyo</groupId>
   <artifactId>lyo-parent</artifactId>
@@ -273,10 +272,9 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <!--CQ 6583-->
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
-        <version>2.12.0</version>
+        <version>2.12.1</version>
       </dependency>
       <dependency>
         <groupId>jakarta.ws.rs</groupId>
@@ -368,9 +366,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.2.0</version>
+          <!-- <version>3.1.1</version> -->
           <configuration>
             <source>8</source>
-            <doclint>none</doclint>
+            <release>8</release> <!-- JDK 9+ -->
+            <doclint>none</doclint> <!-- JDK 8 -->
+            <detectJavaApiLink>false</detectJavaApiLink> <!-- JDK11 -->
           </configuration>
           <executions>
             <execution>
@@ -429,18 +430,24 @@
             </goals>
             <configuration>
               <rules>
-                <banDuplicatePomDependencyVersions/>
+                <banDuplicatePomDependencyVersions />
                 <requireMavenVersion>
                   <version>3.0</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>1.8</version>
                 </requireJavaVersion>
-                <requireUpperBoundDeps/>
+                <requireUpperBoundDeps />
                 <reactorModuleConvergence>
                   <message>The reactor is not valid</message>
                   <ignoreModuleDependencies>false</ignoreModuleDependencies>
                 </reactorModuleConvergence>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>xerces</exclude>
+                    <exclude>xml-apis</exclude>
+                  </excludes>
+                </bannedDependencies>
               </rules>
               <fail>true</fail>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,8 @@
           <!-- <version>3.1.1</version> -->
           <configuration>
             <source>8</source>
-            <release>8</release> <!-- JDK 9+ -->
+            <!-- TODO scope it with a profile for JDK 9+-->
+            <!-- <release>8</release> -->
             <doclint>none</doclint> <!-- JDK 8 -->
             <detectJavaApiLink>false</detectJavaApiLink> <!-- JDK11 -->
           </configuration>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -38,7 +36,7 @@
         <version>${v.jena}</version>
         <type>pom</type>
       </dependency>
-       <dependency>
+      <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-querybuilder</artifactId>
         <version>${v.jena}</version>
@@ -68,12 +66,6 @@
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
         <version>${v.slf4j}</version>
-      </dependency>
-      <dependency>
-        <!--TODO why is it here?-->
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.3.04</version>
       </dependency>
 
       <!-- Test -->

--- a/store/store-core/pom.xml
+++ b/store/store-core/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -13,7 +11,7 @@
 
   <artifactId>store-core</artifactId>
   <name>Lyo :: Store :: Core</name>
-  
+
   <properties>
     <lyo.version>${project.parent.version}</lyo.version>
 
@@ -47,9 +45,9 @@
       </exclusions>
     </dependency>
     <dependency>
-        <groupId>org.eclipse.lyo.core.query</groupId>
-        <artifactId>oslc-query</artifactId>
-        <version>${lyo.version}</version>
+      <groupId>org.eclipse.lyo.core.query</groupId>
+      <artifactId>oslc-query</artifactId>
+      <version>${lyo.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -69,8 +67,8 @@
       <type>pom</type>
     </dependency>
     <dependency>
-        <groupId>org.apache.jena</groupId>
-        <artifactId>jena-querybuilder</artifactId>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-querybuilder</artifactId>
     </dependency>
 
     <!-- Generic -->
@@ -81,11 +79,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
-      <!--TODO why is it here?-->
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
     </dependency>
 
     <!-- Test -->
@@ -129,7 +122,7 @@
           <instrumentation>
             <ignoreTrivial>true</ignoreTrivial>
           </instrumentation>
-          <check/>
+          <check />
         </configuration>
       </plugin>
       <plugin>

--- a/trs/client/client-source-mqtt/pom.xml
+++ b/trs/client/client-source-mqtt/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eclipse.lyo.trs</groupId>
@@ -18,7 +16,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <v.dokka>1.4.20</v.dokka>
-<!--    <v.dokka>0.10.1</v.dokka>-->
   </properties>
 
 
@@ -87,13 +84,4 @@
       <artifactId>oslc4j-jena-provider</artifactId>
     </dependency>
   </dependencies>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jcenter</id>
-      <name>JCenter</name>
-      <url>https://jcenter.bintray.com/</url>
-    </pluginRepository>
-  </pluginRepositories>
-
 </project>

--- a/trs/client/pom.xml
+++ b/trs/client/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.lyo.trs</groupId>
   <artifactId>trs-parent</artifactId>
@@ -15,11 +13,8 @@
   </parent>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-
     <v.kotlin>1.4.20</v.kotlin>
+    <v.dokka>1.4.20</v.dokka>
   </properties>
 
   <modules>
@@ -222,4 +217,12 @@
       </plugin>
     </plugins>
   </build>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jcenter</id>
+      <name>JCenter</name>
+      <url>https://jcenter.bintray.com/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/trs/client/trs-client/pom.xml
+++ b/trs/client/trs-client/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.eclipse.lyo.trs</groupId>
@@ -13,14 +11,7 @@
   <artifactId>trs-client</artifactId>
   <name>Lyo :: TRS :: Client :: Client library</name>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-
-    <v.lyo>${project.version}</v.lyo>
-    <v.jersey>2.25.1</v.jersey>
-  </properties>
+  <properties></properties>
 
   <build>
     <plugins>
@@ -29,8 +20,32 @@
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
+        <groupId>org.jetbrains.dokka</groupId>
+        <artifactId>dokka-maven-plugin</artifactId>
+        <version>${v.dokka}</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>dokka</goal>
+              <goal>javadoc</goal>
+              <goal>javadocJar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <sourceDirectories>
+            <dir>${basedir}/src/main/java</dir>
+            <dir>${basedir}/src/main/kotlin</dir>
+          </sourceDirectories>
+          <dokkaPlugins>
+            <plugin>
+              <groupId>org.jetbrains.dokka</groupId>
+              <artifactId>kotlin-as-java-plugin</artifactId>
+              <version>${v.dokka}</version>
+            </plugin>
+          </dokkaPlugins>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -93,6 +108,12 @@
       <groupId>com.j2bugzilla</groupId>
       <artifactId>j2bugzilla</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- test or not? -->

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <!--	<groupId>org.eclipse.lyo</groupId>-->
   <artifactId>lyo-validation</artifactId>
@@ -40,6 +39,12 @@
       <artifactId>shaclex_2.12</artifactId>
       <version>${v.shaclex}</version>
       <type>pom</type>
+      <exclusions>
+        <exclusion>
+          <groupId>xerces</groupId>
+          <artifactId>xercesImpl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Guava Library -->
@@ -64,12 +69,6 @@
       <groupId>org.eclipse.lyo</groupId>
       <artifactId>shacl</artifactId>
       <version>${v.lyo}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-      <version>1.4.01</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

In the past, we dealt with xerces and xml-apis by pinning latest versions of them. Now that we are not using Wink any more, we can remove them completely.

See https://github.com/eclipse/lyo.core/issues/121 for the old ticket and https://stackoverflow.com/questions/11677572/dealing-with-xerces-hell-in-java-maven for why xerces is trouble and https://www.odi.ch/weblog/posting.php?posting=689 why those libs written for Java 1.3 are not needed since Java 6 anymore.

**I suggest to release Lyo 4.1.0.alpha1 with Jena 3.17 separately and Lyo 4.1.0.alpha2 with this patch.** The reason is that some breakage may occur if the downstream projects depend on xerces (should not be the case since 4.0 but still; those who will see problems should just include xml-apis 1.4.01 manually) and we'd want to have a baseline to know it's not Jena 3.17 causing any problems.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

