### PR TITLE
Test that ChangeEvent's are serialised with their ChangeLog's

### DIFF
--- a/core/oslc-trs/src/test/java/org/eclipse/lyo/core/trs/ChangeLogTest.java
+++ b/core/oslc-trs/src/test/java/org/eclipse/lyo/core/trs/ChangeLogTest.java
@@ -1,10 +1,21 @@
 package org.eclipse.lyo.core.trs;
 
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
 import java.util.List;
+
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
+import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.datatype.DatatypeConfigurationException;
 
 /**
  * Created on 2017-06-08
@@ -29,4 +40,24 @@ public class ChangeLogTest {
         log.info("Setting changeLog Change Event list to null");
         changeLog.setChange(null);
     }
+
+
+    @Test
+    public void changeLogModelContainsEvents() throws InvocationTargetException, DatatypeConfigurationException,
+        OslcCoreApplicationException, IllegalAccessException {
+        // see https://github.com/eclipse/lyo/issues/83
+
+        final ChangeLog log1 = new ChangeLog();
+        log1.setAbout(URI.create("urn:trs:log1"));
+        final URI ch1Uri = URI.create("urn:trs:ch1");
+        final Deletion ch1 = new Deletion(ch1Uri, URI.create("urn:about:nothing"), 1);
+        log1.getChange().add(ch1);
+        final Model model = JenaModelHelper.createJenaModel(new Object[]{log1});
+
+        Helper.printModelTrace(model);
+
+        // <urn:trs:ch1> ?p ?o .
+        assertTrue(model.contains(model.createResource(ch1Uri.toString()), null, (RDFNode) null));
+    }
+
 }

--- a/core/oslc-trs/src/test/java/org/eclipse/lyo/core/trs/Helper.java
+++ b/core/oslc-trs/src/test/java/org/eclipse/lyo/core/trs/Helper.java
@@ -1,0 +1,19 @@
+package org.eclipse.lyo.core.trs;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+
+public class Helper {
+    private static final Logger log = LoggerFactory.getLogger(Helper.class);
+
+    static void printModelTrace(Model model) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        RDFDataMgr.write(baos, model, RDFFormat.TRIG_PRETTY);
+        log.trace(baos.toString()); // .toString(StandardCharsets.UTF_8) for JDK10+
+    }
+}


### PR DESCRIPTION
## Description

Initially an MWE for https://github.com/eclipse/lyo/issues/83, now that the issue was found to be nonexistent, let's keep this as an added test.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [ ] This PR does NOT break the API
