### PR TITLE
Fix Lyo build issues

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+# Does not help, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=574043
+#permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v2
@@ -24,5 +28,4 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Build with Maven
         run: |
-          mvn -B -f pom.xml install -N
           mvn -B package --file pom.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@
 ### Changed
 
 - Update Apache Jena dependency to v3.17
+- Update SHACLEX from 0.0.87 to 0.1.93 (breaking change but should not affect the consumers of Lyo Validation)
+- Update Kotlin from 1.4.20 to 1.5.10  
+- Lyo Validation returns more messages in the reports. _Make sure your code logic scans all messages the report if you are looking for a specific error._
+- Update Eclipse Paho from 1.2.1 to 1.2.5 due to a potential security vulnerability.
 
 ### Deprecated
 
 ### Removed
+
+- All references to HTTP-only repos due to [a change](https://maven.apache.org/docs/3.8.1/release-notes.html#how-to-fix-when-i-get-a-http-repository-blocked) in Maven 3.8.1
+- Lyo Validation removed from the release due to the shutdown of Bintray and subsequent redeploy to Github Packages (not accessible without Github credentials).
 
 ### Fixed
 

--- a/core/oslc-trs/src/test/java/org/eclipse/lyo/core/trs/ChangeLogTest.java
+++ b/core/oslc-trs/src/test/java/org/eclipse/lyo/core/trs/ChangeLogTest.java
@@ -1,10 +1,21 @@
 package org.eclipse.lyo.core.trs;
 
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
 import java.util.List;
+
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
+import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.datatype.DatatypeConfigurationException;
 
 /**
  * Created on 2017-06-08
@@ -29,4 +40,24 @@ public class ChangeLogTest {
         log.info("Setting changeLog Change Event list to null");
         changeLog.setChange(null);
     }
+
+
+    @Test
+    public void changeLogModelContainsEvents() throws InvocationTargetException, DatatypeConfigurationException,
+        OslcCoreApplicationException, IllegalAccessException {
+        // see https://github.com/eclipse/lyo/issues/83
+
+        final ChangeLog log1 = new ChangeLog();
+        log1.setAbout(URI.create("urn:trs:log1"));
+        final URI ch1Uri = URI.create("urn:trs:ch1");
+        final Deletion ch1 = new Deletion(ch1Uri, URI.create("urn:about:nothing"), 1);
+        log1.getChange().add(ch1);
+        final Model model = JenaModelHelper.createJenaModel(new Object[]{log1});
+
+        Helper.printModelTrace(model);
+
+        // <urn:trs:ch1> ?p ?o .
+        assertTrue(model.contains(model.createResource(ch1Uri.toString()), null, (RDFNode) null));
+    }
+
 }

--- a/core/oslc-trs/src/test/java/org/eclipse/lyo/core/trs/Helper.java
+++ b/core/oslc-trs/src/test/java/org/eclipse/lyo/core/trs/Helper.java
@@ -1,0 +1,19 @@
+package org.eclipse.lyo.core.trs;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+
+public class Helper {
+    private static final Logger log = LoggerFactory.getLogger(Helper.class);
+
+    static void printModelTrace(Model model) {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        RDFDataMgr.write(baos, model, RDFFormat.TRIG_PRETTY);
+        log.trace(baos.toString()); // .toString(StandardCharsets.UTF_8) for JDK10+
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <v.lyo>${project.version}</v.lyo>
+
+    <v.kotlin>1.5.10</v.kotlin>
+    <v.dokka>1.4.32</v.dokka>
+
     <v.jena>3.17.0</v.jena>
     <v.jersey>2.25.1</v.jersey>
     <v.slf4j>1.7.30</v.slf4j>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,9 @@
     <module>trs/server</module>
     <module>trs/client</module>
     <module>store</module>
-    <module>validation</module>
+    <!-- Remove util https://bugs.eclipse.org/bugs/show_bug.cgi?id=574043
+    and/or https://github.com/weso/shaclex/issues/390 are resolved-->
+<!--    <module>validation</module>-->
   </modules>
 
   <profiles>

--- a/server/oauth-core/pom.xml
+++ b/server/oauth-core/pom.xml
@@ -21,13 +21,6 @@
         <lyo.version>${project.parent.version}</lyo.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>oauth</id>
-            <url>http://oauth.googlecode.com/svn/code/maven</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <!-- Project specific -->
         <dependency>

--- a/trs/client/client-source-mqtt/pom.xml
+++ b/trs/client/client-source-mqtt/pom.xml
@@ -17,8 +17,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <v.dokka>1.4.20</v.dokka>
-<!--    <v.dokka>0.10.1</v.dokka>-->
   </properties>
 
 

--- a/trs/client/client-source-mqtt/pom.xml
+++ b/trs/client/client-source-mqtt/pom.xml
@@ -87,13 +87,4 @@
       <artifactId>oslc4j-jena-provider</artifactId>
     </dependency>
   </dependencies>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jcenter</id>
-      <name>JCenter</name>
-      <url>https://jcenter.bintray.com/</url>
-    </pluginRepository>
-  </pluginRepositories>
-
 </project>

--- a/trs/client/pom.xml
+++ b/trs/client/pom.xml
@@ -18,8 +18,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-
-    <v.kotlin>1.4.20</v.kotlin>
   </properties>
 
   <modules>

--- a/trs/client/trs-client/pom.xml
+++ b/trs/client/trs-client/pom.xml
@@ -20,7 +20,6 @@
 
     <v.lyo>${project.version}</v.lyo>
     <v.jersey>2.25.1</v.jersey>
-    <v.dokka>1.4.32</v.dokka>
   </properties>
 
   <build>

--- a/trs/client/trs-client/pom.xml
+++ b/trs/client/trs-client/pom.xml
@@ -20,17 +20,44 @@
 
     <v.lyo>${project.version}</v.lyo>
     <v.jersey>2.25.1</v.jersey>
+    <v.dokka>1.4.32</v.dokka>
   </properties>
 
   <build>
     <plugins>
       <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
+        <groupId>org.jetbrains.dokka</groupId>
+        <artifactId>dokka-maven-plugin</artifactId>
+        <version>${v.dokka}</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>javadocJar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dokkaPlugins>
+            <plugin>
+              <groupId>org.jetbrains.dokka</groupId>
+              <artifactId>kotlin-as-java-plugin</artifactId>
+              <version>${v.dokka}</version>
+            </plugin>
+          </dokkaPlugins>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -101,4 +128,5 @@
       <artifactId>jersey-client</artifactId>
     </dependency>
   </dependencies>
+
 </project>

--- a/trs/server/pom.xml
+++ b/trs/server/pom.xml
@@ -27,6 +27,7 @@
     <groupId>org.eclipse.lyo</groupId>
     <artifactId>lyo-parent</artifactId>
     <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <properties>

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -20,7 +20,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <v.jetty>9.4.0.v20161208</v.jetty>
-    <v.shaclex>0.0.87</v.shaclex>
+    <v.shaclex>0.1.93</v.shaclex>
   </properties>
 
   <dependencies>
@@ -40,7 +40,20 @@
       <artifactId>shaclex_2.12</artifactId>
       <version>${v.shaclex}</version>
       <type>pom</type>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.rdf4j</groupId>
+          <artifactId>rdf4j-runtime</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+ <!--   <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-runtime</artifactId>
+      &lt;!&ndash; <version>3.4.2</version> &ndash;&gt;
+      <version>3.4.4</version>
+      <type>pom</type>
+    </dependency>-->
 
     <!-- Guava Library -->
     <dependency>
@@ -125,13 +138,39 @@
         <artifactId>maven-resources-plugin</artifactId>
         <version>2.4.3</version>
       </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- due to shaclex internal mess with dep versions -->
+            <id>enforce</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
+<!--   <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.eclipse.rdf4j</groupId>
+        <artifactId>rdf4j-runtime</artifactId>
+        <version>3.4.2</version>
+&lt;!&ndash;        <scope>compile</scope>&ndash;&gt;
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>-->
+
   <repositories>
     <repository>
-      <id>labra</id>
-      <url>https://dl.bintray.com/labra/maven</url>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2</url>
+    </repository>
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/weso/shaclex</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/validation/src/main/java/org/eclipse/lyo/validation/impl/ShaclExValidatorImpl.java
+++ b/validation/src/main/java/org/eclipse/lyo/validation/impl/ShaclExValidatorImpl.java
@@ -19,13 +19,24 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 
+import cats.effect.IO;
+import cats.effect.IO$;
+import cats.effect.kernel.Resource;
+import cats.effect.kernel.Resource$;
+import cats.effect.unsafe.IORuntime;
+import cats.effect.unsafe.IORuntime$;
+import es.weso.rdf.RDFBuilder;
+import es.weso.rdf.jena.RDFAsJenaModel$;
+import es.weso.schema.RDFReport;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFLanguages;
+import org.checkerframework.checker.units.qual.A;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
 import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
 import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
@@ -43,6 +54,7 @@ import es.weso.schema.Result;
 import es.weso.schema.Schema;
 import es.weso.schema.Schemas;
 import scala.Option;
+import scala.collection.immutable.HashMap;
 import scala.util.Either;
 
 /**
@@ -55,6 +67,7 @@ public class ShaclExValidatorImpl implements Validator {
     private static final String SHACLEX = "SHACLex";
     private static final Logger log = LoggerFactory.getLogger(ShaclExValidatorImpl.class);
     private static final String EMPTY_MAP = "";
+    private static final IORuntime IO_RUNTIME = IORuntime$.MODULE$.global();
 
     @Override
     public ValidationReport validate(AbstractResource resource) throws OslcCoreApplicationException, URISyntaxException,
@@ -94,57 +107,69 @@ public class ShaclExValidatorImpl implements Validator {
 
         Result result = validateInternal(dataModel, shapeModel);
 
-        final RDFReader valReport = result.validationReport().right().get();
-        Either<String, String> valReportAsTurtle = valReport.serialize(RDFLanguages.strLangTurtle);
+        final RDFReport validationReport = result.validationReport();
 
         if (log.isDebugEnabled()) {
-            log.debug("Validation report: \n{}", valReportAsTurtle.right().get());
+            log.debug("Validation report: \n{}", validationReport);
         }
 
-        try {
-            final InputStream in = new ByteArrayInputStream(valReportAsTurtle.right().get().getBytes("UTF-8"));
-            valResultJenaModel.read(in, null, RDFLanguages.strLangTurtle);
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
-        }
+        final String turtleReport = reportToTurtle(validationReport);
+
+        final InputStream in = new ByteArrayInputStream(turtleReport.getBytes(StandardCharsets.UTF_8));
+        valResultJenaModel.read(in, null, RDFLanguages.strLangTurtle);
         return populateValidationReport(result);
     }
 
+    private String reportToTurtle(RDFReport validationReport) {
+        final Model model = ModelFactory.createDefaultModel();
+        final RDFAsJenaModel rdfAsJenaModel = getRdfAsJenaModel(model);
+        final IO<RDFBuilder> builderIO = validationReport.toRDF(rdfAsJenaModel);
+        final RDFBuilder rdfBuilder = builderIO.unsafeRunSync(IO_RUNTIME);
+        final IO<String> stringIO = rdfBuilder.serialize(RDFLanguages.strLangNTriples, Option.apply(null));
+        final String turtleReport = stringIO.unsafeRunSync(IO_RUNTIME);
+        return turtleReport;
+    }
+
+    private RDFAsJenaModel getRdfAsJenaModel(Model model) {
+        final IO<RDFAsJenaModel> modelIO = RDFAsJenaModel.fromModel(model, Option.apply(null),
+            Option.apply(null), new HashMap<>(), new HashMap<>());
+        final RDFAsJenaModel rdfAsJenaModel = modelIO.unsafeRunSync(IO_RUNTIME);
+        return rdfAsJenaModel;
+    }
+
     private Result validateInternal(Model resourceAsModel, Model shapeAsModel) throws IllegalArgumentException {
-        RDFAsJenaModel resourceAsRDFReader = new RDFAsJenaModel(resourceAsModel);
-        RDFAsJenaModel shapeAsRDFReader = new RDFAsJenaModel(shapeAsModel);
+        RDFAsJenaModel resourceAsRDFReader = getRdfAsJenaModel(resourceAsModel);
+        RDFAsJenaModel shapeAsRDFReader = getRdfAsJenaModel(shapeAsModel);
         return validate(resourceAsRDFReader, shapeAsRDFReader);
     }
 
     private Result validate(final RDFAsJenaModel rdf, final Schema schema) {
-        PrefixMap nodeMap = rdf.getPrefixMap();
+        PrefixMap nodeMap = rdf.getPrefixMap().unsafeRunSync(IO_RUNTIME);
         PrefixMap shapesMap = schema.pm();
-        return schema.validate(rdf, TRIGGER_MODE_TARGET_DECLS, EMPTY_MAP, OPTION_NONE, OPTION_NONE, nodeMap, shapesMap);
+        return schema.validate(rdf, TRIGGER_MODE_TARGET_DECLS, EMPTY_MAP, OPTION_NONE, OPTION_NONE, nodeMap, shapesMap, rdf)
+            .unsafeRunSync(IO_RUNTIME);
     }
 
     private Result validate(RDFAsJenaModel resourceAsRDFReader, RDFAsJenaModel shapeAsRDFReader) {
-        final Either<String, Schema> schemaTry = Schemas.fromRDF(shapeAsRDFReader, SHACLEX);
-        if (schemaTry.isRight()) {
-            Schema schema = schemaTry.right().get();
-            return validate(resourceAsRDFReader, schema);
-        } else {
-            throw new IllegalArgumentException("A given Shape cannot be used to create a correct " + "Schema");
-        }
+        final Schema schema = Schemas.fromRDF(shapeAsRDFReader, SHACLEX)
+            .onError(throwable -> {throw new IllegalArgumentException("A given Shape cannot be used to create a correct " + "Schema");})
+            .unsafeRunSync(IO_RUNTIME);
+        return validate(resourceAsRDFReader, schema);
     }
 
     ValidationReport populateValidationReport(Result result) throws IllegalAccessException, IllegalArgumentException,
             InstantiationException, InvocationTargetException, SecurityException, NoSuchMethodException,
             DatatypeConfigurationException, OslcCoreApplicationException, URISyntaxException {
         Model valReportJenaModel = ModelFactory.createDefaultModel();
-        final RDFReader valReport = result.validationReport().right().get();
-        Either<String, String> valReportAsTurtle = valReport.serialize(RDFLanguages.strLangTurtle);
+        final RDFReport valReport = result.validationReport();
+        String valReportAsTurtle = reportToTurtle(valReport);
 
         if (log.isDebugEnabled()) {
-            log.debug("Validation report: \n{}", valReportAsTurtle.right().get());
+            log.debug("Validation report: \n{}", valReportAsTurtle);
         }
 
         try {
-            final InputStream in = new ByteArrayInputStream(valReportAsTurtle.right().get().getBytes("UTF-8"));
+            final InputStream in = new ByteArrayInputStream(valReportAsTurtle.getBytes("UTF-8"));
             valReportJenaModel.read(in, null, RDFLanguages.strLangTurtle);
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();

--- a/validation/src/test/java/org/eclipse/lyo/validation/TestHelper.java
+++ b/validation/src/test/java/org/eclipse/lyo/validation/TestHelper.java
@@ -3,6 +3,7 @@ package org.eclipse.lyo.validation;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.text.ParseException;
+import java.util.Iterator;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 
@@ -13,6 +14,7 @@ import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
 import org.eclipse.lyo.shacl.ShaclShapeFactory;
 import org.eclipse.lyo.shacl.Shape;
 import org.eclipse.lyo.shacl.ValidationReport;
+import org.eclipse.lyo.shacl.ValidationResult;
 import org.junit.Assert;
 
 public class TestHelper {
@@ -31,12 +33,19 @@ public class TestHelper {
 
     }
 
+    /**
+     * At least one result message must start with a given string and the whole report must signal non-conformity.
+     * @param vr report
+     * @param errorMessage a substring that will be checked
+     */
     public static void assertNegative(ValidationReport vr, String errorMessage) {
-        if (vr.getResult().iterator().hasNext()) {
-        Assert.assertTrue(vr.getResult().iterator().next().getMessage().startsWith(errorMessage));
-        } else {
-            Assert.fail("Validation Error should exist.");
+        Assert.assertFalse(vr.isConforms());
+        for (ValidationResult result : vr.getResult()) {
+            if (result.getMessage().startsWith(errorMessage)) {
+                return;
+            }
         }
+        Assert.fail("Validation Error should exist.");
     }
 
     public static void assertPositive(ValidationReport vr) {


### PR DESCRIPTION
## Description

We have the following problems:

- Kotlin classes from the TRS libs were not covered in the Javadoc; JDK11 fails the build (but more importantly, our users were getting incomplete javadoc JARs)
- SHACLex library is no longer available from Bintray because it shut down
	  - SHACLex 0.0.87 is not available in the new repo
	  - SHACLex 0.1.x breaks the 0.0.8x API; updates needed (asked for help in https://github.com/weso/srdf/issues/168)

## TODOs

- [ ] Update the build to add GH repo credentials to secrets?
- [x] Fix the SHACLex invocation (we should consider building a Scala shim that would be easy to invoke from Java and would not use any advanced Scala features on the outside API) 
- [x] Remove use of Bintray by Dokka plugin

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #78; see #80


