### PR TITLE
Roll back to Jena 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### Changed
 
-- Update Apache Jena dependency to v3.17
 - Update SHACLEX from 0.0.87 to 0.1.93 (breaking change but should not affect the consumers of Lyo Validation)
 - Update Kotlin from 1.4.20 to 1.5.10  
 - Lyo Validation returns more messages in the reports. _Make sure your code logic scans all messages the report if you are looking for a specific error._

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <v.lyo>${project.version}</v.lyo>
-    <v.jena>3.17.0</v.jena>
+    <v.jena>3.14.0</v.jena>
     <v.jersey>2.25.1</v.jersey>
     <v.slf4j>1.7.30</v.slf4j>
     <v.servlet>3.1.0</v.servlet>


### PR DESCRIPTION
## Description

Given a number of performance regressions reported in 3.16 and 3.17, let's upgrade the version only if needed.

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] ~This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.~ Jena 3.14 was tested with Lyo 4.0
- [x] This PR does NOT break the API
