### PR TITLE
Force libthrift from 0.13.0 to 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Update Kotlin from 1.4.20 to 1.5.10  
 - Lyo Validation returns more messages in the reports. _Make sure your code logic scans all messages the report if you are looking for a specific error._
 - Update Eclipse Paho from 1.2.1 to 1.2.5 due to a potential security vulnerability.
+- Force libthrift from 0.13.0 to 0.14.1 due to a [vulnerability](https://snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-1074898).
 
 ### Deprecated
 

--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,12 @@
         <artifactId>oauth-consumer</artifactId>
         <version>20100527</version>
       </dependency>
+      <dependency>
+        <!-- https://snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-1074898 -->
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>libthrift</artifactId>
+        <version>0.14.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Description

https://snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-1074898

piggyback on https://github.com/eclipse/lyo/pull/97

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

