### PR TITLE
Remove xml-apis and xerces dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 ### Removed
 
 - All references to HTTP-only repos due to [a change](https://maven.apache.org/docs/3.8.1/release-notes.html#how-to-fix-when-i-get-a-http-repository-blocked) in Maven 3.8.1
-- Lyo Validation removed from the release due to the shutdown of Bintray and subsequent redeploy to Github Packages (not accessible without Github credentials).
+- Remove xml-apis and xerces dependencies (see [#107](https://github.com/eclipse/lyo/pull/107)).
 
 ### Fixed
 

--- a/client/oslc-client/pom.xml
+++ b/client/oslc-client/pom.xml
@@ -146,18 +146,4 @@
             </plugin>
         </plugins>
     </build>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-                <version>1.3.04</version>
-            </dependency>
-            <dependency>
-                <groupId>xerces</groupId>
-                <artifactId>xercesImpl</artifactId>
-                <version>2.12.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/client/oslc-java-client/pom.xml
+++ b/client/oslc-java-client/pom.xml
@@ -142,10 +142,7 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
+      <version>2.12.0</version>
     </dependency>
     <dependency> <!--See https://bugs.eclipse.org/bugs/show_bug.cgi?id=513048-->
       <groupId>javax.servlet</groupId>
@@ -246,16 +243,6 @@
         <groupId>com.ibm.icu</groupId>
         <artifactId>icu4j</artifactId>
         <version>4.0.1</version>
-      </dependency>
-      <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.3.04</version>
-      </dependency>
-      <dependency>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>2.12.0</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -268,19 +268,6 @@
         <type>pom</type>
       </dependency>
       <dependency>
-        <!--CQ 6780-->
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.4.01</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <!--CQ 6583-->
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>2.12.0</version>
-      </dependency>
-      <dependency>
         <groupId>jakarta.ws.rs</groupId>
         <artifactId>jakarta.ws.rs-api</artifactId>
         <version>2.1.6</version>
@@ -507,6 +494,12 @@
                   <message>The reactor is not valid</message>
                   <ignoreModuleDependencies>false</ignoreModuleDependencies>
                 </reactorModuleConvergence>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>xerces</exclude>
+                    <exclude>xml-apis</exclude>
+                  </excludes>
+                </bannedDependencies>
               </rules>
               <fail>true</fail>
             </configuration>

--- a/store/pom.xml
+++ b/store/pom.xml
@@ -64,12 +64,6 @@
         <artifactId>jcl-over-slf4j</artifactId>
         <version>${v.slf4j}</version>
       </dependency>
-      <dependency>
-        <!--TODO why is it here?-->
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.3.04</version>
-      </dependency>
 
       <!-- Test -->
       <dependency>

--- a/store/store-core/pom.xml
+++ b/store/store-core/pom.xml
@@ -82,11 +82,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <dependency>
-      <!--TODO why is it here?-->
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/trs/client/trs-client/pom.xml
+++ b/trs/client/trs-client/pom.xml
@@ -119,6 +119,12 @@
       <groupId>com.j2bugzilla</groupId>
       <artifactId>j2bugzilla</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- test or not? -->

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -78,12 +78,6 @@
     </dependency>
 
     <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-      <version>1.4.01</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.24</version>


### PR DESCRIPTION
## Description

Remove xml-apis and xerces dependencies from everywhere except for the legacy OSLC Client. Rationale:

- https://stackoverflow.com/questions/11677572/dealing-with-xerces-hell-in-java-maven
- https://www.odi.ch/weblog/posting.php?posting=689
- https://github.com/oslc-op/refimpl/issues/2

If your project experiences errors after upsteam removal from our side, you can add the following dependencies to your project (needed ONLY IF you are using ancient APIs from Java 5 times or earlier):

```xml
<dependency>
    <groupId>xml-apis</groupId>
    <artifactId>xml-apis</artifactId>
    <version>1.3.04</version>
</dependency>
<dependency>
    <groupId>xerces</groupId>
    <artifactId>xercesImpl</artifactId>
    <version>2.12.0</version>
</dependency>
```

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #121
