### PR TITLE
JUnit 5; in-mem Store tests; wink-json4j 1.4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,6 +18,9 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,17 +18,17 @@ jobs:
       matrix:
         jdk: ['11']
         # temurin is Eclipse/AdoptOpenJDK/Adoptium
-        # liberica is a preferred Spring SDK
-        distribution: ['temurin', 'zulu', 'liberica']
+        # 'liberica' is a preferred Spring SDK
+        distribution: ['temurin', 'zulu']
         experimental: [false]
         # jena 3.x has some locking problems under JDK 16/17
         include:
-          - jdk: '15' # Zulu MTS
-            experimental: true
-            distribution: zulu
-          - jdk: '16'
-            experimental: true
-            distribution: zulu
+#          - jdk: '15' # Zulu MTS
+#            experimental: true
+#            distribution: zulu
+#          - jdk: '16'
+#            experimental: true
+#            distribution: zulu
           - jdk: '17' # LTS
             experimental: true
             distribution: zulu

--- a/client/oslc-client/pom.xml
+++ b/client/oslc-client/pom.xml
@@ -107,14 +107,31 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <scope>test</scope>
         </dependency>
         <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!--CQ 13719-->
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/client/oslc-client/src/test/java/org/eclipse/lyo/client/test/OslcClientTest.java
+++ b/client/oslc-client/src/test/java/org/eclipse/lyo/client/test/OslcClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,41 +13,53 @@
  */
 package org.eclipse.lyo.client.test;
 
-import javax.ws.rs.core.Response;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status.Family;
+import javax.xml.namespace.QName;
+
+import org.eclipse.lyo.client.OSLCConstants;
 import org.eclipse.lyo.client.OslcClient;
-import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
+import org.junit.jupiter.api.Test;
 
 public class OslcClientTest {
-	/*
-	 * Tests that the RDF/XML MessageBodyWriter doesn't go into an infinite loop when
-	 * given bad data on the client (Bug 417749). ClientRuntimeException expected.
-	 */
-//	@Ignore("Unit test actually POSTs data to example.com, which we shouldn't do as we " +
-//			"don't own that domain. It also fails in our Hudson build environment.")
-//	@Test(expected = ClientErrorException.class, timeout = 5000)
-//	public void postInvalidOlscResource() throws IOException, URISyntaxException {
-//		final OslcClient client = new OslcClient();
-//		final AutomationRequest request = new AutomationRequest();
-//
-//		// Causes NullPointerException.
-//		request.getExtendedProperties().put(new QName("http://example.com/ns#", "test"), null);
-//
-//		client.createResource("http://example.com/resources/factory", request, OSLCConstants.CT_RDF);
-//	}
+    /*
+     * Tests that the RDF/XML MessageBodyWriter doesn't go into an infinite loop when
+     * given bad data on the client (Bug 417749). ClientRuntimeException no longer expected in Lyo 4.0.
+     */
+//    @Disabled("Unit test actually POSTs data to example.com, which we shouldn't do as we don't own that domain.")
+    @Test
+    public void postInvalidOlscResource() throws IOException, URISyntaxException {
+        assertTimeout(ofSeconds(5), () -> {
+            final OslcClient client = new OslcClient();
+            final ServiceProvider request = new ServiceProvider();
+            request.getExtendedProperties().put(new QName("http://example.com/ns#", "test"), "test");
+            Response response = client.createResource("http://example.com/resources/factory", request, OSLCConstants.CT_RDF);
+            assertThat(response.getStatusInfo().getFamily() != Family.SUCCESSFUL);
+//            assertThrows(ClientErrorException.class, () -> {
+//                
+//            });
+        });  
+    }
 
-	@Test
-	public void initTest() {
-		final OslcClient client = new OslcClient();
-		assertThat(client).isNotNull();
-	}
+    @Test
+    public void initTest() {
+        final OslcClient client = new OslcClient();
+        assertThat(client).isNotNull();
+    }
 
-	@Test
-	public void connectionTest() {
-		final OslcClient client = new OslcClient();
-		final Response resource = client.getResource("https://open-services.net");
-		assertThat(resource).isNotNull();
-		assertThat(resource.getStatus()).isLessThan(400);
-	}
+    @Test
+    public void connectionTest() {
+        final OslcClient client = new OslcClient();
+        final Response resource = client.getResource("https://open-services.net");
+        assertThat(resource).isNotNull();
+        assertThat(resource.getStatus()).isLessThan(400);
+    }
 }

--- a/core/oslc4j-json4j-provider/pom.xml
+++ b/core/oslc4j-json4j-provider/pom.xml
@@ -23,6 +23,7 @@
         <dependency>
             <groupId>org.apache.wink</groupId>
             <artifactId>wink-json4j</artifactId>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.7.2</version>
+        <version>5.8.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -209,11 +209,7 @@
         <artifactId>jaxb-runtime</artifactId>
         <version>2.3.5</version>
       </dependency>
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>3.21.0</version>
-      </dependency>
+
       <dependency>
         <!--CQ 13716-->
         <groupId>org.slf4j</groupId>
@@ -331,6 +327,18 @@
         <version>4.13.2</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.7.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>3.21.0</version>
+      </dependency>
 
 
       <!--Maven Enforcer-->
@@ -339,7 +347,6 @@
         <artifactId>commons-codec</artifactId>
         <version>1.15</version>
       </dependency>
-
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
@@ -358,7 +365,6 @@
         <scope>provided</scope>
       </dependency>
 
-
       <!--Convergence-->
       <dependency>
         <!--net.oauth.core:oauth-httpclient4:jar:20090913-->
@@ -368,49 +374,14 @@
       </dependency>
       <!-- https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHETOMCATEMBED-1080637 -->
       <dependency>
-          <groupId>org.apache.tomcat.embed</groupId>
-          <artifactId>tomcat-embed-core</artifactId>
-          <version>8.5.75</version>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>8.5.75</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.11.0</version>
-      </dependency>
-
-
-      <!--To remove-->
-      <!--      <dependency>
-              &lt;!&ndash;hk2 and powermock&ndash;&gt;
-              <groupId>org.javassist</groupId>
-              <artifactId>javassist</artifactId>
-              <version>3.27.0-GA</version>
-            </dependency>-->
-      <!--      <dependency>
-        &lt;!&ndash;es.weso:shaclex_2.12:pom:0.0.87&ndash;&gt;
-        <groupId>org.apache.jena</groupId>
-        <artifactId>jena-arq</artifactId>
-        <version>${v.jena}</version>
-      </dependency>-->
-
-
-      <!--      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-compress</artifactId>
-        <version>1.21</version>
-      </dependency>-->
-      <dependency>
-        <!--CQ 6780-->
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.4.01</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <!--CQ 6733-->
-        <groupId>org.apache.wink</groupId>
-        <artifactId>wink-json4j</artifactId>
-        <version>1.2.1-incubating</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/store/store-core/src/test/java/org/eclipse/lyo/store/SparqlStoreImplTest.java
+++ b/store/store-core/src/test/java/org/eclipse/lyo/store/SparqlStoreImplTest.java
@@ -1,7 +1,7 @@
 package org.eclipse.lyo.store;
 
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,7 +16,6 @@ package org.eclipse.lyo.store;
 
 import com.google.common.base.Stopwatch;
 import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.tdb.TDBFactory;
@@ -29,27 +28,19 @@ import org.eclipse.lyo.store.internals.query.DatasetQueryExecutorImpl;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertTrue;
 
-/**
- * DatasetBuilderTest is .
- * @author Andrew Berezovskyi <andriib@kth.se>
- * @since 2016-11-01
- */
-@SuppressWarnings("PMD.LongVariable")
 public class SparqlStoreImplTest extends StoreTestBase<SparqlStoreImpl> {
 
     private SparqlStoreImpl manager;
@@ -57,13 +48,15 @@ public class SparqlStoreImplTest extends StoreTestBase<SparqlStoreImpl> {
 
     @Before
     public void setUp() throws Exception {
-        final Path tdbDir = Files.createTempDirectory("lyo_tdb_");
-        System.out.println(tdbDir);
+        dataset = TDBFactory.createDataset(); // use in-mem implementation instead
+
+//        final Path tdbDir = Files.createTempDirectory("lyo_tdb_");
+//        System.out.println(tdbDir);
+//        dataset = TDBFactory.createDataset(tdbDir.toAbsolutePath().toString());
+
         //FIXME make sure DatasetQueryExecutorImpl runs everything in a transaction
 //        dataset = TDB2Factory.connectDataset(tdbDir.toAbsolutePath().toString());
 
-//        dataset = TDBFactory.createDataset(tdbDir.toAbsolutePath().toString());
-        dataset = TDBFactory.createDataset(); // use in-mem implementation instead
         manager = new SparqlStoreImpl(new DatasetQueryExecutorImpl(dataset));
     }
 
@@ -122,7 +115,8 @@ public class SparqlStoreImplTest extends StoreTestBase<SparqlStoreImpl> {
     }
 
     @Test
-    public void testInsertionPerfRaw() throws InvocationTargetException, DatatypeConfigurationException, OslcCoreApplicationException, IllegalAccessException {
+    public void testInsertionPerfRaw() throws InvocationTargetException, DatatypeConfigurationException,
+            OslcCoreApplicationException, IllegalAccessException {
         final List<ServiceProvider> providers = genProviders();
         final Model jenaModel = JenaModelHelper.createJenaModel(providers.toArray());
         final Stopwatch stopwatch = Stopwatch.createStarted();

--- a/store/store-core/src/test/java/org/eclipse/lyo/store/SparqlStoreImplTest.java
+++ b/store/store-core/src/test/java/org/eclipse/lyo/store/SparqlStoreImplTest.java
@@ -61,7 +61,9 @@ public class SparqlStoreImplTest extends StoreTestBase<SparqlStoreImpl> {
         System.out.println(tdbDir);
         //FIXME make sure DatasetQueryExecutorImpl runs everything in a transaction
 //        dataset = TDB2Factory.connectDataset(tdbDir.toAbsolutePath().toString());
-        dataset = TDBFactory.createDataset(tdbDir.toAbsolutePath().toString());
+
+//        dataset = TDBFactory.createDataset(tdbDir.toAbsolutePath().toString());
+        dataset = TDBFactory.createDataset(); // use in-mem implementation instead
         manager = new SparqlStoreImpl(new DatasetQueryExecutorImpl(dataset));
     }
 

--- a/validation/src/test/java/org/eclipse/lyo/validation/AResource.java
+++ b/validation/src/test/java/org/eclipse/lyo/validation/AResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,9 +12,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 
-/**
- * @since 2.3.0
- */
+
 
 package org.eclipse.lyo.validation;
 
@@ -66,11 +64,8 @@ import org.eclipse.lyo.shacl.annotations.ShaclTargetClass;
 import org.eclipse.lyo.validation.impl.ShaclExValidatorImpl;
 
 /**
- *
- * @author Yash Khatri 
- *
+ * @since 2.3.0
  */
-
 @OslcNamespace(SampleAdaptorConstants.SAMPLEDOMAIN_NAMSPACE)
 @OslcName(SampleAdaptorConstants.ARESOURCE)
 @OslcResourceShape(title = "AResource Resource Shape",
@@ -180,7 +175,7 @@ public class AResource extends AbstractResource {
     @OslcTitle("a Property")
     @ShaclMinCount(1)
     @ShaclMaxCount(1)
-    @ShaclPattern("^B")
+    @ShaclPattern("^B.*")
     @ShaclMinLength(7)
     @ShaclMaxLength(10)
     public String getAStringProperty() {

--- a/validation/src/test/java/org/eclipse/lyo/validation/AResource.java
+++ b/validation/src/test/java/org/eclipse/lyo/validation/AResource.java
@@ -175,7 +175,7 @@ public class AResource extends AbstractResource {
     @OslcTitle("a Property")
     @ShaclMinCount(1)
     @ShaclMaxCount(1)
-    @ShaclPattern("^B.*")
+    @ShaclPattern("^B")
     @ShaclMinLength(7)
     @ShaclMaxLength(10)
     public String getAStringProperty() {


### PR DESCRIPTION
## Description

JUnit 5 was released in 2017 and it's time to upgrade in order to future-proof our codebase. The transition is expected to be seamless thanks to JUnit 5 Vintage engine running JUnit 4 tests as is and thanks to the fact we didn't use any non-standard JUnit features. Migration guide: https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

