### PR TITLE
Make the inlined shape test more robust

### DIFF
--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/shapefactory/test/ShapeFactoryTest.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/shapefactory/test/ShapeFactoryTest.java
@@ -3,6 +3,7 @@ package org.eclipse.lyo.oslc4j.provider.jena.shapefactory.test;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Set;
 
 import javax.xml.datatype.DatatypeConfigurationException;
@@ -29,11 +30,11 @@ public class ShapeFactoryTest {
     private static ShapeWithWorkingReferences createShapeInstanceWithWorkingReferences(String id) {
         ShapeWithWorkingReferences r = new ShapeWithWorkingReferences(URI.create("http://test.adaptor.net/r/" + id));
         r.setIdentifier(id);
-        
+
         LocalShape local = new LocalShape();
         local.setIdentifier("local" + id);
         r.setReferencesAsLocal(local);
-        
+
         ReferencedShape ref = new ReferencedShape();
         ref.setAbout(URI.create("http://test.adaptor.net/ref/" + id));
         r.setReferencesAsResource(new Link(ref.getAbout()));
@@ -43,25 +44,25 @@ public class ShapeFactoryTest {
         inline.setIdentifier("inline" + id);
         r.setInlines(inline);
 
-        
+
         InlinedShape i1 = new InlinedShape();
         i1.setAbout(URI.create("http://test.adaptor.net/inlineMany_1_" + id));
         i1.setIdentifier("inlineMany_1_" + id);
         r.addInlinesMany(i1);
-        
+
         InlinedShape i2 = new InlinedShape();
         i2.setAbout(URI.create("http://test.adaptor.net/inlineMany_2_" + id));
         i2.setIdentifier("inlineMany_2_" + id);
         r.addInlinesMany(i2);
-    
+
         return r;
     }
 
     @Test
     public void validShapeTest() throws OslcCoreApplicationException, URISyntaxException {
-        ResourceShape shape = ResourceShapeFactory.createResourceShape("http://localhost:8080", 
-                OslcConstants.PATH_RESOURCE_SHAPES, 
-                "http://test.net/ns/test#", 
+        ResourceShape shape = ResourceShapeFactory.createResourceShape("http://localhost:8080",
+                OslcConstants.PATH_RESOURCE_SHAPES,
+                "http://test.net/ns/test#",
                 ShapeWithWorkingReferences.class);
         assertNotNull(shape);
     }
@@ -69,18 +70,18 @@ public class ShapeFactoryTest {
 
     @Test(expected = OslcCoreInvalidRepresentationException.class)
     public void invalidShapeWithInlinedResourceTest() throws OslcCoreApplicationException, URISyntaxException {
-        ResourceShape shape = ResourceShapeFactory.createResourceShape("http://localhost:8080", 
-                OslcConstants.PATH_RESOURCE_SHAPES, 
-                "http://test.net/ns/test#", 
+        ResourceShape shape = ResourceShapeFactory.createResourceShape("http://localhost:8080",
+                OslcConstants.PATH_RESOURCE_SHAPES,
+                "http://test.net/ns/test#",
                 ShapeWithWrongReferenceToInline.class);
         assertNotNull(shape);
     }
 
     @Test(expected = OslcCoreInvalidValueTypeException.class)
     public void invalidShapeWithReferencedResourceTest() throws OslcCoreApplicationException, URISyntaxException {
-        ResourceShape shape = ResourceShapeFactory.createResourceShape("http://localhost:8080", 
-                OslcConstants.PATH_RESOURCE_SHAPES, 
-                "http://test.net/ns/test#", 
+        ResourceShape shape = ResourceShapeFactory.createResourceShape("http://localhost:8080",
+                OslcConstants.PATH_RESOURCE_SHAPES,
+                "http://test.net/ns/test#",
                 ShapeWithWrongReferenceToResource.class);
         assertNotNull(shape);
     }
@@ -91,39 +92,46 @@ public class ShapeFactoryTest {
          final Model sourceModel = JenaModelHelper.createJenaModel(new Object[]{sourceResource});
          ShapeWithWorkingReferences resultingResource = JenaModelHelper.unmarshalSingle(sourceModel, ShapeWithWorkingReferences.class);
          final Model resultingModel = JenaModelHelper.createJenaModel(new Object[]{resultingResource});
-         
+
          assertThat(sourceModel).isomorphicWith(resultingModel);
     }
 
     @Test
     public void validInstanceMarshalsAndUnmarshalsAsResourcesTest2() throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, DatatypeConfigurationException, OslcCoreApplicationException, InstantiationException, SecurityException, URISyntaxException {
-         ShapeWithWorkingReferences sourceResource = createShapeInstanceWithWorkingReferences("1");
-         final Model sourceModel = JenaModelHelper.createJenaModel(new Object[]{sourceResource});
-         ShapeWithWorkingReferences resultingResource = JenaModelHelper.unmarshalSingle(sourceModel, ShapeWithWorkingReferences.class);
-         final Model resultingModel = JenaModelHelper.createJenaModel(new Object[]{resultingResource});
-         
-         //Assert that the identifier of the inlined resource remains intact.
-         assertTrue(sourceResource.getInlines().getIdentifier().equals(resultingResource.getInlines().getIdentifier()));
+        ShapeWithWorkingReferences sourceResource = createShapeInstanceWithWorkingReferences("1");
+        final Model sourceModel = JenaModelHelper.createJenaModel(new Object[]{sourceResource});
+        ShapeWithWorkingReferences resultingResource = JenaModelHelper.unmarshalSingle(sourceModel, ShapeWithWorkingReferences.class);
+        final Model resultingModel = JenaModelHelper.createJenaModel(new Object[]{resultingResource});
 
-         //Assert that the URL of the inlined resource remains intact.
-         assertTrue(sourceResource.getInlines().getAbout().equals(resultingResource.getInlines().getAbout()));
+        //Assert that the identifier of the inlined resource remains intact.
+        assertTrue(sourceResource.getInlines().getIdentifier().equals(resultingResource.getInlines().getIdentifier()));
 
-         
-         //Assert that inlined resources, with multiple cardinality, remains intact.
-         InlinedShape s1 = (InlinedShape) sourceResource.getInlinesMany().toArray()[0];
-         InlinedShape r1 = (InlinedShape) resultingResource.getInlinesMany().toArray()[0];
-         assertTrue(s1.getIdentifier().equals(r1.getIdentifier()));
-         
-         //Assert that the identifier of the Local resource remains intact.
-         assertTrue(sourceResource.getReferencesAsLocal().getIdentifier().equals(resultingResource.getReferencesAsLocal().getIdentifier()));
+        //Assert that the URL of the inlined resource remains intact.
+        assertTrue(sourceResource.getInlines().getAbout().equals(resultingResource.getInlines().getAbout()));
 
-         //Assert that the URL of the local resource is null.
-         assertNull(sourceResource.getReferencesAsLocal().getAbout());
-         assertNull(resultingResource.getReferencesAsLocal().getAbout());
 
-         //Assert that the URL of the referenced resource remains intact.
-         assertNotNull(resultingResource.getReferencesAsResource().getValue());
-         assertTrue(sourceResource.getReferencesAsResource().getValue().equals(resultingResource.getReferencesAsResource().getValue()));
+        //Assert that inlined resources, with multiple cardinality, remains intact.
+        InlinedShape[] sourcesInlines = sourceResource.getInlinesMany().toArray(new InlinedShape[]{});
+        InlinedShape[] resultInlines = resultingResource.getInlinesMany().toArray(new InlinedShape[]{});
+        for (InlinedShape sourcesInline : sourcesInlines) {
+            assertTrue("Shape "+sourcesInline.getIdentifier()+" missing in the resulting inlined shapes",
+                containsResource(resultInlines, sourcesInline));
+        }
+
+        //Assert that the identifier of the Local resource remains intact.
+        assertTrue(sourceResource.getReferencesAsLocal().getIdentifier().equals(resultingResource.getReferencesAsLocal().getIdentifier()));
+
+        //Assert that the URL of the local resource is null.
+        assertNull(sourceResource.getReferencesAsLocal().getAbout());
+        assertNull(resultingResource.getReferencesAsLocal().getAbout());
+
+        //Assert that the URL of the referenced resource remains intact.
+        assertNotNull(resultingResource.getReferencesAsResource().getValue());
+        assertTrue(sourceResource.getReferencesAsResource().getValue().equals(resultingResource.getReferencesAsResource().getValue()));
     }
-    
+
+    private boolean containsResource(InlinedShape[] resultInlines, InlinedShape s1) {
+        return Arrays.stream(resultInlines).anyMatch(inlinedShape -> inlinedShape.getIdentifier().equals(s1.getIdentifier()));
+    }
+
 }


### PR DESCRIPTION
## Description

- asserts for all source members
- ignore the order of the resources in the set arrays

## Checklist

- [ ] ~~This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._~~ Unit test
- [ ] ~~This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.~~ Unit test
- [x] This PR does NOT break the API

