### PR TITLE
add oslc:name and dcterms:description to the ResourceShape class

### DIFF
--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcResourceShape.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcResourceShape.java
@@ -28,6 +28,11 @@ public @interface OslcResourceShape {
 	 */
 	String title() default "";
 
+     /**
+     * Description of the resource shape.
+     */
+    String description() default "";
+
 	/**
 	 * Type or types of resource described by this shape.
 	 */

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShape.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShape.java
@@ -22,6 +22,7 @@ import java.util.TreeSet;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcRange;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
@@ -37,7 +38,9 @@ public final class ResourceShape extends AbstractResource {
 	private final SortedSet<URI> describes= new TreeSet<URI>();
 	private final TreeMap<URI, Property> properties = new TreeMap<URI, Property>();
 
+    private String name;
 	private String title;
+    private String description;
 
 	public ResourceShape() {
 		super();
@@ -81,7 +84,14 @@ public final class ResourceShape extends AbstractResource {
 		return properties.values().toArray(new Property[properties.size()]);
 	}
 
-	
+    @OslcDescription("The local name of the defined resource")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "name")
+    @OslcReadOnly
+    @OslcTitle("Name")
+    public String getName() {
+        return name;
+    }
 
 	@OslcDescription("Title of the resource shape. SHOULD include only content that is valid and suitable inside an XHTML <div> element")
 	@OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "title")
@@ -91,6 +101,15 @@ public final class ResourceShape extends AbstractResource {
 	public String getTitle() {
 		return title;
 	}
+
+    @OslcDescription("The description of the defined constraint.")
+    @OslcPropertyDefinition(OslcConstants.DCTERMS_NAMESPACE + "description")
+    @OslcReadOnly
+    @OslcTitle("Description")
+    @OslcValueType(ValueType.XMLLiteral)
+    public String getDescription() {
+        return description;
+    }
 
 	public void setDescribes(final URI[] describes) {
 		this.describes.clear();
@@ -109,7 +128,16 @@ public final class ResourceShape extends AbstractResource {
 		}
 	}
 
+    public void setName(final String name) {
+        this.name = name;
+    }
+
 	public void setTitle(final String title) {
 		this.title = title;
 	}
+	
+    public void setDescription(final String description) {
+        this.description = description;
+    }
+
 }

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
@@ -104,10 +104,22 @@ public class ResourceShapeFactory {
 		final URI about = UriBuilder.fromUri(baseURI).path(resourceShapesPath).path(resourceShapePath).build();
 		final ResourceShape resourceShape = new ResourceShape(about);
 
+        final OslcName nameAnnotation = resourceClass.getAnnotation(OslcName.class);
+        if (nameAnnotation != null) {
+            resourceShape.setName(nameAnnotation.value());
+        } else {
+            resourceShape.setName(resourceClass.getSimpleName());
+        }
+
 		final String title = resourceShapeAnnotation.title();
 		if ((title != null) && (title.length() > 0)) {
 			resourceShape.setTitle(title);
 		}
+
+	      final String description = resourceShapeAnnotation.description();
+	        if ((description != null) && (description.length() > 0)) {
+	            resourceShape.setDescription(description);
+	        }
 
 		for (final String describesItem : resourceShapeAnnotation.describes()) {
 			resourceShape.addDescribeItem(new URI(describesItem));


### PR DESCRIPTION
## Description

add oslc:name and dcterms:description to the ResourceShape class.
Also adding "description" to the Shape annotations in order to be able
to construct resourceshape instances from information in the
annotations.

## Checklist

- [X] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

closes #198

