### PR TITLE
Get catalogUrl for Configuration Management - Fixes #205

### DIFF
--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/RootServicesHelper.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/RootServicesHelper.java
@@ -108,16 +108,19 @@ public class RootServicesHelper {
 			this.catalogNamespace = OSLCConstants.OSLC_AM_V2;
 			this.catalogProperty =  RootServicesConstants.AM_ROOTSERVICES_CATALOG_PROP;
 
-		}
-		else if (this.catalogDomain.equalsIgnoreCase(OSLCConstants.OSLC_AUTO)) {
+		} else if (this.catalogDomain.equalsIgnoreCase(OSLCConstants.OSLC_AUTO)) {
 
-			this.catalogNamespace = OSLCConstants.OSLC_AUTO;
-			this.catalogProperty =  RootServicesConstants.AUTO_ROOTSERVICES_CATALOG_PROP;
+            this.catalogNamespace = OSLCConstants.OSLC_AUTO;
+            this.catalogProperty = RootServicesConstants.AUTO_ROOTSERVICES_CATALOG_PROP;
 
-		}
-		else {
-			logger.error("Jazz rootservices only supports CM, RM, QM, and Automation catalogs");
-		}
+        } else if (this.catalogDomain.equalsIgnoreCase(OSLCConstants.OSLC_CONFIG)) {
+
+            this.catalogNamespace = OSLCConstants.OSLC_CONFIG;
+            this.catalogProperty = RootServicesConstants.CM_ROOTSERVICES_CATALOG_PROP;
+
+        } else {
+            logger.error("Jazz rootservices only supports CM, RM, QM, GC and Automation catalogs");
+        }
 
 		processRootServices(client);
 	}


### PR DESCRIPTION
Signed-off-by: Mario Jiménez Carrasco <mario.carrasco@gmail.com>

## Description

Adding the section to look for the catalogUrl endpoint of the
Configuration Management service from the Rootservices.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #205

_(use exactly this syntax to link to issues, one issue per statement only!)_
