### PR TITLE
Updates to build on JDK 17

### DIFF
--- a/client/oslc-client/pom.xml
+++ b/client/oslc-client/pom.xml
@@ -98,37 +98,36 @@
         </dependency>
 
       <!--TEST-->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${v.slf4j}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.23.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <!--CQ 13719-->
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
       <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${v.jersey}</version>
-            <scope>test</scope>
-        </dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${v.slf4j}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>3.12.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <!--CQ 13719-->
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.core</groupId>
+        <artifactId>jersey-client</artifactId>
+        <version>${v.jersey}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/client/oslc-java-client/pom.xml
+++ b/client/oslc-java-client/pom.xml
@@ -165,10 +165,11 @@
       <version>${v.slf4j}</version>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.8.5</version>
+      <version>3.12.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -76,15 +76,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.12.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 
     <v.lyo>${project.version}</v.lyo>
 
-    <v.kotlin>1.5.10</v.kotlin>
-    <v.dokka>1.4.32</v.dokka>
+    <v.kotlin>1.5.31</v.kotlin>
+    <v.dokka>1.5.31</v.dokka>
 
     <v.jena>3.16.0</v.jena>
     <v.jersey>2.25.1</v.jersey>
@@ -361,11 +361,6 @@
         <version>${v.guava}</version>
       </dependency>
       <dependency>
-        <groupId>org.objenesis</groupId>
-        <artifactId>objenesis</artifactId>
-        <version>2.6</version>
-      </dependency>
-      <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.3.2</version>
@@ -406,7 +401,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>2.2.1</version>
+          <version>3.2.1</version>
           <executions>
             <execution>
               <id>attach-sources</id>
@@ -419,7 +414,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
           <configuration>
             <source>8</source>
             <doclint>none</doclint>
@@ -432,6 +427,11 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>3.3.2</version>
         </plugin>
         <!-- Surefire Plugin (JUnit) -->
         <plugin>

--- a/server/oauth-consumer-store/pom.xml
+++ b/server/oauth-consumer-store/pom.xml
@@ -56,13 +56,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
             </plugin>
         </plugins>
     </build>

--- a/server/oauth-webapp/pom.xml
+++ b/server/oauth-webapp/pom.xml
@@ -88,20 +88,21 @@
 
     </dependencies>
 
-    <build>
-        <finalName>oauth-webapp</finalName>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
-            </plugin>
-        </plugins>
-    </build>
+  <build>
+    <finalName>oauth-webapp</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -81,7 +81,7 @@
     </dependencies>
   </dependencyManagement>
 
-  <build>
+<!--  <build>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -90,7 +90,7 @@
           <version>2.2.1</version>
           <executions>
             <execution>
-              <!-- This id must match the -Prelease-profile id value or else sources will be "uploaded" twice, which causes Nexus to fail -->
+              &lt;!&ndash; This id must match the -Prelease-profile id value or else sources will be "uploaded" twice, which causes Nexus to fail &ndash;&gt;
               <id>attach-sources</id>
               <goals>
                 <goal>jar</goal>
@@ -116,5 +116,5 @@
         </plugin>
       </plugins>
     </pluginManagement>
-  </build>
+  </build>-->
 </project>


### PR DESCRIPTION
## Description

Updates to build on JDK 17. We are still targeting JDK 8 but want to eliminate tech debt to be able to switch to JDK 11 or JDK 17 when the time comes.

shaclex fails for now; tracking https://github.com/weso/utils/pull/148

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #0; Closes #00

_(use exactly this syntax to link to issues, one issue per statement only!)_
