### PR TITLE
Support for inlined properties, by displaying them as links.

### DIFF
--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PreviewFactory.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PreviewFactory.java
@@ -68,12 +68,25 @@ public class PreviewFactory {
                     value = constructPropertyValue(PropertyDefintion.RepresentationType.LINK, multiple, l);
                 } else {
                     Link link = (Link) getterMethod.invoke(aResource);
-                    value = constructPropertyValue(PropertyDefintion.RepresentationType.LINK, multiple,
-                        constructLink(link));
+                    value = constructPropertyValue(PropertyDefintion.RepresentationType.LINK, multiple, constructLink(link));
                 }
             } else {
-                value = constructPropertyValue(PropertyDefintion.RepresentationType.TEXT, multiple,
-                    getterMethod.invoke(aResource));
+            	if (!isNotInlinedRepresentation) {
+                    if (multiple) {
+                        Collection<AbstractResource> rs = (Collection<AbstractResource>) getterMethod.invoke(aResource);
+                        List<org.eclipse.lyo.server.ui.model.Link> l = new ArrayList<>();
+                        for (AbstractResource r: rs) {
+                            l.add(constructLink(r.getAbout().toString(), r.toString()));
+                        }
+                        value = constructPropertyValue(PropertyDefintion.RepresentationType.LINK, multiple, l);
+                    } else {
+                    	AbstractResource r = (AbstractResource) getterMethod.invoke(aResource);
+                        value = constructPropertyValue(PropertyDefintion.RepresentationType.LINK, multiple, constructLink(r.getAbout().toString(), r.toString()));
+                    }
+            	}
+            	else {
+                    value = constructPropertyValue(PropertyDefintion.RepresentationType.TEXT, multiple, getterMethod.invoke(aResource));
+            	}
             }
             previewItems.add(constructProperty(key, value));
         }


### PR DESCRIPTION
## Description

Support for inlined properties, by displaying them as links.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [X] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [X] This PR does NOT break the API

