### PR TITLE
Additional API to support SPARQL queries for inlined resources.

### DIFF
--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/JenaTdbStoreImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/JenaTdbStoreImpl.java
@@ -16,6 +16,8 @@ package org.eclipse.lyo.store.internals;
 
 import com.google.common.collect.Sets;
 import java.util.HashSet;
+
+import org.apache.jena.arq.querybuilder.SelectBuilder;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Model;
@@ -163,23 +165,35 @@ public class JenaTdbStoreImpl implements Store {
         return resources.subList(offset, Math.min(resources.size(), offset + limit));
     }
 
-	@Override
-	public <T extends IResource> List<T> getResources(URI namedGraphUri, Class<T> clazz, String prefixes, String where,
-			String searchTerms, int limit, int offset) throws StoreAccessException, ModelUnmarshallingException {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Model getResources(URI namedGraph, String prefixes, String where, int limit,
-			int offset) {
+    @Override
+    public <T extends IResource> List<T> getResources(URI namedGraphUri, Class<T> clazz, String prefixes, String where,
+            String searchTerms, int limit, int offset) throws StoreAccessException, ModelUnmarshallingException {
         throw new UnsupportedOperationException();
-	}
+    }
 
-	@Override
-	public Model getResources(URI namedGraph, String prefixes, String where, String searchTerms, int limit,
-			int offset) {
+    @Override
+    public <T extends IResource> List<T> getResources(URI namedGraphUri, Class<T> clazz, String prefixes, String where,
+            String searchTerms, int limit, int offset, List<String> additionalDistinctVars, SelectBuilder additionalQueryFilter) throws StoreAccessException, ModelUnmarshallingException {
         throw new UnsupportedOperationException();
-	}
+    }
+
+    @Override
+    public Model getResources(URI namedGraph, String prefixes, String where, int limit,
+            int offset) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Model getResources(URI namedGraph, String prefixes, String where, String searchTerms, int limit,
+            int offset) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Model getResources(URI namedGraph, String prefixes, String where, String searchTerms, int limit,
+            int offset, List<String> additionalDistinctVars, SelectBuilder additionalQueryFilter) {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     public Set<String> keySet() {

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
@@ -260,13 +260,20 @@ public class SparqlStoreImpl implements Store {
     public <T extends IResource> List<T> getResources(final URI namedGraph, final Class<T> clazz, final String prefixes,
             final String where, final String searchTerms, final int limit, final int offset)
             throws StoreAccessException, ModelUnmarshallingException {
+        return getResources(namedGraph, clazz, prefixes, where, searchTerms, limit, offset, null, null);
+    }
+    
+    @Override
+    public <T extends IResource> List<T> getResources(final URI namedGraph, final Class<T> clazz, final String prefixes,
+            final String where, final String searchTerms, final int limit, final int offset, List<String> additionalDistinctVars, SelectBuilder additionalQueryFilter)
+            throws StoreAccessException, ModelUnmarshallingException {
 
         String _prefixes = prefixes;
         String _where = where;
 
         _prefixes = (StringUtils.isEmpty(_prefixes) ? "" : _prefixes + ",") + oslcQueryPrefixes(clazz);
         _where = (StringUtils.isEmpty(_where) ? "" : _where + " and ") + oslcQueryWhere(clazz);
-        Model model = getResources(namedGraph, _prefixes, _where, searchTerms, limit, offset);
+        Model model = getResources(namedGraph, _prefixes, _where, searchTerms, limit, offset, additionalDistinctVars, additionalQueryFilter);
         return getResourcesFromModel(model, clazz);
     }
 
@@ -277,46 +284,51 @@ public class SparqlStoreImpl implements Store {
 
     @Override
     public Model getResources(final URI namedGraph, final String prefixes, final String where, final String searchTerms, final int limit, final int offset) {
+        return getResources(namedGraph, prefixes, where, searchTerms, limit, offset, null, null);
+    }
+    
+    @Override
+    public Model getResources(final URI namedGraph, final String prefixes, final String where, final String searchTerms, final int limit, final int offset, List<String> additionalDistinctVars, SelectBuilder additionalQueryFilter) {
 
-    	if (namedGraph != null) {
-        	//Make sure the designated namedGraph exists, if it is specified.
-    		//Otherwise, the search occurs across all namedgraphs.
-        	if (!namedGraphExists(namedGraph)) {
+        if (namedGraph != null) {
+            //Make sure the designated namedGraph exists, if it is specified.
+            //Otherwise, the search occurs across all namedgraphs.
+            if (!namedGraphExists(namedGraph)) {
                 throw new IllegalArgumentException("Named graph" + String.valueOf(namedGraph) + " was missing from the triplestore");
             }
-    	}
+        }
 
-    	SelectBuilder sparqlWhereQuery = constructSparqlWhere (prefixes, where, searchTerms, limit, offset);
-    	DescribeBuilder describeBuilder = new DescribeBuilder();
-		if (namedGraph != null) {
-			describeBuilder.addVar("s")
-			.addGraph(new ResourceImpl(String.valueOf(namedGraph)), sparqlWhereQuery);
-		}
-		else {
-			describeBuilder.addVar("s")
-			.addGraph("?g", sparqlWhereQuery);
-		}
-
+        SelectBuilder sparqlWhereQuery = constructSparqlWhere (prefixes, where, searchTerms, limit, offset, additionalDistinctVars, additionalQueryFilter);
+        DescribeBuilder describeBuilder = new DescribeBuilder();
+        describeBuilder.addVar("s")
+        .addGraph((namedGraph != null) ? new ResourceImpl(String.valueOf(namedGraph)) : "?g", sparqlWhereQuery);
+        
+        if (null != additionalDistinctVars) {
+            for (String additionalDistinctVar : additionalDistinctVars) {
+                describeBuilder.addVar(additionalDistinctVar);
+            }
+        }
+        
         if (log.isTraceEnabled() && !Strings.isNullOrEmpty(where)) {
             log.trace("SPARQL WHERE query for oslc.where='{}': {}", where,
                     sparqlWhereQuery.buildString());
         }
 
-		Query describeQuery = describeBuilder.build() ;
-		String describeQueryString = describeQuery.toString();
-		final QueryExecution queryExecution = queryExecutor.prepareSparqlQuery(describeQueryString);
+        Query describeQuery = describeBuilder.build() ;
+        String describeQueryString = describeQuery.toString();
+        final QueryExecution queryExecution = queryExecutor.prepareSparqlQuery(describeQueryString);
 
         Model execDescribe;
         try {
             execDescribe = queryExecution.execDescribe();
-		} catch (RiotException e) {
-			//a request that returns an empty set seems to cause an exception when using Marklogic.
-			if ((e.getCause() == null) && (e.getMessage().equals("[line: 2, col: 2 ] Out of place: [DOT]"))) {
-		        return ModelFactory.createDefaultModel();
-			}
-			// Otherwise, there is a proper exception that we need to deal with!
-	        throw e;
-		}
+        } catch (RiotException e) {
+            //a request that returns an empty set seems to cause an exception when using Marklogic.
+            if ((e.getCause() == null) && (e.getMessage().equals("[line: 2, col: 2 ] Out of place: [DOT]"))) {
+                return ModelFactory.createDefaultModel();
+            }
+            // Otherwise, there is a proper exception that we need to deal with!
+            throw e;
+        }
         return execDescribe;
     }
 
@@ -388,7 +400,7 @@ public class SparqlStoreImpl implements Store {
     }
 
     private <T extends IResource> String oslcQueryWhere(final Class<T> clazz) {
-    	return "rdf:type=" + "<" + getResourceNsUri(clazz) + ">";
+        return "rdf:type=" + "<" + getResourceNsUri(clazz) + ">";
     }
 
     private <T extends IResource> List<T> getResourcesFromModel(final Model model,
@@ -451,14 +463,14 @@ public class SparqlStoreImpl implements Store {
         Model execDescribe;
         try {
             execDescribe = queryExecution.execDescribe();
-		} catch (RiotException e) {
-			//a request that returns an empty set seems to cause an exception when using Marklogic.
-			if ((e.getCause() == null) && (e.getMessage().equals("[line: 2, col: 2 ] Out of place: [DOT]"))) {
-		        return ModelFactory.createDefaultModel();
-			}
-			// Otherwise, there is a proper exception that we need to deal with!
-	        throw e;
-		}
+        } catch (RiotException e) {
+            //a request that returns an empty set seems to cause an exception when using Marklogic.
+            if ((e.getCause() == null) && (e.getMessage().equals("[line: 2, col: 2 ] Out of place: [DOT]"))) {
+                return ModelFactory.createDefaultModel();
+            }
+            // Otherwise, there is a proper exception that we need to deal with!
+            throw e;
+        }
         return execDescribe;
 
     }
@@ -502,97 +514,106 @@ public class SparqlStoreImpl implements Store {
     }
 
     //This method currently only provides support for terms of type Comparisons, where the operator is 'EQUALS', and the operand is either a String or a URI.
-    private SelectBuilder constructSparqlWhere(final String prefixes, final String where, final String searchTerms, final int limit, final int offset) {
+    private SelectBuilder constructSparqlWhere(final String prefixes, final String where, final String searchTerms, final int limit, final int offset, List<String> additionalDistinctVars, SelectBuilder additionalQueryFilter) {
 
-    	SelectBuilder distinctResourcesQuery = new SelectBuilder();
+        SelectBuilder distinctResourcesQuery = new SelectBuilder();
 
-    	//Setup prefixes
-    	Map<String, String> prefixesMap = new HashMap<String, String>();
+        //Setup prefixes
+        Map<String, String> prefixesMap = new HashMap<String, String>();
         try {
-        	if (!StringUtils.isEmpty(prefixes)) {
-    			prefixesMap = QueryUtils.parsePrefixes(prefixes);
-    	        for (Entry<String, String> prefix : prefixesMap.entrySet()) {
-    	            distinctResourcesQuery.addPrefix(prefix.getKey(), prefix.getValue());
-    			}
-        	}
-		} catch (ParseException e) {
+            if (!StringUtils.isEmpty(prefixes)) {
+                prefixesMap = QueryUtils.parsePrefixes(prefixes);
+                for (Entry<String, String> prefix : prefixesMap.entrySet()) {
+                    distinctResourcesQuery.addPrefix(prefix.getKey(), prefix.getValue());
+                }
+            }
+        } catch (ParseException e) {
             throw new IllegalArgumentException("prefixesExpression could not be parsed", e);
-		}
+        }
 
         distinctResourcesQuery
         .addVar( "s" )
-		.setDistinct(true)
-		.addWhere( "?s", "?p", "?o");
+        .setDistinct(true)
+        .addWhere( "?s", "?p", "?o");
 
+        if (null != additionalDistinctVars) {
+            for (String additionalDistinctVar : additionalDistinctVars) {
+                distinctResourcesQuery.addVar(additionalDistinctVar);
+            }
+        }
+        if (null != additionalQueryFilter) {
+            distinctResourcesQuery.addWhere(additionalQueryFilter);
+        }
+        
         //Setup where
-		WhereClause whereClause = null;
+        WhereClause whereClause = null;
         try {
-        	if (!StringUtils.isEmpty(where)) {
-    			whereClause = QueryUtils.parseWhere(where, prefixesMap);
-    			List<SimpleTerm> parseChildren = whereClause.children();
-    			for (Iterator<SimpleTerm> iterator = parseChildren.iterator(); iterator.hasNext();) {
-    				SimpleTerm simpleTerm = iterator.next();
-    				Type termType = simpleTerm.type();
-    				PName property = simpleTerm.property();
+            if (!StringUtils.isEmpty(where)) {
+                whereClause = QueryUtils.parseWhere(where, prefixesMap);
+                List<SimpleTerm> parseChildren = whereClause.children();
+                for (Iterator<SimpleTerm> iterator = parseChildren.iterator(); iterator.hasNext();) {
+                    SimpleTerm simpleTerm = iterator.next();
+                    Type termType = simpleTerm.type();
+                    PName property = simpleTerm.property();
 
-    				if (!termType.equals(Type.COMPARISON)){
-    			        throw new UnsupportedOperationException("only support for terms of type Comparisons");
-    				}
-    				ComparisonTerm aComparisonTerm = (ComparisonTerm) simpleTerm;
-    				if (!aComparisonTerm.operator().equals(Operator.EQUALS)){
-    			        throw new UnsupportedOperationException("only support for terms of type Comparisons, where the operator is 'EQUALS'");
-    				}
+                    if (!termType.equals(Type.COMPARISON)){
+                        throw new UnsupportedOperationException("only support for terms of type Comparisons");
+                    }
+                    ComparisonTerm aComparisonTerm = (ComparisonTerm) simpleTerm;
+                    if (!aComparisonTerm.operator().equals(Operator.EQUALS)){
+                        throw new UnsupportedOperationException("only support for terms of type Comparisons, where the operator is 'EQUALS'");
+                    }
 
-    				Value comparisonOperand = aComparisonTerm.operand();
-    				Value.Type operandType = comparisonOperand.type();
-    				String predicate;
-    				if (property.local.equals("*")) {
-    					predicate = "?p";
-    				}
-    				else {
-    					predicate = property.toString();
-    				}
+                    Value comparisonOperand = aComparisonTerm.operand();
+                    Value.Type operandType = comparisonOperand.type();
+                    String predicate;
+                    if (property.local.equals("*")) {
+                        predicate = "?p";
+                    }
+                    else {
+                        predicate = property.toString();
+                    }
 
-    				switch (operandType) {
-    				case DECIMAL:
-    					DecimalValue decimalOperand = (DecimalValue) comparisonOperand;
-    			        distinctResourcesQuery.addWhere( "?s", predicate, decimalOperand.value());
-    					break;
-    				case STRING:
-    					StringValue stringOperand = (StringValue) comparisonOperand;
-    			        distinctResourcesQuery.addWhere( "?s", predicate, "\"" + stringOperand.value() + "\"");
-    					break;
-    				case URI_REF:
-    					UriRefValue uriOperand = (UriRefValue) comparisonOperand;
-    			        distinctResourcesQuery.addWhere( "?s", predicate,  new ResourceImpl(uriOperand.value()));
-    					break;
-    				default:
-    			        throw new UnsupportedOperationException("only support for terms of type Comparisons, where the operator is 'EQUALS', and the operand is either a String, an Integer or a URI");
-    				}
-    			}
-        	}
-		} catch (ParseException e) {
+                    switch (operandType) {
+                    case DECIMAL:
+                        DecimalValue decimalOperand = (DecimalValue) comparisonOperand;
+                        distinctResourcesQuery.addWhere( "?s", predicate, decimalOperand.value());
+                        break;
+                    case STRING:
+                        StringValue stringOperand = (StringValue) comparisonOperand;
+                        distinctResourcesQuery.addWhere( "?s", predicate, "\"" + stringOperand.value() + "\"");
+                        break;
+                    case URI_REF:
+                        UriRefValue uriOperand = (UriRefValue) comparisonOperand;
+                        distinctResourcesQuery.addWhere( "?s", predicate,  new ResourceImpl(uriOperand.value()));
+                        break;
+                    default:
+                        throw new UnsupportedOperationException("only support for terms of type Comparisons, where the operator is 'EQUALS', and the operand is either a String, an Integer or a URI");
+                    }
+                }
+            }
+        } catch (ParseException e) {
             throw new IllegalArgumentException("whereExpression could not be parsed", e);
-		}
+        }
 
         //Setup searchTerms
         //Add a sparql filter "FILTER regex(?o, "<searchTerms>", "i")" to the distinctResourcesQuery
-		if (!StringUtils.isEmpty(searchTerms)) {
-			ExprFactory factory = new ExprFactory();
+        if (!StringUtils.isEmpty(searchTerms)) {
+            ExprFactory factory = new ExprFactory();
             E_Regex regex = factory.regex(factory.str("?o"), searchTerms, "i");
-			distinctResourcesQuery.addFilter(regex);
-		}
+            distinctResourcesQuery.addFilter(regex);
+        }
 
-		if (limit > 0) {
-			distinctResourcesQuery.setLimit(limit);
-		}
-		if (offset > 0) {
-			distinctResourcesQuery.setOffset(offset);
-		}
+        if (limit > 0) {
+            distinctResourcesQuery.setLimit(limit);
+        }
+        if (offset > 0) {
+            distinctResourcesQuery.setOffset(offset);
+        }
 
         SelectBuilder constructSelectQuery = new SelectBuilder();
         constructSelectQuery.addVar( "s p o" )
-        	.addSubQuery(distinctResourcesQuery);
+            .addSubQuery(distinctResourcesQuery);
 
         return constructSelectQuery;
     }


### PR DESCRIPTION
## Description

Additional API to support SPARQL queries for inlined resources.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [X] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [X] This PR does NOT break the API

