### PR TITLE
Migrate to Jena 4.1.0 & jersey 2.35

### DIFF
--- a/client/oslc-client/pom.xml
+++ b/client/oslc-client/pom.xml
@@ -129,6 +129,12 @@
             <version>${v.jersey}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${v.jersey}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/AbstractOslcRdfXmlProvider.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/AbstractOslcRdfXmlProvider.java
@@ -31,8 +31,8 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Providers;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFReader;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFReaderI;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.util.FileUtils;
 import org.eclipse.lyo.oslc4j.core.OSLC4JConstants;
@@ -132,7 +132,7 @@ public abstract class AbstractOslcRdfXmlProvider
 																responseInfo,
 																objects,
 																properties);
-			RDFWriter writer = getRdfWriter(serializationLanguage, model);
+			RDFWriterI writer = getRdfWriter(serializationLanguage, model);
 
 			if (serializationLanguage.equals(FileUtils.langXML) || serializationLanguage.equals(FileUtils.langXMLAbbrev))
 			{
@@ -154,8 +154,8 @@ public abstract class AbstractOslcRdfXmlProvider
 		}
 	}
 
-	private RDFWriter getRdfWriter(final String serializationLanguage, final Model model) {
-		RDFWriter writer;
+	private RDFWriterI getRdfWriter(final String serializationLanguage, final Model model) {
+		RDFWriterI writer;
 		if	(serializationLanguage.equals(FileUtils.langXMLAbbrev))
         {
             writer = new RdfXmlAbbreviatedWriter();
@@ -290,7 +290,7 @@ public abstract class AbstractOslcRdfXmlProvider
 	{
 		final Model model = ModelFactory.createDefaultModel();
 
-		RDFReader reader = getRdfReader(mediaType, model);
+		RDFReaderI reader = getRdfReader(mediaType, model);
 
 		try
 		{
@@ -313,8 +313,8 @@ public abstract class AbstractOslcRdfXmlProvider
 		}
 	}
 
-	private RDFReader getRdfReader(final MediaType mediaType, final Model model) {
-		RDFReader reader;
+	private RDFReaderI getRdfReader(final MediaType mediaType, final Model model) {
+		RDFReaderI reader;
 		final String language = getSerializationLanguage(mediaType);
 		if (language.equals(FileUtils.langXMLAbbrev))
 		{

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/RdfXmlAbbreviatedWriter.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/RdfXmlAbbreviatedWriter.java
@@ -60,7 +60,7 @@ import org.apache.jena.vocabulary.RDF;
  * @see		RDFWriter
  */
 @SuppressWarnings("FieldCanBeLocal")
-public class RdfXmlAbbreviatedWriter implements RDFWriter {
+public class RdfXmlAbbreviatedWriter implements RDFWriterI {
 
 	private final Map<AnonId, String> resourceIdToShortIdMap;
 	private int shortIdCounter = 0;

--- a/core/oslc4j-utils/src/main/java/org/eclipse/lyo/core/utils/marshallers/OSLC4JMarshaller.java
+++ b/core/oslc4j-utils/src/main/java/org/eclipse/lyo/core/utils/marshallers/OSLC4JMarshaller.java
@@ -23,7 +23,7 @@ import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
 import org.eclipse.lyo.oslc4j.provider.json4j.JsonHelper;
 
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.util.FileUtils;
 
 import static org.eclipse.lyo.core.utils.marshallers.MarshallerConstants.*;
@@ -58,7 +58,7 @@ public class OSLC4JMarshaller {
 					}else if (mediaType.isCompatible(MT_N3)) {
 						format = FileUtils.langN3;
 					}
-					final RDFWriter writer = model.getWriter(format);
+					final RDFWriterI writer = model.getWriter(format);
 					if (mediaType.isCompatible(MT_RDF_XML)
 							|| mediaType.isCompatible(MediaType.APPLICATION_XML_TYPE)
 							|| mediaType.isCompatible(MT_OSLC_COMPACT)){

--- a/core/oslc4j-utils/src/main/java/org/eclipse/lyo/core/utils/marshallers/OSLC4JUnmarshaller.java
+++ b/core/oslc4j-utils/src/main/java/org/eclipse/lyo/core/utils/marshallers/OSLC4JUnmarshaller.java
@@ -30,7 +30,7 @@ import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFReader;
+import org.apache.jena.rdf.model.RDFReaderI;
 import org.apache.jena.util.FileUtils;
 
 public class OSLC4JUnmarshaller {
@@ -42,7 +42,7 @@ public class OSLC4JUnmarshaller {
 	@SuppressWarnings("unchecked")
 	public <T> T unmarshal(InputStream inputStream, Class<T> clazz) throws IllegalArgumentException, SecurityException, DatatypeConfigurationException, IllegalAccessException, InstantiationException, InvocationTargetException, OslcCoreApplicationException, URISyntaxException, NoSuchMethodException{
 		final Model model = ModelFactory.createDefaultModel();
-		final RDFReader reader = getReader(model);
+		final RDFReaderI reader = getReader(model);
 		if (reader == null) { // unsupported media type
 			return null;
 		}
@@ -67,7 +67,7 @@ public class OSLC4JUnmarshaller {
 		return ret;
 	}
 
-	private RDFReader getReader(final Model model) {
+	private RDFReaderI getReader(final Model model) {
 		if (mediaType.isCompatible(MT_RDF_XML) || mediaType.isCompatible(MediaType.APPLICATION_XML_TYPE)) {
 			return model.getReader(); // Default reader handles both xml and abbreviated xml
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
     <v.kotlin>1.5.10</v.kotlin>
     <v.dokka>1.4.32</v.dokka>
 
-    <v.jena>3.16.0</v.jena>
-    <v.jersey>2.25.1</v.jersey>
+    <v.jena>4.1.0</v.jena>
+    <v.jersey>2.35</v.jersey>
     <v.slf4j>1.7.32</v.slf4j>
     <v.servlet>3.1.0</v.servlet>
     <v.httpclient>4.5.13</v.httpclient>
@@ -320,12 +320,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.12.0</version>
+        <version>2.12.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.12.0</version>
+        <version>2.12.3</version>
        </dependency>
 
        <dependency>
@@ -336,7 +336,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.11</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -353,7 +353,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.7</version>
+        <version>2.8.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/DatasetQueryExecutorImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/DatasetQueryExecutorImpl.java
@@ -19,8 +19,6 @@ import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.tdb.TDB;
 import org.apache.jena.tdb.TDBFactory;
-import org.apache.jena.update.GraphStore;
-import org.apache.jena.update.GraphStoreFactory;
 import org.apache.jena.update.UpdateExecutionFactory;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateProcessor;

--- a/trs/server/pom.xml
+++ b/trs/server/pom.xml
@@ -116,6 +116,12 @@
       <version>${v.jersey}</version>
       <scope>test</scope>
     </dependency>
+	<dependency>
+		<groupId>org.glassfish.jersey.inject</groupId>
+		<artifactId>jersey-hk2</artifactId>
+		<version>${v.jersey}</version>
+		<scope>test</scope>
+	</dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework</groupId>
       <artifactId>jersey-test-framework-core</artifactId>

--- a/trs/server/src/main/java/org/eclipse/lyo/oslc4j/trs/server/TRSUtil.java
+++ b/trs/server/src/main/java/org/eclipse/lyo/oslc4j/trs/server/TRSUtil.java
@@ -33,7 +33,7 @@ import javax.xml.namespace.QName;
 import org.apache.commons.lang.math.RandomUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.rdf.model.RDFWriterI;
 import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
@@ -172,7 +172,7 @@ public class TRSUtil {
 
         final OutputStream os = new FileOutputStream(file);
 
-        final RDFWriter rdfWriter = jenaModel.getWriter("RDF/XML");
+        final RDFWriterI rdfWriter = jenaModel.getWriter("RDF/XML");
         rdfWriter.setProperty("showXmlDeclaration", true);
         rdfWriter.setProperty("allowBadURIs", "true");
         rdfWriter.setProperty("relativeURIs", "");


### PR DESCRIPTION
## Description

Migrate to Jena 4.1.0 & jersey 2.35

This is still work in progress, but I thought I share how far I went when experimenting with latest Jena. Identified problems when building:

- [ ] <module>oauth-consumer-store</module> does not yet compile.
- [ ] SparqlUtilTest under trs/client does not compile.
- [ ] Tests from Store fail.


## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [ ] This PR does NOT break the API


