### PR TITLE
Add XMLLiteral well-formedness helper to Lyo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - The OSLC Config domain model was expanded.
+- An `OSLC4JUtils::isWellFormed` method was added to help check the validity of strings as valid XML literals when the inputs are supposed to be used on properties of the `rdf:XMLLiteral` type. Warning: this method is quite slow, especially if a resource contains 10s or 100s of such values. We recommend to use this method only in tests.
 
 ### Changed
 

--- a/core/lyo-core-settings/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
+++ b/core/lyo-core-settings/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
@@ -13,6 +13,9 @@
  */
 package org.eclipse.lyo.oslc4j.core;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
@@ -29,6 +32,10 @@ import javax.ws.rs.core.UriBuilder;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.jena.datatypes.DatatypeFormatException;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.TypeMapper;
@@ -41,6 +48,7 @@ import org.eclipse.lyo.oslc4j.core.model.ResourceShape;
 import org.eclipse.lyo.oslc4j.core.model.XMLLiteral;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
 // TODO: Lyo6 extract to LyoServletUriUtils
 public class OSLC4JUtils {
@@ -755,4 +763,21 @@ public class OSLC4JUtils {
         System.setProperty(OSLC4JConstants.LYO_STORE_PAGING_PRECISE_LIMIT, Boolean.toString(value));
     }
 
+    public static boolean isWellFormed(String xmlLiteral) {
+        try {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            InputStream targetStream = new ByteArrayInputStream(xmlLiteral.getBytes());
+            db.parse(targetStream);
+            return true;
+        } catch (ParserConfigurationException e) {
+            throw new IllegalStateException("XML Validator cannot be initialized");
+        } catch (IOException | SAXException e) {
+            return false;
+        }
+    }
+
+    public static boolean isWellFormed(XMLLiteral literal) {
+        return isWellFormed(literal.getValue());
+    }
 }

--- a/core/lyo-core-settings/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
+++ b/core/lyo-core-settings/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.UriBuilder;
+import javax.xml.XMLConstants;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.namespace.QName;
@@ -765,8 +766,17 @@ public class OSLC4JUtils {
 
     public static boolean isWellFormed(String xmlLiteral) {
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            // or completely disable external entities declarations:
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            // or prohibit the use of all protocols by external entities:
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            // or disable entity expansion but keep in mind that this doesn't prevent fetching external entities
+            // and this solution is not correct for OpenJDK < 13 due to a bug: https://bugs.openjdk.java.net/browse/JDK-8206132
+//            factory.setExpandEntityReferences(false);
+            DocumentBuilder db = factory.newDocumentBuilder();
             InputStream targetStream = new ByteArrayInputStream(xmlLiteral.getBytes());
             db.parse(targetStream);
             return true;

--- a/core/lyo-core-settings/src/test/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtilsTest.java
+++ b/core/lyo-core-settings/src/test/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtilsTest.java
@@ -14,8 +14,12 @@
 package org.eclipse.lyo.oslc4j.core;
 
 import java.net.MalformedURLException;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import static org.junit.Assert.*;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -173,5 +177,18 @@ public class OSLC4JUtilsTest {
         Mockito.when(mockedRequest.getServletPath()).thenReturn("/resources");
         Mockito.when(mockedRequest.getPathInfo()).thenReturn("/bugs/1");
         return mockedRequest;
+    }
+
+    @Test
+    public void isWellFormed() {
+        List<Pair<Boolean, String>> pairs = Lists.newArrayList(
+            Pair.of(true, "<span>John &amp; Mary</span>")
+            ,Pair.of(false, "<span>John & Mary</span>")
+            ,Pair.of(false, "John and Mary")
+        );
+        for (Pair<Boolean, String> pair : pairs) {
+            boolean checkResult = OSLC4JUtils.isWellFormed(pair.getRight());
+            assertEquals(pair.getLeft(), checkResult);
+        }
     }
 }

--- a/core/lyo-core-settings/src/test/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtilsTest.java
+++ b/core/lyo-core-settings/src/test/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtilsTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import static org.junit.Assert.*;
 
-import com.google.common.collect.Lists;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Test;
@@ -181,7 +180,7 @@ public class OSLC4JUtilsTest {
 
     @Test
     public void isWellFormed() {
-        List<Pair<Boolean, String>> pairs = Lists.newArrayList(
+        List<Pair<Boolean, String>> pairs = List.of(
             Pair.of(true, "<span>John &amp; Mary</span>")
             ,Pair.of(false, "<span>John & Mary</span>")
             ,Pair.of(false, "John and Mary")

--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -99,11 +99,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -13,6 +13,7 @@
 
   <dependencies>
     <dependency>
+<<<<<<< HEAD
       <groupId>org.eclipse.lyo.oslc4j.core</groupId>
       <artifactId>lyo-core-model</artifactId>
       <version>${v.lyo}</version><!--TODO: depManage-->
@@ -30,6 +31,13 @@
       <version>4.8.143</version>
     </dependency>
     <dependency>
+||||||| parent of 4a1760cc (Put the logging dep back)
+=======
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+>>>>>>> 4a1760cc (Put the logging dep back)
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
       <scope>provided</scope>

--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -85,10 +85,6 @@
       <artifactId>jakarta.activation-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -99,6 +99,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -13,7 +13,6 @@
 
   <dependencies>
     <dependency>
-<<<<<<< HEAD
       <groupId>org.eclipse.lyo.oslc4j.core</groupId>
       <artifactId>lyo-core-model</artifactId>
       <version>${v.lyo}</version><!--TODO: depManage-->
@@ -31,22 +30,14 @@
       <version>4.8.143</version>
     </dependency>
     <dependency>
-||||||| parent of 4a1760cc (Put the logging dep back)
-=======
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
->>>>>>> 4a1760cc (Put the logging dep back)
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
       <scope>provided</scope>
     </dependency>
-<!--    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>-->
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>apache-jena-libs</artifactId>

--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -30,10 +30,6 @@
       <version>4.8.143</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
       <scope>provided</scope>
@@ -75,6 +71,10 @@
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Signed-off-by: Jad El-khoury <jad.el.khoury@scania.com>

## Description

Add XMLLiteral well-formedness helper to Lyo

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [X] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [X] This PR does NOT break the API

