### PR TITLE
For update requests, avoid creating a sparql query string . This is very inefficient for large queries.

### DIFF
--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
@@ -144,8 +144,7 @@ public class SparqlStoreImpl implements Store {
             quadAccumulator.addTriple(triple);
         }
         final UpdateDataInsert dataInsertUpdate = new UpdateDataInsert(quadAccumulator);
-        final String queryString = dataInsertUpdate.toString();
-        final UpdateProcessor up = queryExecutor.prepareSparqlUpdate(queryString);
+        final UpdateProcessor up = queryExecutor.prepareSparqlUpdate(dataInsertUpdate);
         up.execute();
     }
 

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/DatasetQueryExecutorImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/DatasetQueryExecutorImpl.java
@@ -21,6 +21,7 @@ import org.apache.jena.tdb.TDB;
 import org.apache.jena.tdb.TDBFactory;
 import org.apache.jena.update.GraphStore;
 import org.apache.jena.update.GraphStoreFactory;
+import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateExecutionFactory;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateProcessor;
@@ -64,13 +65,21 @@ public class DatasetQueryExecutorImpl implements JenaQueryExecutor {
     }
 
     @Override
-    public UpdateProcessor prepareSparqlUpdate(final String query) {
+    public UpdateProcessor prepareSparqlUpdate(final UpdateRequest updateRequest) {
         if(released) {
             throw new IllegalStateException("Cannot execute queries after releasing the connection");
         }
-        log.debug("Running update: '{}'", query);
-        final UpdateRequest update = UpdateFactory.create(query);
-        return UpdateExecutionFactory.create(update, dataset);
+        return UpdateExecutionFactory.create(updateRequest, dataset);
+    }
+
+    @Override
+    public UpdateProcessor prepareSparqlUpdate(final Update update) {
+        return prepareSparqlUpdate(new UpdateRequest(update));
+    }
+
+    @Override
+    public UpdateProcessor prepareSparqlUpdate(final String query) {
+        return prepareSparqlUpdate(UpdateFactory.create(query));
     }
 
     @Override

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/JenaQueryExecutor.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/JenaQueryExecutor.java
@@ -1,5 +1,7 @@
 package org.eclipse.lyo.store.internals.query;
 
+import java.io.InputStream;
+
 /*
  * Copyright (c) 2020 Contributors to the Eclipse Foundation
  *
@@ -15,7 +17,9 @@ package org.eclipse.lyo.store.internals.query;
  */
 
 import org.apache.jena.query.QueryExecution;
+import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateProcessor;
+import org.apache.jena.update.UpdateRequest;
 
 /**
  * QueryExecutor is an interface that allows to run SPARQL queries on different triplestore
@@ -33,6 +37,22 @@ public interface JenaQueryExecutor {
      * @return prepared executor
      */
     QueryExecution prepareSparqlQuery(String query);
+
+    /**
+     * Prepares a SPARQL Update processor (write-only).
+     *
+     * @param query SPARQL query string
+     * @return prepared processor
+     */
+    UpdateProcessor prepareSparqlUpdate(final UpdateRequest updateRequest);
+
+    /**
+     * Prepares a SPARQL Update processor (write-only).
+     *
+     * @param query SPARQL query string
+     * @return prepared processor
+     */
+    UpdateProcessor prepareSparqlUpdate(final Update update);
 
     /**
      * Prepares a SPARQL Update processor (write-only).

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/SparqlQueryExecutorBasicAuthImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/SparqlQueryExecutorBasicAuthImpl.java
@@ -22,13 +22,16 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateExecutionFactory;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateProcessor;
+import org.apache.jena.update.UpdateRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * SparqlQueryExecutorImpl is a SPARQL endpoint-based implementation of {@link JenaQueryExecutor}.
@@ -65,15 +68,25 @@ public class SparqlQueryExecutorBasicAuthImpl implements JenaQueryExecutor {
     }
 
     @Override
-    public UpdateProcessor prepareSparqlUpdate(final String query) {
+    public UpdateProcessor prepareSparqlUpdate(final UpdateRequest updateRequest) {
         if (released) {
             throw new IllegalStateException("Cannot execute queries after releasing the connection");
         }
         return UpdateExecutionFactory.createRemote(
-            UpdateFactory.create(query),
+            updateRequest,
             updateEndpoint,
             client
         );
+    }
+
+    @Override
+    public UpdateProcessor prepareSparqlUpdate(final Update update) {
+        return prepareSparqlUpdate(new UpdateRequest(update));
+    }
+
+    @Override
+    public UpdateProcessor prepareSparqlUpdate(final String query) {
+        return prepareSparqlUpdate(UpdateFactory.create(query));
     }
 
     @Override

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/SparqlQueryExecutorImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/SparqlQueryExecutorImpl.java
@@ -16,9 +16,11 @@ package org.eclipse.lyo.store.internals.query;
 
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateExecutionFactory;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateProcessor;
+import org.apache.jena.update.UpdateRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,9 +47,20 @@ public class SparqlQueryExecutorImpl implements JenaQueryExecutor {
         return QueryExecutionFactory.sparqlService(queryEndpoint, query);
     }
 
+
+    @Override
+    public UpdateProcessor prepareSparqlUpdate(final UpdateRequest updateRequest) {
+        return UpdateExecutionFactory.createRemote(updateRequest, updateEndpoint);
+    }
+
+    @Override
+    public UpdateProcessor prepareSparqlUpdate(final Update update) {
+        return prepareSparqlUpdate(new UpdateRequest(update));
+    }
+
     @Override
     public UpdateProcessor prepareSparqlUpdate(final String query) {
-        return UpdateExecutionFactory.createRemote(UpdateFactory.create(query), updateEndpoint);
+        return prepareSparqlUpdate(UpdateFactory.create(query));
     }
 
     @Override


### PR DESCRIPTION

## Description

For update requests, avoid creating a sparql query string . This is very inefficient for large queries.

## Checklist

- [X] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [X] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [X] This PR does NOT break the API

