### PR TITLE
reverting back to previous version of Lyo models.

### DIFF
--- a/domains/org.eclipse.lyo.tools.domainmodels/representations.aird
+++ b/domains/org.eclipse.lyo.tools.domainmodels/representations.aird
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:oscl4j_vocabulary="http://org.eclipse.lyo/oslc4j/vocabulary" xmlns:oslc4j_ai="http://org.eclipse.lyo/oslc4j/adaptorInterface" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
-  <viewpoint:DAnalysis uid="_JR6MID4xEeqAQMi9WMAJGg" selectedViews="_JthKED4xEeqAQMi9WMAJGg" version="14.5.1.202106111100">
+  <viewpoint:DAnalysis uid="_JR6MID4xEeqAQMi9WMAJGg" selectedViews="_JthKED4xEeqAQMi9WMAJGg" version="14.3.1.202003261200">
     <semanticResources>oslcDomainSpecifications.xml</semanticResources>
     <semanticResources>vocabulary.xml</semanticResources>
     <ownedViews xmi:type="viewpoint:DView" uid="_JthKED4xEeqAQMi9WMAJGg">
@@ -21,7 +21,7 @@
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']"/>
         <target xmi:type="oslc4j_ai:Specification" href="oslcDomainSpecifications.xml#/"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_VZ-KID4xEeqAQMi9WMAJGg" name="Change Management" repPath="#_VZ9jED4xEeqAQMi9WMAJGg" changeId="1613f74d-2164-4d22-82c9-58a8308497e3">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_VZ-KID4xEeqAQMi9WMAJGg" name="Change Management" repPath="#_VZ9jED4xEeqAQMi9WMAJGg">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']"/>
         <target xmi:type="oslc4j_ai:Specification" href="oslcDomainSpecifications.xml#/"/>
       </ownedRepresentationDescriptors>
@@ -48,10 +48,6 @@
       <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_Xp5wEEP9EeqWXLXqxx7Bnw" name="Core" repPath="#_Xp4h8UP9EeqWXLXqxx7Bnw">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']"/>
         <target xmi:type="oslc4j_ai:Specification" href="oslcDomainSpecifications.xml#/"/>
-      </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_qU8HwDzsEeyX-opQFu4xUg" name="CMDiag" repPath="#_qU3PQDzsEeyX-opQFu4xUg" changeId="2f6f08d1-2864-4f3d-9ee4-e600f9f033bd">
-        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']"/>
-        <target xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']"/>
       </ownedRepresentationDescriptors>
     </ownedViews>
   </viewpoint:DAnalysis>
@@ -534,14 +530,14 @@
           <labelFormat>underline</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_-IrqMGeLEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Configuration%20Management']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Configuration%20Management']/@configuration/@generalConfiguration"/>
           <ownedStyle xmi:type="diagram:BundledImage" uid="_-IrqMWeLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_-IrqMmeLEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Configuration%20Management']/@configuration/@projectConfiguration"/>
@@ -549,7 +545,7 @@
           <ownedStyle xmi:type="diagram:BundledImage" uid="_-IrqM2eLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
     </ownedDiagramElements>
@@ -599,14 +595,14 @@
           <labelFormat>underline</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_90rJEGeLEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Provenance']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Provenance']/@configuration/@generalConfiguration"/>
           <ownedStyle xmi:type="diagram:BundledImage" uid="_90rJEWeLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_90rJEmeLEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Provenance']/@configuration/@projectConfiguration"/>
@@ -614,7 +610,7 @@
           <ownedStyle xmi:type="diagram:BundledImage" uid="_90rJE2eLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
     </ownedDiagramElements>
@@ -3269,14 +3265,14 @@
           <labelFormat>underline</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_CZO5YGeMEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Requirements%20Management%20shapes']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Requirements%20Management%20shapes']/@configuration/@generalConfiguration"/>
           <ownedStyle xmi:type="diagram:BundledImage" uid="_CZO5YWeMEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_CZO5YmeMEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Requirements%20Management%20shapes']/@configuration/@projectConfiguration"/>
@@ -3284,7 +3280,7 @@
           <ownedStyle xmi:type="diagram:BundledImage" uid="_CZO5Y2eMEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
     </ownedDiagramElements>
@@ -4291,14 +4287,14 @@
           <labelFormat>underline</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_7qiz0GeLEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Automation']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Automation']/@configuration/@generalConfiguration"/>
           <ownedStyle xmi:type="diagram:BundledImage" uid="_7qiz0WeLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_7qiz0meLEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Automation']/@configuration/@projectConfiguration"/>
@@ -4306,7 +4302,7 @@
           <ownedStyle xmi:type="diagram:BundledImage" uid="_7qiz02eLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
     </ownedDiagramElements>
@@ -4489,18 +4485,6 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_anx2UT4yEeqAQMi9WMAJGg" fontName="Segoe UI"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2Uj4yEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_anx2WT4yEeqAQMi9WMAJGg" type="3010" element="_am2CMT4yEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2Wj4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2Wz4yEeqAQMi9WMAJGg"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_anx2Yj4yEeqAQMi9WMAJGg" type="3010" element="_am2pQz4yEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2Yz4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2ZD4yEeqAQMi9WMAJGg"/>
-                </children>
-                <children xmi:type="notation:Node" xmi:id="_anx2Xz4yEeqAQMi9WMAJGg" type="3010" element="_am2pQT4yEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2YD4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2YT4yEeqAQMi9WMAJGg"/>
-                </children>
                 <children xmi:type="notation:Node" xmi:id="_anx2XD4yEeqAQMi9WMAJGg" type="3010" element="_am2CMz4yEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_anx2XT4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2Xj4yEeqAQMi9WMAJGg"/>
@@ -4509,13 +4493,25 @@
                   <styles xmi:type="notation:FontStyle" xmi:id="_anydZD4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_anydZT4yEeqAQMi9WMAJGg"/>
                 </children>
-                <children xmi:type="notation:Node" xmi:id="_anx2Uz4yEeqAQMi9WMAJGg" type="3010" element="_am1bID4yEeqAQMi9WMAJGg">
-                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2VD4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
-                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2VT4yEeqAQMi9WMAJGg"/>
+                <children xmi:type="notation:Node" xmi:id="_anx2WT4yEeqAQMi9WMAJGg" type="3010" element="_am2CMT4yEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2Wj4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2Wz4yEeqAQMi9WMAJGg"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_anx2Xz4yEeqAQMi9WMAJGg" type="3010" element="_am2pQT4yEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2YD4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2YT4yEeqAQMi9WMAJGg"/>
                 </children>
                 <children xmi:type="notation:Node" xmi:id="_anx2Vj4yEeqAQMi9WMAJGg" type="3010" element="_am1bIj4yEeqAQMi9WMAJGg">
                   <styles xmi:type="notation:FontStyle" xmi:id="_anx2Vz4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
                   <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2WD4yEeqAQMi9WMAJGg"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_anx2Yj4yEeqAQMi9WMAJGg" type="3010" element="_am2pQz4yEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2Yz4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2ZD4yEeqAQMi9WMAJGg"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_anx2Uz4yEeqAQMi9WMAJGg" type="3010" element="_am1bID4yEeqAQMi9WMAJGg">
+                  <styles xmi:type="notation:FontStyle" xmi:id="_anx2VD4yEeqAQMi9WMAJGg" fontName="Segoe UI" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Location" xmi:id="_anx2VT4yEeqAQMi9WMAJGg"/>
                 </children>
                 <styles xmi:type="notation:SortingStyle" xmi:id="_anuzAj4yEeqAQMi9WMAJGg"/>
                 <styles xmi:type="notation:FilteringStyle" xmi:id="_anuzAz4yEeqAQMi9WMAJGg"/>
@@ -5178,373 +5174,373 @@
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8LkdQmeLEeqWubhHVdX5HA"/>
         </children>
         <styles xmi:type="notation:DiagramStyle" xmi:id="_VZ-KIz4xEeqAQMi9WMAJGg"/>
-        <edges xmi:type="notation:Edge" xmi:id="_nUQlADzsEeyX-opQFu4xUg" type="4001" element="_nReWwDzsEeyX-opQFu4xUg" source="_bhGrBz4yEeqAQMi9WMAJGg" target="_udmMcEBHEeuwb5aqDturqw">
-          <children xmi:type="notation:Node" xmi:id="_nURMEDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nURMETzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_an2HzT4yEeqAQMi9WMAJGg" type="4001" element="_anrvsD4yEeqAQMi9WMAJGg" source="_anuzBD4yEeqAQMi9WMAJGg" target="_anuL9z4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_an2H0T4yEeqAQMi9WMAJGg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_391KUD4yEeqAQMi9WMAJGg" x="8" y="8"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nURzIDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nURzITzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_an2H0z4yEeqAQMi9WMAJGg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_391KUT4yEeqAQMi9WMAJGg" x="-3" y="-7"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nURzIjzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nURzIzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_an2H1T4yEeqAQMi9WMAJGg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_391KUj4yEeqAQMi9WMAJGg" x="12" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUQlATzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUQlAjzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUQlAzzsEeyX-opQFu4xUg" points="[0, 0, -352, -495]$[352, 495, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUTBQDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUTBQTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_an2Hzj4yEeqAQMi9WMAJGg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_an2Hzz4yEeqAQMi9WMAJGg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_an2H0D4yEeqAQMi9WMAJGg" points="[-20, -13, 276, 50]$[-100, -64, 196, -1]$[-139, -63, 157, 0]$[-186, -63, 110, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_an2u0D4yEeqAQMi9WMAJGg" id="(0.5263157894736842,1.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_an2u0T4yEeqAQMi9WMAJGg" id="(0.5045045045045045,0.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUTBQjzsEeyX-opQFu4xUg" type="4001" element="_nR7pwDzsEeyX-opQFu4xUg" source="_bhHSEz4yEeqAQMi9WMAJGg" target="_bhHSIT4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUTBRjzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUTBRzzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_an2u0j4yEeqAQMi9WMAJGg" type="4001" element="_anrvsz4yEeqAQMi9WMAJGg" source="_anuzGT4yEeqAQMi9WMAJGg" target="_anuL9z4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_an2u1j4yEeqAQMi9WMAJGg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_an2u1z4yEeqAQMi9WMAJGg" x="5" y="-5"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUToUDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUToUTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_an2u2D4yEeqAQMi9WMAJGg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_an2u2T4yEeqAQMi9WMAJGg" x="-3" y="11"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUToUjzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUToUzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_an2u2j4yEeqAQMi9WMAJGg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_an2u2z4yEeqAQMi9WMAJGg" x="-2" y="11"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUTBQzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUTBRDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUTBRTzsEeyX-opQFu4xUg" points="[0, 0, 20, -190]$[-20, 190, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUUPYDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUUPYTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_an2u0z4yEeqAQMi9WMAJGg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_an2u1D4yEeqAQMi9WMAJGg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_an2u1T4yEeqAQMi9WMAJGg" points="[-38, 5, 276, -39]$[-314, 44, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_an2u3D4yEeqAQMi9WMAJGg" id="(0.5066666666666667,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_an2u3T4yEeqAQMi9WMAJGg" id="(0.5045045045045045,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUU2cDzsEeyX-opQFu4xUg" type="4001" element="_nSEzszzsEeyX-opQFu4xUg" source="_bhHSIT4yEeqAQMi9WMAJGg" target="_bhHSKD4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUVdgDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUVdgTzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_an2u3j4yEeqAQMi9WMAJGg" type="4001" element="_ansWwj4yEeqAQMi9WMAJGg" source="_anvaED4yEeqAQMi9WMAJGg" target="_anuL9z4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_an2u4j4yEeqAQMi9WMAJGg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-5et0D4yEeqAQMi9WMAJGg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUWEkDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUWEkTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_an2u5D4yEeqAQMi9WMAJGg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-5et0T4yEeqAQMi9WMAJGg" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUWroDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUWroTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_an2u5j4yEeqAQMi9WMAJGg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-5et0j4yEeqAQMi9WMAJGg" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUU2cTzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUU2cjzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUU2czzsEeyX-opQFu4xUg" points="[0, 0, -270, -70]$[270, 70, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUYg0DzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUYg0TzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_an2u3z4yEeqAQMi9WMAJGg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_an2u4D4yEeqAQMi9WMAJGg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_an2u4T4yEeqAQMi9WMAJGg" points="[0, 0, 120, -34]$[-107, 30, 13, -4]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_an3V4D4yEeqAQMi9WMAJGg" id="(0.5263157894736842,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_an3V4T4yEeqAQMi9WMAJGg" id="(0.9414414414414415,0.5545243619489559)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUYg0jzsEeyX-opQFu4xUg" type="4001" element="_nSGB0DzsEeyX-opQFu4xUg" source="_bhHSIT4yEeqAQMi9WMAJGg" target="_bhHSEz4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUZH4DzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUZH4TzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_an3V4j4yEeqAQMi9WMAJGg" type="4001" element="_ansWxT4yEeqAQMi9WMAJGg" source="_anvaFz4yEeqAQMi9WMAJGg" target="_anvaED4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_an3V5j4yEeqAQMi9WMAJGg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_an3V5z4yEeqAQMi9WMAJGg" x="12"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUZH4jzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUZH4zzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_an3V6D4yEeqAQMi9WMAJGg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_an3V6T4yEeqAQMi9WMAJGg" x="-7" y="1"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUZH5DzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUZH5TzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_an3V6j4yEeqAQMi9WMAJGg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_an3V6z4yEeqAQMi9WMAJGg" x="-8"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUYg0zzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUYg1DzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUYg1TzsEeyX-opQFu4xUg" points="[0, 0, -20, 190]$[20, -190, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUZu8DzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUaWADzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_an3V4z4yEeqAQMi9WMAJGg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_an3V5D4yEeqAQMi9WMAJGg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_an3V5T4yEeqAQMi9WMAJGg" points="[-30, 5, 91, -18]$[-121, 23, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_an388D4yEeqAQMi9WMAJGg" id="(0.5084745762711864,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_an388T4yEeqAQMi9WMAJGg" id="(0.5263157894736842,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUaWATzsEeyX-opQFu4xUg" type="4001" element="_nSH3ADzsEeyX-opQFu4xUg" source="_anuL9z4yEeqAQMi9WMAJGg" target="_bhHSGj4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUaWBTzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUaWBjzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_an388j4yEeqAQMi9WMAJGg" type="4001" element="_ansWyD4yEeqAQMi9WMAJGg" source="_anvaHj4yEeqAQMi9WMAJGg" target="_anuL9z4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_an389j4yEeqAQMi9WMAJGg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y1jUD4yEeqAQMi9WMAJGg" x="2" y="-9"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUaWBzzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUaWCDzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_an38-D4yEeqAQMi9WMAJGg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y1jUT4yEeqAQMi9WMAJGg" x="-1" y="11"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUaWCTzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUaWCjzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_an38-j4yEeqAQMi9WMAJGg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="__Y1jUj4yEeqAQMi9WMAJGg" x="-2" y="11"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUaWAjzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUaWAzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUaWBDzsEeyX-opQFu4xUg" points="[0, 0, -771, -76]$[771, 76, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUbkIDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUbkITzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_an388z4yEeqAQMi9WMAJGg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_an389D4yEeqAQMi9WMAJGg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_an389T4yEeqAQMi9WMAJGg" points="[-37, 18, 234, -121]$[-271, 139, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_an38_D4yEeqAQMi9WMAJGg" id="(0.5138888888888888,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_an38_T4yEeqAQMi9WMAJGg" id="(0.5045045045045045,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUbkIjzsEeyX-opQFu4xUg" type="4001" element="_nSJsMDzsEeyX-opQFu4xUg" source="_udllYEBHEeuwb5aqDturqw" target="_bhGrBz4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUbkJjzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUbkJzzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_3YDW4JUdEeq-KoPaR9_Cfg" type="4001" element="_3XpHMJUdEeq-KoPaR9_Cfg" source="_bhHSEz4yEeqAQMi9WMAJGg" target="_bhHSIT4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_3YD98JUdEeq-KoPaR9_Cfg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YD98ZUdEeq-KoPaR9_Cfg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUcLMDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUcLMTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YD98pUdEeq-KoPaR9_Cfg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YD985UdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUcLMjzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUcLMzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YD99JUdEeq-KoPaR9_Cfg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YD99ZUdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUbkIzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUbkJDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUbkJTzsEeyX-opQFu4xUg" points="[0, 0, 417, 625]$[-417, -625, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUcyQDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUcyQTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_3YDW4ZUdEeq-KoPaR9_Cfg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_3YDW4pUdEeq-KoPaR9_Cfg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3YDW45UdEeq-KoPaR9_Cfg" points="[0, 0, 20, -190]$[-20, 190, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YD99pUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YD995UdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUcyQjzsEeyX-opQFu4xUg" type="4001" element="_nSLhYDzsEeyX-opQFu4xUg" source="_bhGrBz4yEeqAQMi9WMAJGg" target="_udllZ0BHEeuwb5aqDturqw">
-          <children xmi:type="notation:Node" xmi:id="_nUdZUDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUdZUTzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_3YD9-JUdEeq-KoPaR9_Cfg" type="4001" element="_3X4-0JUdEeq-KoPaR9_Cfg" source="_bhHSIT4yEeqAQMi9WMAJGg" target="_bhHSKD4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_3YD9_JUdEeq-KoPaR9_Cfg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YD9_ZUdEeq-KoPaR9_Cfg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUdZUjzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUdZUzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YD9_pUdEeq-KoPaR9_Cfg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YD9_5UdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUdZVDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUdZVTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YD-AJUdEeq-KoPaR9_Cfg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YD-AZUdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUcyQzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUcyRDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUcyRTzsEeyX-opQFu4xUg" points="[0, 0, -552, -495]$[552, 495, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUencDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUencTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_3YD9-ZUdEeq-KoPaR9_Cfg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_3YD9-pUdEeq-KoPaR9_Cfg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3YD9-5UdEeq-KoPaR9_Cfg" points="[0, 0, -270, -70]$[270, 70, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YElAJUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YElAZUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUencjzsEeyX-opQFu4xUg" type="4001" element="_nSMvgDzsEeyX-opQFu4xUg" source="_udllZ0BHEeuwb5aqDturqw" target="_udmMd0BHEeuwb5aqDturqw">
-          <children xmi:type="notation:Node" xmi:id="_nUf1kDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUf1kTzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_3YElApUdEeq-KoPaR9_Cfg" type="4001" element="_3X4-1JUdEeq-KoPaR9_Cfg" source="_bhHSIT4yEeqAQMi9WMAJGg" target="_bhHSEz4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_3YElBpUdEeq-KoPaR9_Cfg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YElB5UdEeq-KoPaR9_Cfg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUf1kjzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUf1kzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YElCJUdEeq-KoPaR9_Cfg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YElCZUdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUf1lDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUf1lTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YElCpUdEeq-KoPaR9_Cfg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YElC5UdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUenczzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUendDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUendTzsEeyX-opQFu4xUg" points="[0, 0, 1067, 855]$[-1067, -855, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUgcoDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUgcoTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_3YElA5UdEeq-KoPaR9_Cfg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_3YElBJUdEeq-KoPaR9_Cfg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3YElBZUdEeq-KoPaR9_Cfg" points="[0, 0, -20, 190]$[20, -190, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YElDJUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YElDZUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUhDsDzsEeyX-opQFu4xUg" type="4001" element="_nSN9oDzsEeyX-opQFu4xUg" source="_udllZ0BHEeuwb5aqDturqw" target="_udnak0BHEeuwb5aqDturqw">
-          <children xmi:type="notation:Node" xmi:id="_nUhDtDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUhDtTzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_3YElDpUdEeq-KoPaR9_Cfg" type="4001" element="_3X5l45UdEeq-KoPaR9_Cfg" source="_anuL9z4yEeqAQMi9WMAJGg" target="_bhHSGj4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_3YElEpUdEeq-KoPaR9_Cfg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YElE5UdEeq-KoPaR9_Cfg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUhDtjzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUhDtzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YFMEJUdEeq-KoPaR9_Cfg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFMEZUdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUhDuDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUhDuTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YFMEpUdEeq-KoPaR9_Cfg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFME5UdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUhDsTzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUhDsjzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUhDszzsEeyX-opQFu4xUg" points="[0, 0, 1270, 855]$[-1270, -855, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUhqwDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUhqwTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_3YElD5UdEeq-KoPaR9_Cfg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_3YElEJUdEeq-KoPaR9_Cfg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3YElEZUdEeq-KoPaR9_Cfg" points="[0, 0, -771, -76]$[771, 76, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YFMFJUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YFMFZUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUiR0DzsEeyX-opQFu4xUg" type="4001" element="_nSOksDzsEeyX-opQFu4xUg" source="_udllZ0BHEeuwb5aqDturqw" target="_udnamkBHEeuwb5aqDturqw">
-          <children xmi:type="notation:Node" xmi:id="_nUiR1DzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUiR1TzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_3YFMFpUdEeq-KoPaR9_Cfg" type="4001" element="_3X6M8JUdEeq-KoPaR9_Cfg" source="_anuL9z4yEeqAQMi9WMAJGg" target="_anuzBD4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_3YFMGpUdEeq-KoPaR9_Cfg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFMG5UdEeq-KoPaR9_Cfg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUiR1jzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUiR1zzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YFMHJUdEeq-KoPaR9_Cfg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFMHZUdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUiR2DzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUiR2TzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YFMHpUdEeq-KoPaR9_Cfg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFMH5UdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUiR0TzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUiR0jzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUiR0zzsEeyX-opQFu4xUg" points="[0, 0, 1470, 849]$[-1470, -849, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUi44DzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUi44TzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_3YFMF5UdEeq-KoPaR9_Cfg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_3YFMGJUdEeq-KoPaR9_Cfg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3YFMGZUdEeq-KoPaR9_Cfg" points="[0, 0, -388, -25]$[388, 25, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YFMIJUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YFMIZUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUi44jzsEeyX-opQFu4xUg" type="4001" element="_nSPLwzzsEeyX-opQFu4xUg" source="_udllZ0BHEeuwb5aqDturqw" target="_udnamkBHEeuwb5aqDturqw">
-          <children xmi:type="notation:Node" xmi:id="_nUjf8DzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUjf8TzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_3YFMIpUdEeq-KoPaR9_Cfg" type="4001" element="_3X6M9JUdEeq-KoPaR9_Cfg" source="_anuL9z4yEeqAQMi9WMAJGg" target="_anuL9z4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_3YFzIJUdEeq-KoPaR9_Cfg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFzIZUdEeq-KoPaR9_Cfg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUjf8jzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUjf8zzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YFzIpUdEeq-KoPaR9_Cfg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFzI5UdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUjf9DzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUjf9TzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YFzJJUdEeq-KoPaR9_Cfg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFzJZUdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUi44zzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUi45DzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUi45TzsEeyX-opQFu4xUg" points="[0, 0, 1470, 849]$[-1470, -849, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUkuEDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUkuETzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_3YFMI5UdEeq-KoPaR9_Cfg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_3YFMJJUdEeq-KoPaR9_Cfg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3YFMJZUdEeq-KoPaR9_Cfg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YFzJpUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YFzJ5UdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUkuEjzsEeyX-opQFu4xUg" type="4001" element="_nSQZ4DzsEeyX-opQFu4xUg" source="_udmMd0BHEeuwb5aqDturqw" target="_bhHSEz4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUlVIDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUlVITzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_3YFzKJUdEeq-KoPaR9_Cfg" type="4001" element="_3X60AJUdEeq-KoPaR9_Cfg" source="_anuL9z4yEeqAQMi9WMAJGg" target="_anuzCz4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_3YFzLJUdEeq-KoPaR9_Cfg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFzLZUdEeq-KoPaR9_Cfg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUlVIjzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUlVIzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YFzLpUdEeq-KoPaR9_Cfg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFzL5UdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUlVJDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUlVJTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YFzMJUdEeq-KoPaR9_Cfg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YFzMZUdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUkuEzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUkuFDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUkuFTzsEeyX-opQFu4xUg" points="[0, 0, -287, -305]$[287, 305, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUl8MDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUl8MTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_3YFzKZUdEeq-KoPaR9_Cfg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_3YFzKpUdEeq-KoPaR9_Cfg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3YFzK5UdEeq-KoPaR9_Cfg" points="[0, 0, 130, -275]$[-130, 275, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YGaMJUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YGaMZUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUl8MjzsEeyX-opQFu4xUg" type="4001" element="_nSSPEDzsEeyX-opQFu4xUg" source="_udnak0BHEeuwb5aqDturqw" target="_bhHSEz4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUl8NjzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUl8NzzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_3YGaMpUdEeq-KoPaR9_Cfg" type="4001" element="_3X60BJUdEeq-KoPaR9_Cfg" source="_anuL9z4yEeqAQMi9WMAJGg" target="_anuzEj4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_3YGaNpUdEeq-KoPaR9_Cfg" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YGaN5UdEeq-KoPaR9_Cfg" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUl8ODzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUl8OTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YGaOJUdEeq-KoPaR9_Cfg" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YGaOZUdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUl8OjzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUl8OzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_3YGaOpUdEeq-KoPaR9_Cfg" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YGaO5UdEeq-KoPaR9_Cfg" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUl8MzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUl8NDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUl8NTzsEeyX-opQFu4xUg" points="[0, 0, -490, -305]$[490, 305, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUmjQDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUmjQTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_3YGaM5UdEeq-KoPaR9_Cfg"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_3YGaNJUdEeq-KoPaR9_Cfg" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3YGaNZUdEeq-KoPaR9_Cfg" points="[0, 0, -441, 108]$[441, -108, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YGaPJUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3YGaPZUdEeq-KoPaR9_Cfg" id="(0.5,0.5)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUnKUDzsEeyX-opQFu4xUg" type="4001" element="_nSUEQDzsEeyX-opQFu4xUg" source="_udnamkBHEeuwb5aqDturqw" target="_bhHSEz4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUnKVDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUnKVTzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_udvWYEBHEeuwb5aqDturqw" type="4001" element="_udYKAEBHEeuwb5aqDturqw" source="_bhGrBz4yEeqAQMi9WMAJGg" target="_udmMcEBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udvWZEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udvWZUBHEeuwb5aqDturqw" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUnKVjzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUnKVzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udvWZkBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udvWZ0BHEeuwb5aqDturqw" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUnKWDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUnKWTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udvWaEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udvWaUBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUnKUTzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUnKUjzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUnKUzzsEeyX-opQFu4xUg" points="[0, 0, -690, -299]$[690, 299, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUnxYDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUnxYTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udvWYUBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udvWYkBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udvWY0BHEeuwb5aqDturqw" points="[-1, 0, 84, 60]$[-86, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udv9cEBHEeuwb5aqDturqw" id="(0.5028248587570622,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udv9cUBHEeuwb5aqDturqw" id="(0.5071428571428571,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUnxYjzsEeyX-opQFu4xUg" type="4001" element="_nSVSYDzsEeyX-opQFu4xUg" source="_anuL9z4yEeqAQMi9WMAJGg" target="_anuzBD4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUnxZjzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUnxZzzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_udv9ckBHEeuwb5aqDturqw" type="4001" element="_udYxE0BHEeuwb5aqDturqw" source="_udllYEBHEeuwb5aqDturqw" target="_bhGrBz4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_udv9dkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9d0BHEeuwb5aqDturqw" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUoYcDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUoYcTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udv9eEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9eUBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUoYcjzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUoYczzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udv9ekBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9e0BHEeuwb5aqDturqw" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUnxYzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUnxZDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUnxZTzsEeyX-opQFu4xUg" points="[0, 0, -388, -25]$[388, 25, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUo_gDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUo_gTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udv9c0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udv9dEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udv9dUBHEeuwb5aqDturqw" points="[-1, 0, -1, 60]$[-1, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udv9fEBHEeuwb5aqDturqw" id="(0.5028248587570622,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udv9fUBHEeuwb5aqDturqw" id="(0.5028248587570622,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUo_gjzsEeyX-opQFu4xUg" type="4001" element="_nSWggDzsEeyX-opQFu4xUg" source="_anuL9z4yEeqAQMi9WMAJGg" target="_anuL9z4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUo_hjzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUo_hzzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_udv9fkBHEeuwb5aqDturqw" type="4001" element="_udZYIEBHEeuwb5aqDturqw" source="_bhGrBz4yEeqAQMi9WMAJGg" target="_udllZ0BHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udv9gkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9g0BHEeuwb5aqDturqw" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUo_iDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUo_iTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udv9hEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9hUBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUpmkDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUxiYDzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udv9hkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udv9h0BHEeuwb5aqDturqw" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUo_gzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUo_hDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUo_hTzsEeyX-opQFu4xUg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUywgDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUywgTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udv9f0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udv9gEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udv9gUBHEeuwb5aqDturqw" points="[-1, 0, -86, 60]$[84, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udwkgEBHEeuwb5aqDturqw" id="(0.5028248587570622,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udwkgUBHEeuwb5aqDturqw" id="(0.5131578947368421,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUywgjzsEeyX-opQFu4xUg" type="4001" element="_nSYVsDzsEeyX-opQFu4xUg" source="_anuL9z4yEeqAQMi9WMAJGg" target="_anuzCz4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nUzXkDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUzXkTzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_udwkgkBHEeuwb5aqDturqw" type="4001" element="_udZYJEBHEeuwb5aqDturqw" source="_udllZ0BHEeuwb5aqDturqw" target="_udmMd0BHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udwkhkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwkh0BHEeuwb5aqDturqw" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUzXkjzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUzXkzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udwkiEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwkiUBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nUzXlDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nUzXlTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udwkikBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwki0BHEeuwb5aqDturqw" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUywgzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUywhDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUywhTzsEeyX-opQFu4xUg" points="[0, 0, 130, -275]$[-130, 275, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUz-oDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nUz-oTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udwkg0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udwkhEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udwkhUBHEeuwb5aqDturqw" points="[-1, 0, -250, 60]$[248, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udwkjEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udwkjUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nUz-ojzsEeyX-opQFu4xUg" type="4001" element="_nSZj0DzsEeyX-opQFu4xUg" source="_anuL9z4yEeqAQMi9WMAJGg" target="_anuzEj4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nU0lsDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU0lsTzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_udwkjkBHEeuwb5aqDturqw" type="4001" element="_udZ_MEBHEeuwb5aqDturqw" source="_udllZ0BHEeuwb5aqDturqw" target="_udnak0BHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udwkkkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwkk0BHEeuwb5aqDturqw" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nU0lsjzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU0lszzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udwklEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwklUBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nU0ltDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU0ltTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udwklkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udwkl0BHEeuwb5aqDturqw" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nUz-ozzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nUz-pDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nUz-pTzsEeyX-opQFu4xUg" points="[0, 0, -441, 108]$[441, -108, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nU1z0DzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nU1z0TzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udwkj0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udwkkEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udwkkUBHEeuwb5aqDturqw" points="[-1, 0, -50, 60]$[48, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLkEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLkUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nU1z0jzsEeyX-opQFu4xUg" type="4001" element="_nS_ZsDzsEeyX-opQFu4xUg" source="_anuzBD4yEeqAQMi9WMAJGg" target="_anuL9z4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nU1z1jzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU2a4DzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_udxLkkBHEeuwb5aqDturqw" type="4001" element="_udZ_NEBHEeuwb5aqDturqw" source="_udllZ0BHEeuwb5aqDturqw" target="_udnamkBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udxLlkBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLl0BHEeuwb5aqDturqw" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nU2a4TzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU2a4jzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udxLmEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLmUBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nU2a4zzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU2a5DzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udxLmkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLm0BHEeuwb5aqDturqw" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nU1z0zzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nU1z1DzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nU1z1TzsEeyX-opQFu4xUg" points="[0, 0, 388, 25]$[-388, -25, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nU3pADzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nU3pATzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udxLk0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udxLlEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udxLlUBHEeuwb5aqDturqw" points="[-1, 0, 150, 60]$[-152, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLnEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLnUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nU4QEDzsEeyX-opQFu4xUg" type="4001" element="_nTAn0DzsEeyX-opQFu4xUg" source="_anuzGT4yEeqAQMi9WMAJGg" target="_anuL9z4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nU4QFDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU4QFTzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_udxLnkBHEeuwb5aqDturqw" type="4001" element="_udamQEBHEeuwb5aqDturqw" source="_udllZ0BHEeuwb5aqDturqw" target="_udnamkBHEeuwb5aqDturqw">
+          <children xmi:type="notation:Node" xmi:id="_udxLokBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLo0BHEeuwb5aqDturqw" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nU4QFjzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU4QFzzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udxLpEBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLpUBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nU4QGDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU4QGTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udxLpkBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxLp0BHEeuwb5aqDturqw" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nU4QETzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nU4QEjzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nU4QEzzsEeyX-opQFu4xUg" points="[0, 0, 388, 387]$[-388, -387, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nU6FQDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nU6sUDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udxLn0BHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udxLoEBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udxLoUBHEeuwb5aqDturqw" points="[-1, 0, 150, 60]$[-152, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLqEBHEeuwb5aqDturqw" id="(0.5131578947368421,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxLqUBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nU6sUTzsEeyX-opQFu4xUg" type="4001" element="_nTAn1TzsEeyX-opQFu4xUg" source="_anvaED4yEeqAQMi9WMAJGg" target="_anuL9z4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nU7TYDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU7TYTzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_udxLqkBHEeuwb5aqDturqw" type="4001" element="_udbNUEBHEeuwb5aqDturqw" source="_udmMd0BHEeuwb5aqDturqw" target="_bhHSEz4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_udxyo0BHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxypEBHEeuwb5aqDturqw" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nU76cDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU76cTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udxypUBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxypkBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nU8hgDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU8hgTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udxyp0BHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxyqEBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nU6sUjzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nU6sUzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nU6sVDzsEeyX-opQFu4xUg" points="[0, 0, 309, 205]$[-309, -205, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nU9IkDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nU9IkTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udxyoEBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udxyoUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udxyokBHEeuwb5aqDturqw" points="[-1, 0, 199, 60]$[-201, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxyqUBHEeuwb5aqDturqw" id="(0.5072463768115942,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxyqkBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nU9voDzsEeyX-opQFu4xUg" type="4001" element="_nTBO4DzsEeyX-opQFu4xUg" source="_anvaFz4yEeqAQMi9WMAJGg" target="_anvaED4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nU9vpDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU9vpTzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_udxyq0BHEeuwb5aqDturqw" type="4001" element="_udb0YEBHEeuwb5aqDturqw" source="_udnak0BHEeuwb5aqDturqw" target="_bhHSEz4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_udxyr0BHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxysEBHEeuwb5aqDturqw" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nU-WsDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU-WsTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udxysUBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxyskBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nU-WsjzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nU-WszzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udxys0BHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udxytEBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nU9voTzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nU9vojzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nU9vozzsEeyX-opQFu4xUg" points="[0, 0, 111, 15]$[-111, -15, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nVBaADzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nVBaATzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udxyrEBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udxyrUBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udxyrkBHEeuwb5aqDturqw" points="[-1, 0, -1, 60]$[-1, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxytUBHEeuwb5aqDturqw" id="(0.5072463768115942,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udxytkBHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_nVBaAjzsEeyX-opQFu4xUg" type="4001" element="_nTBO5TzsEeyX-opQFu4xUg" source="_anvaHj4yEeqAQMi9WMAJGg" target="_anuL9z4yEeqAQMi9WMAJGg">
-          <children xmi:type="notation:Node" xmi:id="_nVCBEDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nVCoIDzsEeyX-opQFu4xUg" y="-10"/>
+        <edges xmi:type="notation:Edge" xmi:id="_udyZsEBHEeuwb5aqDturqw" type="4001" element="_udcbcEBHEeuwb5aqDturqw" source="_udnamkBHEeuwb5aqDturqw" target="_bhHSEz4yEeqAQMi9WMAJGg">
+          <children xmi:type="notation:Node" xmi:id="_udyZtEBHEeuwb5aqDturqw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udyZtUBHEeuwb5aqDturqw" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nVDPMDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nVDPMTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udyZtkBHEeuwb5aqDturqw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udyZt0BHEeuwb5aqDturqw" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_nVEdUDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nVEdUTzsEeyX-opQFu4xUg" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_udyZuEBHEeuwb5aqDturqw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_udyZuUBHEeuwb5aqDturqw" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_nVBaAzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_nVBaBDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nVBaBTzsEeyX-opQFu4xUg" points="[0, 0, 346, 292]$[-346, -292, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nVFrcDzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nVFrcTzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_udyZsUBHEeuwb5aqDturqw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_udyZskBHEeuwb5aqDturqw" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_udyZs0BHEeuwb5aqDturqw" points="[-1, 0, -201, 60]$[199, -60, -1, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udyZukBHEeuwb5aqDturqw" id="(0.5072463768115942,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_udyZu0BHEeuwb5aqDturqw" id="(0.5072463768115942,1.0)"/>
         </edges>
       </data>
     </ownedAnnotationEntries>
@@ -5554,463 +5550,470 @@
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_alySQD4yEeqAQMi9WMAJGg" labelSize="9" iconPath="/org.eclipse.lyo.tools.toolchain.design/images/IconAdaptor.png" borderSize="2" borderSizeComputationExpression="2" foregroundColor="255,255,255">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_alySQD4yEeqAQMi9WMAJGg" labelSize="9" iconPath="/org.eclipse.lyo.tools.toolchain.design/images/IconAdaptor.png" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']"/>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ambygD4yEeqAQMi9WMAJGg" name="ChangeRequest" outgoingEdges="_nSH3ADzsEeyX-opQFu4xUg _nSVSYDzsEeyX-opQFu4xUg _nSWggDzsEeyX-opQFu4xUg _nSYVsDzsEeyX-opQFu4xUg _nSZj0DzsEeyX-opQFu4xUg" incomingEdges="_nSWggDzsEeyX-opQFu4xUg _nS_ZsDzsEeyX-opQFu4xUg _nTAn0DzsEeyX-opQFu4xUg _nTAn1TzsEeyX-opQFu4xUg _nTBO5TzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ambygD4yEeqAQMi9WMAJGg" name="ChangeRequest" outgoingEdges="_3X5l45UdEeq-KoPaR9_Cfg _3X6M8JUdEeq-KoPaR9_Cfg _3X6M9JUdEeq-KoPaR9_Cfg _3X60AJUdEeq-KoPaR9_Cfg _3X60BJUdEeq-KoPaR9_Cfg" incomingEdges="_anrvsD4yEeqAQMi9WMAJGg _anrvsz4yEeqAQMi9WMAJGg _ansWwj4yEeqAQMi9WMAJGg _ansWyD4yEeqAQMi9WMAJGg _3X6M9JUdEeq-KoPaR9_Cfg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poJRUJUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poJRUJUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nFa3wTzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_amh5ID4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amn_wD4yEeqAQMi9WMAJGg" name="oslc:shortTitle: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnaRgZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnaRgZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nFwO8DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amrqID4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amrqIT4yEeqAQMi9WMAJGg" name="dcterms:description: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nFzSQDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amrqIj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amsRMD4yEeqAQMi9WMAJGg" name="dcterms:title: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nF1ugDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amsRMT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amsRMj4yEeqAQMi9WMAJGg" name="dcterms:identifier: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnX1QJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnX1QJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nF4KwDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amsRMz4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amsRND4yEeqAQMi9WMAJGg" name="dcterms:subject: String []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnYcUZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnYcUZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nF6nADzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amsRNT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ams4QD4yEeqAQMi9WMAJGg" name="dcterms:created: DateTime">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nF9DQDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ams4QT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ams4Qj4yEeqAQMi9WMAJGg" name="dcterms:modified: DateTime">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnYcUJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnYcUJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGAGkDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ams4Qz4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ams4RD4yEeqAQMi9WMAJGg" name="oslc:serviceProvider: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqdJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqdJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGCi0DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amtfUD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amtfUT4yEeqAQMi9WMAJGg" name="oslc:instanceShape: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqcpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqcpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGEYATzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amtfUj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amtfUz4yEeqAQMi9WMAJGg" name="closeDate: DateTime">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGGNMDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amtfVD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amtfVT4yEeqAQMi9WMAJGg" name="status: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGICYDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amuGYD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amuGYT4yEeqAQMi9WMAJGg" name="closed: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGJQgTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amuGYj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amuGYz4yEeqAQMi9WMAJGg" name="inProgress: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4Y5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4Y5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGLswTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amutcD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amutcT4yEeqAQMi9WMAJGg" name="fixed: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGNh8TzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amutcj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amutcz4yEeqAQMi9WMAJGg" name="approved: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGPXIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amvUgD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amvUgT4yEeqAQMi9WMAJGg" name="reviewed: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGRzYDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amvUgj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amvUgz4yEeqAQMi9WMAJGg" name="verified: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfc5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfc5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGTokTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amv7kD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amv7kT4yEeqAQMi9WMAJGg" name="relatedChangeRequest: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGWr4DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amv7kj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_amv7kz4yEeqAQMi9WMAJGg" name="affectsPlanItem: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGZIITzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_amv7lD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
-        </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" uid="_am2CMT4yEeqAQMi9WMAJGg" name="authorizer: Agent []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGcLcTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-          </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
-        </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" uid="_am2pQz4yEeqAQMi9WMAJGg" name="tracksRequirement: Requirement []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfeJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfeJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGeAoTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-          </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
-        </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" uid="_am2pQT4yEeqAQMi9WMAJGg" name="implementsRequirement: Requirement []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGgc4DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-          </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am2CMz4yEeqAQMi9WMAJGg" name="dcterms:creator: Person []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGi5IDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_am2pQD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am3QUT4yEeqAQMi9WMAJGg" name="dcterms:contributor: Person []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGlVYDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_am3QUj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" uid="_am1bID4yEeqAQMi9WMAJGg" name="affectsRequirement: Requirement []">
-          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
-          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGnKkTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+        <ownedElements xmi:type="diagram:DNodeListElement" uid="_am2CMT4yEeqAQMi9WMAJGg" name="authorizer: Agent []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_am2CMj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" uid="_am2pQT4yEeqAQMi9WMAJGg" name="implementsRequirement: Requirement []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_am2pQj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am1bIj4yEeqAQMi9WMAJGg" name="tracksChangeSet: ChangeSet []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfd5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfd5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nGo_wTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_am2CMD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" uid="_am2pQz4yEeqAQMi9WMAJGg" name="tracksRequirement: Requirement []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfeJUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfeJUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_am2pRD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
+        </ownedElements>
+        <ownedElements xmi:type="diagram:DNodeListElement" uid="_am1bID4yEeqAQMi9WMAJGg" name="affectsRequirement: Requirement []">
+          <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
+          <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_am1bIT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amh5IT4yEeqAQMi9WMAJGg" name="Defect" outgoingEdges="_nS_ZsDzsEeyX-opQFu4xUg" incomingEdges="_nSVSYDzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amh5IT4yEeqAQMi9WMAJGg" name="Defect" outgoingEdges="_anrvsD4yEeqAQMi9WMAJGg" incomingEdges="_3X6M8JUdEeq-KoPaR9_Cfg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLGgpUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLGgpUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nFdUADzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_amh5Ij4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amigMD4yEeqAQMi9WMAJGg" name="Priority" incomingEdges="_nSYVsDzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amigMD4yEeqAQMi9WMAJGg" name="Priority" incomingEdges="_3X60AJUdEeq-KoPaR9_Cfg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkJUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkJUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nFeiITzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_amigMT4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amigMj4yEeqAQMi9WMAJGg" name="State" incomingEdges="_nSZj0DzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amigMj4yEeqAQMi9WMAJGg" name="State" incomingEdges="_3X60BJUdEeq-KoPaR9_Cfg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkZUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkZUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nFgXUDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_amigMz4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amigND4yEeqAQMi9WMAJGg" name="ChangeNotice" outgoingEdges="_nTAn0DzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amigND4yEeqAQMi9WMAJGg" name="ChangeNotice" outgoingEdges="_anrvsz4yEeqAQMi9WMAJGg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkpUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkpUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nFhlcTzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_amjHQD4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amjHQT4yEeqAQMi9WMAJGg" name="Task" outgoingEdges="_nTAn1TzsEeyX-opQFu4xUg" incomingEdges="_nTBO4DzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amjHQT4yEeqAQMi9WMAJGg" name="Task" outgoingEdges="_ansWwj4yEeqAQMi9WMAJGg" incomingEdges="_ansWxT4yEeqAQMi9WMAJGg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtk5UdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtk5UdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nFjaoDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_amjHQj4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amjHQz4yEeqAQMi9WMAJGg" name="ReviewTask" outgoingEdges="_nTBO4DzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amjHQz4yEeqAQMi9WMAJGg" name="ReviewTask" outgoingEdges="_ansWxT4yEeqAQMi9WMAJGg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoJUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoJUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nFl24DzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_amjuUD4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amjuUT4yEeqAQMi9WMAJGg" name="Enhancement" outgoingEdges="_nTBO5TzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_amjuUT4yEeqAQMi9WMAJGg" name="Enhancement" outgoingEdges="_ansWyD4yEeqAQMi9WMAJGg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoZUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoZUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nFnsEDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_amjuUj4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
       </ownedDiagramElements>
       <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_am5skD4yEeqAQMi9WMAJGg" name="Property Constraints">
         <target xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']"/>
         <semanticElements xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nGtRMDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1">
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_am5skT4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1">
           <labelFormat>bold</labelFormat>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@style"/>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am5skj4yEeqAQMi9WMAJGg" name="closeDate: DateTime">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nG3CMDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_am9-AD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am-lED4yEeqAQMi9WMAJGg" name="status: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nG5ecDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_am-lET4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am-lEj4yEeqAQMi9WMAJGg" name="closed: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nG76sTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_am-lEz4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am-lFD4yEeqAQMi9WMAJGg" name="inProgress: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4Y5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4Y5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nG9v4TzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_am_MID4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am_MIT4yEeqAQMi9WMAJGg" name="fixed: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHAMIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_am_MIj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am_MIz4yEeqAQMi9WMAJGg" name="approved: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHBaQTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_am_MJD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am_MJT4yEeqAQMi9WMAJGg" name="reviewed: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHDPcDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_am_zMD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am_zMT4yEeqAQMi9WMAJGg" name="verified: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfc5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfc5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHEdkTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_am_zMj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am_zMz4yEeqAQMi9WMAJGg" name="relatedChangeRequest: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHGSwTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_am_zND4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am_zNT4yEeqAQMi9WMAJGg" name="affectsPlanItem: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHIvATzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_am_zNj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_am_zNz4yEeqAQMi9WMAJGg" name="affectedByDefect: Defect []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poNiwJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poNiwJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHLLQDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_anAaQD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_anAaQT4yEeqAQMi9WMAJGg" name="tracksRequirement: Requirement []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfeJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfeJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHNAcDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_anAaQj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_anAaQz4yEeqAQMi9WMAJGg" name="implementsRequirement: Requirement []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHO1oTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_anAaRD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_anAaRT4yEeqAQMi9WMAJGg" name="affectsRequirement: Requirement []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHRR4DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_anBBUD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_anBBUT4yEeqAQMi9WMAJGg" name="tracksChangeSet: ChangeSet []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfd5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfd5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHWKYDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_anBBUj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_anBBUz4yEeqAQMi9WMAJGg" name="parent: ChangeRequest []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0JUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0JUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHc4EDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_anBBVD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_anBBVT4yEeqAQMi9WMAJGg" name="priority: Priority []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0ZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0ZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHetQTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_anBBVj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_anBoYD4yEeqAQMi9WMAJGg" name="state: State">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0pUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0pUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHhwkDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_anBoYT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_anBoYj4yEeqAQMi9WMAJGg" name="authorizer: Agent []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHjlwDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_anBoYz4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
@@ -6018,29 +6021,72 @@
       <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_8eD7cGeLEeqWubhHVdX5HA" name="Configuration">
         <target xmi:type="oslc4j_ai:MavenSpecificationConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration"/>
         <semanticElements xmi:type="oslc4j_ai:MavenSpecificationConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nHkz4DzsEeyX-opQFu4xUg" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,255,255">
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_8eD7cWeLEeqWubhHVdX5HA" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,255,255">
           <labelFormat>italic</labelFormat>
           <labelFormat>underline</labelFormat>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@style"/>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_8emuAGeLEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration/@generalConfiguration"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHmpETzsEeyX-opQFu4xUg" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='SpecificationConfiguration.GeneralConfiguration']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_8emuAWeLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_8emuAmeLEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration/@projectConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration/@projectConfiguration"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nHpsYDzsEeyX-opQFu4xUg" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='SpecificationConfiguration.ProjectConfiguration']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_8emuA2eLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_anrvsD4yEeqAQMi9WMAJGg" sourceNode="_amh5IT4yEeqAQMi9WMAJGg" targetNode="_ambygD4yEeqAQMi9WMAJGg">
+      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLGgpUdEeq-KoPaR9_Cfg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_anrvsT4yEeqAQMi9WMAJGg" targetArrow="InputClosedArrow" size="2" strokeColor="0,0,0">
+        <customFeatures>routingStyle</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToParentResource']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_anrvsj4yEeqAQMi9WMAJGg"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToParentResource']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_anrvsz4yEeqAQMi9WMAJGg" sourceNode="_amigND4yEeqAQMi9WMAJGg" targetNode="_ambygD4yEeqAQMi9WMAJGg">
+      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkpUdEeq-KoPaR9_Cfg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ansWwD4yEeqAQMi9WMAJGg" targetArrow="InputClosedArrow" size="2" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToParentResource']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ansWwT4yEeqAQMi9WMAJGg"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToParentResource']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ansWwj4yEeqAQMi9WMAJGg" sourceNode="_amjHQT4yEeqAQMi9WMAJGg" targetNode="_ambygD4yEeqAQMi9WMAJGg">
+      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtk5UdEeq-KoPaR9_Cfg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ansWwz4yEeqAQMi9WMAJGg" targetArrow="InputClosedArrow" size="2" strokeColor="0,0,0">
+        <customFeatures>routingStyle</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToParentResource']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ansWxD4yEeqAQMi9WMAJGg"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToParentResource']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ansWxT4yEeqAQMi9WMAJGg" sourceNode="_amjHQz4yEeqAQMi9WMAJGg" targetNode="_amjHQT4yEeqAQMi9WMAJGg">
+      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoJUdEeq-KoPaR9_Cfg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ansWxj4yEeqAQMi9WMAJGg" targetArrow="InputClosedArrow" size="2" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToParentResource']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ansWxz4yEeqAQMi9WMAJGg"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToParentResource']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ansWyD4yEeqAQMi9WMAJGg" sourceNode="_amjuUT4yEeqAQMi9WMAJGg" targetNode="_ambygD4yEeqAQMi9WMAJGg">
+      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoZUdEeq-KoPaR9_Cfg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ansWyT4yEeqAQMi9WMAJGg" targetArrow="InputClosedArrow" size="2" strokeColor="0,0,0">
+        <customFeatures>routingStyle</customFeatures>
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToParentResource']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ansWyj4yEeqAQMi9WMAJGg"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToParentResource']"/>
     </ownedDiagramElements>
     <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_bgSysD4yEeqAQMi9WMAJGg" name="OSLC (oslc)" width="40" height="30">
       <target xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']"/>
@@ -6048,213 +6094,213 @@
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_bgSysT4yEeqAQMi9WMAJGg" labelSize="9" iconPath="/org.eclipse.lyo.tools.toolchain.design/images/IconAdaptor.png" borderSize="2" borderSizeComputationExpression="2" foregroundColor="255,255,255">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_bgSysT4yEeqAQMi9WMAJGg" labelSize="9" iconPath="/org.eclipse.lyo.tools.toolchain.design/images/IconAdaptor.png" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']"/>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_bggOED4yEeqAQMi9WMAJGg" name="ServiceProvider" outgoingEdges="_nReWwDzsEeyX-opQFu4xUg _nSLhYDzsEeyX-opQFu4xUg" incomingEdges="_nSJsMDzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_bggOED4yEeqAQMi9WMAJGg" name="ServiceProvider" outgoingEdges="_udYKAEBHEeuwb5aqDturqw _udZYIEBHEeuwb5aqDturqw" incomingEdges="_udYxE0BHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8JUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8JUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nHrhkDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_bgg1ID4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub7_kEBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIBf0DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub7_kUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub7_kkBHEeuwb5aqDturqw" name="dcterms:description: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIDVADzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub8moEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_bgg1IT4yEeqAQMi9WMAJGg" name="ResourceShape" outgoingEdges="_nR7pwDzsEeyX-opQFu4xUg" incomingEdges="_nSGB0DzsEeyX-opQFu4xUg _nSQZ4DzsEeyX-opQFu4xUg _nSSPEDzsEeyX-opQFu4xUg _nSUEQDzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_bgg1IT4yEeqAQMi9WMAJGg" name="ResourceShape" outgoingEdges="_3XpHMJUdEeq-KoPaR9_Cfg" incomingEdges="_3X4-1JUdEeq-KoPaR9_Cfg _udbNUEBHEeuwb5aqDturqw _udb0YEBHEeuwb5aqDturqw _udcbcEBHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8ZUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poPX8ZUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nHt90DzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_bgg1Ij4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgiDQD4yEeqAQMi9WMAJGg" name="dcterms:title: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIHmcDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgiDQT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgiDQj4yEeqAQMi9WMAJGg" name="describes: URI []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poPX8pUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poPX8pUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIKCsDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgiqUD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_bgg1Iz4yEeqAQMi9WMAJGg" name="Discussion" incomingEdges="_nSH3ADzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_bgg1Iz4yEeqAQMi9WMAJGg" name="Discussion" incomingEdges="_3X5l45UdEeq-KoPaR9_Cfg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poP_AJUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poP_AJUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nHvL8DzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_bghcMD4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_bghcMT4yEeqAQMi9WMAJGg" name="Property" outgoingEdges="_nSEzszzsEeyX-opQFu4xUg _nSGB0DzsEeyX-opQFu4xUg" incomingEdges="_nR7pwDzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_bghcMT4yEeqAQMi9WMAJGg" name="Property" outgoingEdges="_3X4-0JUdEeq-KoPaR9_Cfg _3X4-1JUdEeq-KoPaR9_Cfg" incomingEdges="_3XpHMJUdEeq-KoPaR9_Cfg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poP_AZUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poP_AZUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nHwaETzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_bghcMj4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgjRYD4yEeqAQMi9WMAJGg" name="dcterms:description: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIO7MTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgjRYT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgjRYj4yEeqAQMi9WMAJGg" name="dcterms:title: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIR-gDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgj4cD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgj4cT4yEeqAQMi9WMAJGg" name="allowedValue: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_ApUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_ApUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIVB0DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgj4cj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgj4cz4yEeqAQMi9WMAJGg" name="defaultValue: Resource">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_A5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_A5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIXeEDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgj4dD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgkfgD4yEeqAQMi9WMAJGg" name="hidden: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_BJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_BJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIYsMTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgkfgT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgkfgj4yEeqAQMi9WMAJGg" name="isMemberProperty: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_BZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_BZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIahYTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgkfgz4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgkfhD4yEeqAQMi9WMAJGg" name="name: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIcWkDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bglGkD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bglGkT4yEeqAQMi9WMAJGg" name="maxSize: Integer">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIey0DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bglGkj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bglGkz4yEeqAQMi9WMAJGg" name="occurs: Resource">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIhPEDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgltoD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgltoT4yEeqAQMi9WMAJGg" name="propertyDefinition: Resource">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmE5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmE5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIjEQDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgltoj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgltoz4yEeqAQMi9WMAJGg" name="range: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmFJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmFJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIlggDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgltpD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgltpT4yEeqAQMi9WMAJGg" name="readOnly: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmFZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmFZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nInVsTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgmUsD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgmUsT4yEeqAQMi9WMAJGg" name="representation: Resource">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poRNIJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poRNIJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIpK4TzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgmUsj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgmUsz4yEeqAQMi9WMAJGg" name="valueType: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poRNIZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poRNIZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIrnIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgmUtD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_bghcMz4yEeqAQMi9WMAJGg" name="AllowedValues" incomingEdges="_nSEzszzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_bghcMz4yEeqAQMi9WMAJGg" name="Allowed Values" incomingEdges="_3X4-0JUdEeq-KoPaR9_Cfg">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poRNIpUdEeq-KoPaR9_Cfg"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poRNIpUdEeq-KoPaR9_Cfg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nHy2UDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_bghcND4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgni0D4yEeqAQMi9WMAJGg" name="allowedValue: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_ApUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_ApUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nIxGsDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_bgni0T4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
@@ -6265,320 +6311,320 @@
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nLH3IDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1">
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_bgoJ4T4yEeqAQMi9WMAJGg" showIcon="false" borderSize="1" borderSizeComputationExpression="1">
           <labelFormat>bold</labelFormat>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@style"/>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgoJ4j4yEeqAQMi9WMAJGg" name="serviceProvider: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqdJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqdJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nLMvoDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgoJ4z4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgow8D4yEeqAQMi9WMAJGg" name="shortTitle: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnaRgZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnaRgZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nLRBEDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgow8T4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgow8j4yEeqAQMi9WMAJGg" name="shortId: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnaRgJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnaRgJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nLV5kDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgow8z4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgow9D4yEeqAQMi9WMAJGg" name="modifiedBy: Resource">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqc5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqc5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nLZj8DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgpYAD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgpYAT4yEeqAQMi9WMAJGg" name="describes: URI []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poPX8pUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poPX8pUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nLdOUDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgpYAj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgpYAz4yEeqAQMi9WMAJGg" name="property: Property []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poSbQJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poSbQJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nLhfwDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgp_ED4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgp_ET4yEeqAQMi9WMAJGg" name="allowedValue: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_ApUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_ApUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nLpbkDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgp_Ej4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
-        <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgp_Ez4yEeqAQMi9WMAJGg" name="allowedValues: AllowedValues">
+        <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgp_Ez4yEeqAQMi9WMAJGg" name="allowedValues: Allowed Values">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poSbQZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poSbQZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nLttADzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgqmID4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgqmIT4yEeqAQMi9WMAJGg" name="defaultValue: Resource">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_A5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_A5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nLxXYDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgqmIj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgqmIz4yEeqAQMi9WMAJGg" name="hidden: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_BJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_BJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nL228DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgrNMD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgrNMT4yEeqAQMi9WMAJGg" name="isMemberProperty: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_BZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poP_BZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nL7vcDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgrNMj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgrNMz4yEeqAQMi9WMAJGg" name="name: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nMB2EDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgr0QD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgr0QT4yEeqAQMi9WMAJGg" name="maxSize: Integer">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nMHVoDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgr0Qj4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgr0Qz4yEeqAQMi9WMAJGg" name="occurs: Resource">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmEpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nMMOIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgr0RD4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgsbUD4yEeqAQMi9WMAJGg" name="propertyDefinition: Resource">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmE5UdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmE5UdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nMRGoDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgsbUT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgsbUj4yEeqAQMi9WMAJGg" name="range: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmFJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmFJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nMUxADzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgsbUz4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgtCYD4yEeqAQMi9WMAJGg" name="readOnly: Boolean">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmFZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poQmFZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nMdT4DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgtCYT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgtCYj4yEeqAQMi9WMAJGg" name="representation: Resource">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poRNIJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poRNIJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nMkBkDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgtCYz4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgtpcD4yEeqAQMi9WMAJGg" name="valueType: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poRNIZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poRNIZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nMxc8DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgtpcT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgtpcj4yEeqAQMi9WMAJGg" name="valueShape: ResourceShape">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poTpYJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poTpYJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nM1HUDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgtpcz4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bgtpdD4yEeqAQMi9WMAJGg" name="discussedBy: Discussion">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poTpYZUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poTpYZUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nM6m4DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bgtpdT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_bguQgD4yEeqAQMi9WMAJGg" name="instanceShape: Resource []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqcpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqcpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nM-4UDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_bguQgT4yEeqAQMi9WMAJGg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucDUUEBHEeuwb5aqDturqw" name="serviceProvider: ServiceProvider []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNDw0DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucD7YEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucD7YUBHEeuwb5aqDturqw" name="domain: URI []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNHbMDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucD7YkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucD7Y0BHEeuwb5aqDturqw" name="service: Service []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNMTsDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucEicEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucEicUBHEeuwb5aqDturqw" name="creationFactory: CreationFactory">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNP-EDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucEickBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucEic0BHEeuwb5aqDturqw" name="queryCapability: QueryCapability">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNTBYDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucEidEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucFJgEBHEeuwb5aqDturqw" name="creationDialog: Dialog">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNWrwDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucFJgUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucFJgkBHEeuwb5aqDturqw" name="selectionDialog: Dialog">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNaWIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucFJg0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucFJhEBHEeuwb5aqDturqw" name="usage: URI []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNfOoDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucFwkEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucFwkUBHEeuwb5aqDturqw" name="creation: URI">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNiR8DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucGXoEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucGXoUBHEeuwb5aqDturqw" name="resourceShape: ResourceShape []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNkuMDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucGXokBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucGXo0BHEeuwb5aqDturqw" name="resourceType: Class">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNnxgDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucGXpEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucGXpUBHEeuwb5aqDturqw" name="queryBase: URI">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNq00DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucGXpkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucGXp0BHEeuwb5aqDturqw" name="dialog: URI">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNtREDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucGXqEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucGXqUBHEeuwb5aqDturqw" name="hintHeight: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNwUYDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucGXqkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucG-sEBHEeuwb5aqDturqw" name="hintWidth: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nNywoDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucG-sUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucG-skBHEeuwb5aqDturqw" name="label: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nN1z8DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucG-s0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ucG-tEBHEeuwb5aqDturqw" name="domain: URI">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nN43QDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_ucHlwEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.PropertiesList']/@subNodeMappings[name='Specification.DomainSpecification.PropertiesList.Property']"/>
         </ownedElements>
@@ -6586,273 +6632,276 @@
       <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_8LCRwGeLEeqWubhHVdX5HA" name="Configuration">
         <target xmi:type="oslc4j_ai:MavenSpecificationConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration"/>
         <semanticElements xmi:type="oslc4j_ai:MavenSpecificationConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nN6scDzsEeyX-opQFu4xUg" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,255,255">
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_8LCRwWeLEeqWubhHVdX5HA" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,255,255">
           <labelFormat>italic</labelFormat>
           <labelFormat>underline</labelFormat>
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@style"/>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_8LC40GeLEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration/@generalConfiguration"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nN-W0DzsEeyX-opQFu4xUg" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='SpecificationConfiguration.GeneralConfiguration']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_8LC40WeLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_8LC40meLEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration/@projectConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration/@projectConfiguration"/>
-          <ownedStyle xmi:type="diagram:BundledImage" uid="_nOCoQDzsEeyX-opQFu4xUg" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='SpecificationConfiguration.ProjectConfiguration']/@style"/>
+          <ownedStyle xmi:type="diagram:BundledImage" uid="_8LC402eLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+            <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ubxAcEBHEeuwb5aqDturqw" name="ServiceProviderCatalog" outgoingEdges="_nSJsMDzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ubxAcEBHEeuwb5aqDturqw" name="ServiceProviderCatalog" outgoingEdges="_udYxE0BHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEiKJEeuEW8NmTOtW7w"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEiKJEeuEW8NmTOtW7w"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nH0EcDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_ubxAcUBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_uby1o0BHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nI1_MDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_uby1pEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ubzcsEBHEeuwb5aqDturqw" name="dcterms:description: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nI5pkDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ubzcsUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ubzcskBHEeuwb5aqDturqw" name="domain: URI []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHECKJEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nI8s4DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ubzcs0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ubxAckBHEeuwb5aqDturqw" name="Service" outgoingEdges="_nSMvgDzsEeyX-opQFu4xUg _nSN9oDzsEeyX-opQFu4xUg _nSOksDzsEeyX-opQFu4xUg _nSPLwzzsEeyX-opQFu4xUg" incomingEdges="_nSLhYDzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ubxAckBHEeuwb5aqDturqw" name="Service" outgoingEdges="_udZYJEBHEeuwb5aqDturqw _udZ_MEBHEeuwb5aqDturqw _udZ_NEBHEeuwb5aqDturqw _udamQEBHEeuwb5aqDturqw" incomingEdges="_udZYIEBHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEyKJEeuEW8NmTOtW7w"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_gtmHEyKJEeuEW8NmTOtW7w"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nH15oDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_ubyOkEBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub0DwEBHEeuwb5aqDturqw" name="usage: URI []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJCzgDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub0q0EBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub0q0UBHEeuwb5aqDturqw" name="domain: URI">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_kXjpACLZEeu9M4063qtrOA"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJGd4DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub0q0kBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ubyOkUBHEeuwb5aqDturqw" name="Publisher" incomingEdges="_nReWwDzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ubyOkUBHEeuwb5aqDturqw" name="Publisher" incomingEdges="_udYKAEBHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_nr5V8CKJEeuEW8NmTOtW7w"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_nr5V8CKJEeuEW8NmTOtW7w"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nH4V4DzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_ubyOkkBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub1R4EBHEeuwb5aqDturqw" name="dcterms:identifier: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnX1QJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnX1QJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJL9cDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub1R4UBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub1R4kBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJQ18DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub1R40BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub148EBHEeuwb5aqDturqw" name="label: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJWVgDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub148UBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ubyOk0BHEeuwb5aqDturqw" name="CreationFactory" outgoingEdges="_nSQZ4DzsEeyX-opQFu4xUg" incomingEdges="_nSMvgDzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ubyOk0BHEeuwb5aqDturqw" name="CreationFactory" outgoingEdges="_udbNUEBHEeuwb5aqDturqw" incomingEdges="_udZYJEBHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-8yKKEeuEW8NmTOtW7w"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-8yKKEeuEW8NmTOtW7w"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nH6LEDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_ubyOlEBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub148kBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJccIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub2gAEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub2gAUBHEeuwb5aqDturqw" name="creation: URI">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sCKLEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJffcDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub2gAkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub2gA0BHEeuwb5aqDturqw" name="usage: URI []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJkX8DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub2gBEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub2gBUBHEeuwb5aqDturqw" name="label: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJp3gDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub2gBkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub3HEEBHEeuwb5aqDturqw" name="resourceType: Class">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJzogDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub3HEUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ubyOlUBHEeuwb5aqDturqw" name="QueryCapability" outgoingEdges="_nSSPEDzsEeyX-opQFu4xUg" incomingEdges="_nSN9oDzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_ubyOlUBHEeuwb5aqDturqw" name="QueryCapability" outgoingEdges="_udb0YEBHEeuwb5aqDturqw" incomingEdges="_udZ_MEBHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9CKKEeuEW8NmTOtW7w"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9CKKEeuEW8NmTOtW7w"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nH8nUDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_uby1oEBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub3uIEBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJ4hADzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub3uIUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub3uIkBHEeuwb5aqDturqw" name="queryBase: URI">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgSKMEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nJ-noDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub3uI0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub3uJEBHEeuwb5aqDturqw" name="usage: URI []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nKLb8DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub4VMEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub4VMUBHEeuwb5aqDturqw" name="label: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nKPtYDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub4VMkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub4VM0BHEeuwb5aqDturqw" name="resourceType: Class">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nKWbEDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub48QEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_uby1oUBHEeuwb5aqDturqw" name="Dialog" outgoingEdges="_nSUEQDzsEeyX-opQFu4xUg" incomingEdges="_nSOksDzsEeyX-opQFu4xUg _nSPLwzzsEeyX-opQFu4xUg">
+      <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_uby1oUBHEeuwb5aqDturqw" name="Dialog" outgoingEdges="_udcbcEBHEeuwb5aqDturqw" incomingEdges="_udZ_NEBHEeuwb5aqDturqw _udamQEBHEeuwb5aqDturqw">
         <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9SKKEeuEW8NmTOtW7w"/>
         <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_U_N-9SKKEeuEW8NmTOtW7w"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nH-cgDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_uby1okBHEeuwb5aqDturqw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub48QUBHEeuwb5aqDturqw" name="dcterms:title: XMLLiteral">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nKb6oDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub5jUEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub5jUUBHEeuwb5aqDturqw" name="dialog: URI">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_8X71QCKLEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nKj2cDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub5jUkBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub6KYEBHEeuwb5aqDturqw" name="usage: URI []">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_jR7PkCKKEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nKqkIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub6KYUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub6KYkBHEeuwb5aqDturqw" name="hintHeight: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgiKMEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nKwDsDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub6KY0BHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub6KZEBHEeuwb5aqDturqw" name="hintWidth: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_LKVSkCKMEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nK3YcDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub6KZUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub6KZkBHEeuwb5aqDturqw" name="label: String">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_bLP8ACKNEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nK-GIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub6xcEBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.LiteralProperty']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_ub7YgEBHEeuwb5aqDturqw" name="resourceType: Class">
           <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
           <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_zKmGgCKMEeuEW8NmTOtW7w"/>
-          <ownedStyle xmi:type="diagram:Square" uid="_nLDlsDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_ub7YgUBHEeuwb5aqDturqw" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.Resource']/@subNodeMappings[name='Specification.DomainSpecification.Resource.ReferenceProperty']"/>
         </ownedElements>
@@ -6861,248 +6910,208 @@
     <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_8LC41GeLEeqWubhHVdX5HA" name="Configuration">
       <target xmi:type="oslc4j_ai:MavenSpecificationConfiguration" href="oslcDomainSpecifications.xml#//@configuration"/>
       <semanticElements xmi:type="oslc4j_ai:MavenSpecificationConfiguration" href="oslcDomainSpecifications.xml#//@configuration"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_nOFrkDzsEeyX-opQFu4xUg" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,255,255">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_8LC41WeLEeqWubhHVdX5HA" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,255,255">
         <labelFormat>italic</labelFormat>
         <labelFormat>underline</labelFormat>
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@style"/>
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.SpecificationConfiguration']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.SpecificationConfiguration']"/>
       <ownedElements xmi:type="diagram:DNodeListElement" uid="_8LDf4GeLEeqWubhHVdX5HA" name="General">
         <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@configuration/@generalConfiguration"/>
         <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@configuration/@generalConfiguration"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_nOJV8DzsEeyX-opQFu4xUg" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='SpecificationConfiguration.GeneralConfiguration']/@style"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_8LDf4WeLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.SpecificationConfiguration']/@subNodeMappings[name='Specification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.SpecificationConfiguration']/@subNodeMappings[name='Specification.SpecificationConfiguration.GeneralConfiguration']"/>
       </ownedElements>
       <ownedElements xmi:type="diagram:DNodeListElement" uid="_8LDf4meLEeqWubhHVdX5HA" name="Project Configuration">
         <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@configuration/@projectConfiguration"/>
         <semanticElements xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@configuration/@projectConfiguration"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_nONAUDzsEeyX-opQFu4xUg" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='SpecificationConfiguration.ProjectConfiguration']/@style"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_8LDf42eLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.SpecificationConfiguration']/@subNodeMappings[name='Specification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.SpecificationConfiguration']/@subNodeMappings[name='Specification.SpecificationConfiguration.ProjectConfiguration']"/>
       </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nReWwDzsEeyX-opQFu4xUg" name="publisher" sourceNode="_bggOED4yEeqAQMi9WMAJGg" targetNode="_ubyOkUBHEeuwb5aqDturqw" endLabel="1">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_tl7rcCKJEeuEW8NmTOtW7w"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_tl7rcCKJEeuEW8NmTOtW7w"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nRp88DzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nRp88jzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nRp88TzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nR7pwDzsEeyX-opQFu4xUg" name="Local: property" sourceNode="_bgg1IT4yEeqAQMi9WMAJGg" targetNode="_bghcMT4yEeqAQMi9WMAJGg" endLabel="0..*">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_3XpHMJUdEeq-KoPaR9_Cfg" name="Local: property" sourceNode="_bgg1IT4yEeqAQMi9WMAJGg" targetNode="_bghcMT4yEeqAQMi9WMAJGg" endLabel="0..*">
       <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poSbQJUdEeq-KoPaR9_Cfg"/>
       <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poSbQJUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSEMoDzsEeyX-opQFu4xUg" lineStyle="dot" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.1/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSEMojzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSEMoTzsEeyX-opQFu4xUg" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_3Xwb8JUdEeq-KoPaR9_Cfg" lineStyle="dot" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_3Xwb8ZUdEeq-KoPaR9_Cfg" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_3Xwb8pUdEeq-KoPaR9_Cfg" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSEzszzsEeyX-opQFu4xUg" name="allowedValues" sourceNode="_bghcMT4yEeqAQMi9WMAJGg" targetNode="_bghcMz4yEeqAQMi9WMAJGg" endLabel="1">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_3X4-0JUdEeq-KoPaR9_Cfg" name="allowedValues" sourceNode="_bghcMT4yEeqAQMi9WMAJGg" targetNode="_bghcMz4yEeqAQMi9WMAJGg" endLabel="1">
       <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poSbQZUdEeq-KoPaR9_Cfg"/>
       <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poSbQZUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSFawDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSFawjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSFawTzsEeyX-opQFu4xUg" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_3X4-0ZUdEeq-KoPaR9_Cfg" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_3X4-0pUdEeq-KoPaR9_Cfg" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_3X4-05UdEeq-KoPaR9_Cfg" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSGB0DzsEeyX-opQFu4xUg" name="valueShape" sourceNode="_bghcMT4yEeqAQMi9WMAJGg" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="1">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_3X4-1JUdEeq-KoPaR9_Cfg" name="valueShape" sourceNode="_bghcMT4yEeqAQMi9WMAJGg" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="1">
       <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poTpYJUdEeq-KoPaR9_Cfg"/>
       <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poTpYJUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSGo4DzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSGo4jzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSGo4TzsEeyX-opQFu4xUg" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_3X5l4JUdEeq-KoPaR9_Cfg" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_3X5l4ZUdEeq-KoPaR9_Cfg" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_3X5l4pUdEeq-KoPaR9_Cfg" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSH3ADzsEeyX-opQFu4xUg" name="discussedBy" sourceNode="_ambygD4yEeqAQMi9WMAJGg" targetNode="_bgg1Iz4yEeqAQMi9WMAJGg" endLabel="0..1">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_3X5l45UdEeq-KoPaR9_Cfg" name="discussedBy" sourceNode="_ambygD4yEeqAQMi9WMAJGg" targetNode="_bgg1Iz4yEeqAQMi9WMAJGg" endLabel="0..1">
       <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poTpYZUdEeq-KoPaR9_Cfg"/>
       <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poTpYZUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSIeEDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSIeEjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSIeETzsEeyX-opQFu4xUg" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_3X5l5JUdEeq-KoPaR9_Cfg" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_3X5l5ZUdEeq-KoPaR9_Cfg" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_3X5l5pUdEeq-KoPaR9_Cfg" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSJsMDzsEeyX-opQFu4xUg" name="serviceProvider" sourceNode="_ubxAcEBHEeuwb5aqDturqw" targetNode="_bggOED4yEeqAQMi9WMAJGg" endLabel="0..*">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSKTQDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSKTQjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSKTQTzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSLhYDzsEeyX-opQFu4xUg" name="service" sourceNode="_bggOED4yEeqAQMi9WMAJGg" targetNode="_ubxAckBHEeuwb5aqDturqw" endLabel="0..*">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSMIcDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSMIcjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSMIcTzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSMvgDzsEeyX-opQFu4xUg" name="creationFactory" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_ubyOk0BHEeuwb5aqDturqw" endLabel="1">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSNWkDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSNWkjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSNWkTzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSN9oDzsEeyX-opQFu4xUg" name="queryCapability" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_ubyOlUBHEeuwb5aqDturqw" endLabel="1">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSN9oTzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSN9ozzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSN9ojzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSOksDzsEeyX-opQFu4xUg" name="creationDialog" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_uby1oUBHEeuwb5aqDturqw" endLabel="1">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSOksTzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSOkszzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSOksjzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSPLwzzsEeyX-opQFu4xUg" name="selectionDialog" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_uby1oUBHEeuwb5aqDturqw" endLabel="1">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSPy0DzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSPy0jzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSPy0TzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSQZ4DzsEeyX-opQFu4xUg" name="resourceShape" sourceNode="_ubyOk0BHEeuwb5aqDturqw" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="0..*">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSQZ4TzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSQZ4zzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSQZ4jzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSSPEDzsEeyX-opQFu4xUg" name="resourceShape" sourceNode="_ubyOlUBHEeuwb5aqDturqw" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="0..*">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSS2IDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSS2IjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSS2ITzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSUEQDzsEeyX-opQFu4xUg" name="resourceShape" sourceNode="_uby1oUBHEeuwb5aqDturqw" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="0..*">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSUrUDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSUrUjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSUrUTzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSVSYDzsEeyX-opQFu4xUg" name="affectedByDefect" sourceNode="_ambygD4yEeqAQMi9WMAJGg" targetNode="_amh5IT4yEeqAQMi9WMAJGg" endLabel="0..*">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_3X6M8JUdEeq-KoPaR9_Cfg" name="affectedByDefect" sourceNode="_ambygD4yEeqAQMi9WMAJGg" targetNode="_amh5IT4yEeqAQMi9WMAJGg" endLabel="0..*">
       <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poNiwJUdEeq-KoPaR9_Cfg"/>
       <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poNiwJUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSV5cDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSV5cjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSV5cTzsEeyX-opQFu4xUg" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_3X6M8ZUdEeq-KoPaR9_Cfg" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_3X6M8pUdEeq-KoPaR9_Cfg" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_3X6M85UdEeq-KoPaR9_Cfg" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSWggDzsEeyX-opQFu4xUg" name="parent" sourceNode="_ambygD4yEeqAQMi9WMAJGg" targetNode="_ambygD4yEeqAQMi9WMAJGg" endLabel="0..*">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_3X6M9JUdEeq-KoPaR9_Cfg" name="parent" sourceNode="_ambygD4yEeqAQMi9WMAJGg" targetNode="_ambygD4yEeqAQMi9WMAJGg" endLabel="0..*">
       <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0JUdEeq-KoPaR9_Cfg"/>
       <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0JUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSXHkDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSXHkjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSXHkTzsEeyX-opQFu4xUg" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_3X6M9ZUdEeq-KoPaR9_Cfg" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_3X6M9pUdEeq-KoPaR9_Cfg" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_3X6M95UdEeq-KoPaR9_Cfg" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSYVsDzsEeyX-opQFu4xUg" name="priority" sourceNode="_ambygD4yEeqAQMi9WMAJGg" targetNode="_amigMD4yEeqAQMi9WMAJGg" endLabel="0..*">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_3X60AJUdEeq-KoPaR9_Cfg" name="priority" sourceNode="_ambygD4yEeqAQMi9WMAJGg" targetNode="_amigMD4yEeqAQMi9WMAJGg" endLabel="0..*">
       <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0ZUdEeq-KoPaR9_Cfg"/>
       <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0ZUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSY8wDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSY8wjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSY8wTzsEeyX-opQFu4xUg" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_3X60AZUdEeq-KoPaR9_Cfg" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_3X60ApUdEeq-KoPaR9_Cfg" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_3X60A5UdEeq-KoPaR9_Cfg" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nSZj0DzsEeyX-opQFu4xUg" name="state" sourceNode="_ambygD4yEeqAQMi9WMAJGg" targetNode="_amigMj4yEeqAQMi9WMAJGg" endLabel="0..1">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_3X60BJUdEeq-KoPaR9_Cfg" name="state" sourceNode="_ambygD4yEeqAQMi9WMAJGg" targetNode="_amigMj4yEeqAQMi9WMAJGg" endLabel="0..1">
       <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0pUdEeq-KoPaR9_Cfg"/>
       <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0pUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nSaK4DzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nSaK4jzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_nSaK4TzsEeyX-opQFu4xUg" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_3X7bEJUdEeq-KoPaR9_Cfg" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_3X7bEZUdEeq-KoPaR9_Cfg" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_3X7bEpUdEeq-KoPaR9_Cfg" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToReferenceProperty']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nS_ZsDzsEeyX-opQFu4xUg" sourceNode="_amh5IT4yEeqAQMi9WMAJGg" targetNode="_ambygD4yEeqAQMi9WMAJGg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLGgpUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nTAAwDzsEeyX-opQFu4xUg" targetArrow="InputClosedArrow" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nTAAwTzsEeyX-opQFu4xUg"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_udYKAEBHEeuwb5aqDturqw" name="publisher" sourceNode="_bggOED4yEeqAQMi9WMAJGg" targetNode="_ubyOkUBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_tl7rcCKJEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_tl7rcCKJEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_udYxEEBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_udYxEUBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_udYxEkBHEeuwb5aqDturqw" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToParentResource']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nTAn0DzsEeyX-opQFu4xUg" sourceNode="_amigND4yEeqAQMi9WMAJGg" targetNode="_ambygD4yEeqAQMi9WMAJGg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkpUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nTAn0TzsEeyX-opQFu4xUg" targetArrow="InputClosedArrow" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nTAn0jzsEeyX-opQFu4xUg"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_udYxE0BHEeuwb5aqDturqw" name="serviceProvider" sourceNode="_ubxAcEBHEeuwb5aqDturqw" targetNode="_bggOED4yEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtlgACKJEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_udYxFEBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_udYxFUBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_udYxFkBHEeuwb5aqDturqw" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToParentResource']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nTAn1TzsEeyX-opQFu4xUg" sourceNode="_amjHQT4yEeqAQMi9WMAJGg" targetNode="_ambygD4yEeqAQMi9WMAJGg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtk5UdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nTAn1jzsEeyX-opQFu4xUg" targetArrow="InputClosedArrow" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nTAn1zzsEeyX-opQFu4xUg"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_udZYIEBHEeuwb5aqDturqw" name="service" sourceNode="_bggOED4yEeqAQMi9WMAJGg" targetNode="_ubxAckBHEeuwb5aqDturqw" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_gtmHESKJEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_udZYIUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_udZYIkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_udZYI0BHEeuwb5aqDturqw" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToParentResource']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nTBO4DzsEeyX-opQFu4xUg" sourceNode="_amjHQz4yEeqAQMi9WMAJGg" targetNode="_amjHQT4yEeqAQMi9WMAJGg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoJUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nTBO4TzsEeyX-opQFu4xUg" targetArrow="InputClosedArrow" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nTBO4jzsEeyX-opQFu4xUg"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_udZYJEBHEeuwb5aqDturqw" name="creationFactory" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_ubyOk0BHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8CKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_udZYJUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_udZYJkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_udZYJ0BHEeuwb5aqDturqw" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToParentResource']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_nTBO5TzsEeyX-opQFu4xUg" sourceNode="_amjuUT4yEeqAQMi9WMAJGg" targetNode="_ambygD4yEeqAQMi9WMAJGg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoZUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_nTBO5jzsEeyX-opQFu4xUg" targetArrow="InputClosedArrow" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_nTBO5zzsEeyX-opQFu4xUg"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_udZ_MEBHEeuwb5aqDturqw" name="queryCapability" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_ubyOlUBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8SKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_udZ_MUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_udZ_MkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_udZ_M0BHEeuwb5aqDturqw" showIcon="false"/>
       </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappingImports[name='Specification.ResourceToParentResource']"/>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_udZ_NEBHEeuwb5aqDturqw" name="creationDialog" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_uby1oUBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_U_N-8iKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_udZ_NUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_udZ_NkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_udZ_N0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_udamQEBHEeuwb5aqDturqw" name="selectionDialog" sourceNode="_ubxAckBHEeuwb5aqDturqw" targetNode="_uby1oUBHEeuwb5aqDturqw" endLabel="1">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_W3oSECKKEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_udamQUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_udamQkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_udamQ0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_udbNUEBHEeuwb5aqDturqw" name="resourceShape" sourceNode="_ubyOk0BHEeuwb5aqDturqw" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_udbNUUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_udbNUkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_udbNU0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_udb0YEBHEeuwb5aqDturqw" name="resourceShape" sourceNode="_ubyOlUBHEeuwb5aqDturqw" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_udb0YUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_udb0YkBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_udb0Y0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_udcbcEBHEeuwb5aqDturqw" name="resourceShape" sourceNode="_uby1oUBHEeuwb5aqDturqw" targetNode="_bgg1IT4yEeqAQMi9WMAJGg" endLabel="0..*">
+      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_K5f2sSKLEeuEW8NmTOtW7w"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_udcbcUBHEeuwb5aqDturqw" size="2">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_udcbckBHEeuwb5aqDturqw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_udcbc0BHEeuwb5aqDturqw" showIcon="false"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@edgeMappings[name='Specification.ResourceToReferenceProperty']"/>
     </ownedDiagramElements>
     <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']"/>
     <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_VZ9jHD4xEeqAQMi9WMAJGg"/>
@@ -10037,14 +10046,14 @@
           <labelFormat>underline</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_BlUJIGeMEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Quality%20Management']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Quality%20Management']/@configuration/@generalConfiguration"/>
           <ownedStyle xmi:type="diagram:BundledImage" uid="_BlUJIWeMEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_BlUJImeMEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Quality%20Management']/@configuration/@projectConfiguration"/>
@@ -10052,7 +10061,7 @@
           <ownedStyle xmi:type="diagram:BundledImage" uid="_BlUJI2eMEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
     </ownedDiagramElements>
@@ -11636,14 +11645,14 @@
           <labelFormat>underline</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_34ZX4GeLEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Architecture%20Management']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Architecture%20Management']/@configuration/@generalConfiguration"/>
           <ownedStyle xmi:type="diagram:BundledImage" uid="_34ZX4WeLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_34ZX4meLEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Architecture%20Management']/@configuration/@projectConfiguration"/>
@@ -11651,7 +11660,7 @@
           <ownedStyle xmi:type="diagram:BundledImage" uid="_34ZX42eLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
     </ownedDiagramElements>
@@ -12305,14 +12314,14 @@
           <labelFormat>underline</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_5ZjooGeLEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration/@generalConfiguration"/>
           <ownedStyle xmi:type="diagram:BundledImage" uid="_5ZjooWeLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_5ZjoomeLEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='OSLC']/@configuration/@projectConfiguration"/>
@@ -12320,7 +12329,7 @@
           <ownedStyle xmi:type="diagram:BundledImage" uid="_5Zjoo2eLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
       <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_nE6usEBHEeuwb5aqDturqw" name="ServiceProviderCatalog" outgoingEdges="_nHBngEBHEeuwb5aqDturqw">
@@ -12780,14 +12789,14 @@
           <labelFormat>underline</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_6P2XcGeLEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Dublin%20Core']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Dublin%20Core']/@configuration/@generalConfiguration"/>
           <ownedStyle xmi:type="diagram:BundledImage" uid="_6P2XcWeLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_6P2XcmeLEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Dublin%20Core']/@configuration/@projectConfiguration"/>
@@ -12795,7 +12804,7 @@
           <ownedStyle xmi:type="diagram:BundledImage" uid="_6P2Xc2eLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
     </ownedDiagramElements>
@@ -12906,14 +12915,14 @@
           <labelFormat>underline</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_WSv6IG7iEeqC45-EU6_Agg" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Jazz%20Architecture%20Management%20']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Jazz%20Architecture%20Management%20']/@configuration/@generalConfiguration"/>
           <ownedStyle xmi:type="diagram:BundledImage" uid="_WSv6IW7iEeqC45-EU6_Agg" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_WSwhMG7iEeqC45-EU6_Agg" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Jazz%20Architecture%20Management%20']/@configuration/@projectConfiguration"/>
@@ -12921,7 +12930,7 @@
           <ownedStyle xmi:type="diagram:BundledImage" uid="_WSwhMW7iEeqC45-EU6_Agg" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
     </ownedDiagramElements>
@@ -14246,14 +14255,14 @@
           <labelFormat>underline</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']"/>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_-ke1YmeLEeqWubhHVdX5HA" name="General">
           <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Dublin%20Core']/@configuration/@generalConfiguration"/>
           <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Dublin%20Core']/@configuration/@generalConfiguration"/>
           <ownedStyle xmi:type="diagram:BundledImage" uid="_-ke1Y2eLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.GeneralConfiguration']"/>
         </ownedElements>
         <ownedElements xmi:type="diagram:DNodeListElement" uid="_-ke1ZGeLEeqWubhHVdX5HA" name="Project Configuration">
           <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Dublin%20Core']/@configuration/@projectConfiguration"/>
@@ -14261,7 +14270,7 @@
           <ownedStyle xmi:type="diagram:BundledImage" uid="_-ke1ZWeLEeqWubhHVdX5HA" showIcon="false" labelAlignment="LEFT" labelPosition="node">
             <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']/@style"/>
           </ownedStyle>
-          <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='Specification.DomainSpecification.SpecificationConfiguration.ProjectConfiguration']"/>
         </ownedElements>
       </ownedDiagramElements>
     </ownedDiagramElements>
@@ -14523,1000 +14532,5 @@
     <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_Xp5LT0P9EeqWXLXqxx7Bnw"/>
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer"/>
     <target xmi:type="oslc4j_ai:Specification" href="oslcDomainSpecifications.xml#/"/>
-  </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram uid="_qU3PQDzsEeyX-opQFu4xUg">
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_qVb3ADzsEeyX-opQFu4xUg" source="GMF_DIAGRAMS">
-      <data xmi:type="notation:Diagram" xmi:id="_qVb3ATzsEeyX-opQFu4xUg" type="Sirius" element="_qU3PQDzsEeyX-opQFu4xUg" measurementUnit="Pixel">
-        <children xmi:type="notation:Node" xmi:id="_qaL0IDzsEeyX-opQFu4xUg" type="2003" element="_qV1foDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaL0IzzsEeyX-opQFu4xUg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_qaL0JDzsEeyX-opQFu4xUg" type="7004">
-            <children xmi:type="notation:Node" xmi:id="_qaSh0DzsEeyX-opQFu4xUg" type="3010" element="_qWeY0DzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaSh0TzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaSh0jzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaSh0zzsEeyX-opQFu4xUg" type="3010" element="_qWqmEDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaSh1DzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaSh1TzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaSh1jzsEeyX-opQFu4xUg" type="3010" element="_qWr0MDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaSh1zzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaSh2DzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaSh2TzsEeyX-opQFu4xUg" type="3010" element="_qWsbQTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaSh2jzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaSh2zzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaSh3DzsEeyX-opQFu4xUg" type="3010" element="_qWtpYDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaSh3TzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaSh3jzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaTI4DzsEeyX-opQFu4xUg" type="3010" element="_qWu3gTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaTI4TzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaTI4jzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaTI4zzsEeyX-opQFu4xUg" type="3010" element="_qWwFoDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaTI5DzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaTI5TzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaTI5jzsEeyX-opQFu4xUg" type="3010" element="_qWwssTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaTI5zzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaTI6DzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaTI6TzsEeyX-opQFu4xUg" type="3010" element="_qWx60DzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaTI6jzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaTI6zzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaTI7DzsEeyX-opQFu4xUg" type="3010" element="_qWyh4TzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaTI7TzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaTI7jzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaTv8DzsEeyX-opQFu4xUg" type="3010" element="_qWzI8TzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaTv8TzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaTv8jzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaTv8zzsEeyX-opQFu4xUg" type="3010" element="_qW0XEDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaTv9DzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaTv9TzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaTv9jzsEeyX-opQFu4xUg" type="3010" element="_qW0-ITzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaTv9zzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaTv-DzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaTv-TzsEeyX-opQFu4xUg" type="3010" element="_qW2MQDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaTv-jzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaTv-zzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaTv_DzsEeyX-opQFu4xUg" type="3010" element="_qW2zUDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaTv_TzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaTv_jzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaUXADzsEeyX-opQFu4xUg" type="3010" element="_qW3aYTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaUXATzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaUXAjzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaUXAzzsEeyX-opQFu4xUg" type="3010" element="_qW4ogDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaUXBDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaUXBTzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaUXBjzsEeyX-opQFu4xUg" type="3010" element="_qW5PkTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaUXBzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaUXCDzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaU-EDzsEeyX-opQFu4xUg" type="3010" element="_qW52oTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaU-ETzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaU-EjzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaU-EzzsEeyX-opQFu4xUg" type="3010" element="_qXHSADzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaU-FDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" italic="true"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaU-FTzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaU-FjzsEeyX-opQFu4xUg" type="3010" element="_qXH5ETzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaU-FzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" italic="true"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaU-GDzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaU-GTzsEeyX-opQFu4xUg" type="3010" element="_qXJHMDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaU-GjzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" italic="true"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaU-GzzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaU-HDzsEeyX-opQFu4xUg" type="3010" element="_qXJuQDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaU-HTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" italic="true"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaU-HjzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaVlIDzsEeyX-opQFu4xUg" type="3010" element="_qXKVUTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaVlITzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" italic="true"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaVlIjzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaVlIzzsEeyX-opQFu4xUg" type="3010" element="_qXK8YTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaVlJDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" italic="true"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaVlJTzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaVlJjzsEeyX-opQFu4xUg" type="3010" element="_qXMKgDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaVlJzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" italic="true"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaVlKDzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaWMMDzsEeyX-opQFu4xUg" type="3010" element="_qXNYoDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaWMMTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" italic="true"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaWMMjzsEeyX-opQFu4xUg"/>
-            </children>
-            <styles xmi:type="notation:SortingStyle" xmi:id="_qaL0JTzsEeyX-opQFu4xUg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_qaL0JjzsEeyX-opQFu4xUg"/>
-          </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_qaL0ITzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaL0IjzsEeyX-opQFu4xUg" x="446" y="99"/>
-        </children>
-        <children xmi:type="notation:Node" xmi:id="_qaL0JzzsEeyX-opQFu4xUg" type="2003" element="_qWC7ATzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaMbMDzsEeyX-opQFu4xUg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_qaMbMTzsEeyX-opQFu4xUg" type="7004">
-            <styles xmi:type="notation:SortingStyle" xmi:id="_qaMbMjzsEeyX-opQFu4xUg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_qaMbMzzsEeyX-opQFu4xUg"/>
-          </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_qaL0KDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaL0KTzsEeyX-opQFu4xUg" x="450"/>
-        </children>
-        <children xmi:type="notation:Node" xmi:id="_qaMbNDzsEeyX-opQFu4xUg" type="2003" element="_qWEJIjzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaMbNzzsEeyX-opQFu4xUg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_qaNCQDzsEeyX-opQFu4xUg" type="7004">
-            <styles xmi:type="notation:SortingStyle" xmi:id="_qaNCQTzsEeyX-opQFu4xUg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_qaNCQjzsEeyX-opQFu4xUg"/>
-          </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_qaMbNTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaMbNjzsEeyX-opQFu4xUg" x="650"/>
-        </children>
-        <children xmi:type="notation:Node" xmi:id="_qaOQYDzsEeyX-opQFu4xUg" type="2003" element="_qWFXQTzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaO3cDzsEeyX-opQFu4xUg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_qaPegDzsEeyX-opQFu4xUg" type="7004">
-            <styles xmi:type="notation:SortingStyle" xmi:id="_qaPegTzsEeyX-opQFu4xUg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_qaPegjzsEeyX-opQFu4xUg"/>
-          </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_qaOQYTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaOQYjzsEeyX-opQFu4xUg" x="549"/>
-        </children>
-        <children xmi:type="notation:Node" xmi:id="_qaPegzzsEeyX-opQFu4xUg" type="2003" element="_qWF-UjzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaQFkDzsEeyX-opQFu4xUg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_qaQFkTzsEeyX-opQFu4xUg" type="7004">
-            <styles xmi:type="notation:SortingStyle" xmi:id="_qaQFkjzsEeyX-opQFu4xUg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_qaQFkzzsEeyX-opQFu4xUg"/>
-          </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_qaPehDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaPehTzsEeyX-opQFu4xUg" x="628" y="486"/>
-        </children>
-        <children xmi:type="notation:Node" xmi:id="_qaQFlDzsEeyX-opQFu4xUg" type="2003" element="_qWHMcTzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaQFlzzsEeyX-opQFu4xUg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_qaQFmDzsEeyX-opQFu4xUg" type="7004">
-            <styles xmi:type="notation:SortingStyle" xmi:id="_qaQFmTzsEeyX-opQFu4xUg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_qaQFmjzsEeyX-opQFu4xUg"/>
-          </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_qaQFlTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaQFljzsEeyX-opQFu4xUg" x="413" y="486"/>
-        </children>
-        <children xmi:type="notation:Node" xmi:id="_qaQsoDzsEeyX-opQFu4xUg" type="2003" element="_qWIakDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaQsozzsEeyX-opQFu4xUg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_qaQspDzsEeyX-opQFu4xUg" type="7004">
-            <styles xmi:type="notation:SortingStyle" xmi:id="_qaQspTzsEeyX-opQFu4xUg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_qaQspjzsEeyX-opQFu4xUg"/>
-          </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_qaQsoTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaQsojzsEeyX-opQFu4xUg" x="378" y="585"/>
-        </children>
-        <children xmi:type="notation:Node" xmi:id="_qaRTsDzsEeyX-opQFu4xUg" type="2003" element="_qWLd4DzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaRTszzsEeyX-opQFu4xUg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_qaRTtDzsEeyX-opQFu4xUg" type="7004">
-            <styles xmi:type="notation:SortingStyle" xmi:id="_qaRTtTzsEeyX-opQFu4xUg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_qaRTtjzsEeyX-opQFu4xUg"/>
-          </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_qaRTsTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaRTsjzsEeyX-opQFu4xUg" x="513" y="486"/>
-        </children>
-        <children xmi:type="notation:Node" xmi:id="_qaRTtzzsEeyX-opQFu4xUg" type="2003" element="_qXWikDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaR6wDzsEeyX-opQFu4xUg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_qaR6wTzsEeyX-opQFu4xUg" type="7004">
-            <children xmi:type="notation:Node" xmi:id="_qaWMMzzsEeyX-opQFu4xUg" type="3010" element="_qXXJoDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaWMNDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaWMNTzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaWzQDzsEeyX-opQFu4xUg" type="3010" element="_qXfsgTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaWzQTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaWzQjzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaWzQzzsEeyX-opQFu4xUg" type="3010" element="_qXgTkTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaWzRDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaWzRTzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaWzRjzsEeyX-opQFu4xUg" type="3010" element="_qXg6oTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaWzRzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaWzSDzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaXaUDzsEeyX-opQFu4xUg" type="3010" element="_qXg6ozzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaXaUTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaXaUjzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaXaUzzsEeyX-opQFu4xUg" type="3010" element="_qXhhsTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaXaVDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaXaVTzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaXaVjzsEeyX-opQFu4xUg" type="3010" element="_qXiIwTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaXaVzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaXaWDzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaXaWTzsEeyX-opQFu4xUg" type="3010" element="_qXjW4DzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaXaWjzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaXaWzzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaXaXDzsEeyX-opQFu4xUg" type="3010" element="_qXj98TzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaXaXTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaXaXjzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaYBYDzsEeyX-opQFu4xUg" type="3010" element="_qXklATzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaYBYTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaYBYjzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaYBYzzsEeyX-opQFu4xUg" type="3010" element="_qXlMETzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaYBZDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaYBZTzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaYBZjzsEeyX-opQFu4xUg" type="3010" element="_qXmaMDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaYBZzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaYBaDzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaYocDzsEeyX-opQFu4xUg" type="3010" element="_qXnBQTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaYocTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaYocjzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaYoczzsEeyX-opQFu4xUg" type="3010" element="_qXnoUTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaYodDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaYodTzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaYodjzsEeyX-opQFu4xUg" type="3010" element="_qXoPYTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaYodzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaYoeDzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaYoeTzsEeyX-opQFu4xUg" type="3010" element="_qXpdgTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaYoejzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaYoezzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaZPgDzsEeyX-opQFu4xUg" type="3010" element="_qXqEkDzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaZPgTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaZPgjzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaZPgzzsEeyX-opQFu4xUg" type="3010" element="_qXqEkjzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaZPhDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaZPhTzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaZPhjzsEeyX-opQFu4xUg" type="3010" element="_qXqroTzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaZPhzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaZPiDzsEeyX-opQFu4xUg"/>
-            </children>
-            <styles xmi:type="notation:SortingStyle" xmi:id="_qaR6wjzsEeyX-opQFu4xUg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_qaR6wzzsEeyX-opQFu4xUg"/>
-          </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_qaRTuDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8" bold="true"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaRTuTzsEeyX-opQFu4xUg"/>
-        </children>
-        <children xmi:type="notation:Node" xmi:id="_qaR6xDzsEeyX-opQFu4xUg" type="2003" element="_qXrSsTzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaR6xzzsEeyX-opQFu4xUg" type="5007"/>
-          <children xmi:type="notation:Node" xmi:id="_qaR6yDzsEeyX-opQFu4xUg" type="7004">
-            <children xmi:type="notation:Node" xmi:id="_qaZPiTzsEeyX-opQFu4xUg" type="3010" element="_qXr5wjzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaZPijzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaZPizzsEeyX-opQFu4xUg"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_qaZ2kDzsEeyX-opQFu4xUg" type="3010" element="_qXsg0DzsEeyX-opQFu4xUg">
-              <styles xmi:type="notation:FontStyle" xmi:id="_qaZ2kTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_qaZ2kjzsEeyX-opQFu4xUg"/>
-            </children>
-            <styles xmi:type="notation:SortingStyle" xmi:id="_qaR6yTzsEeyX-opQFu4xUg"/>
-            <styles xmi:type="notation:FilteringStyle" xmi:id="_qaR6yjzsEeyX-opQFu4xUg"/>
-          </children>
-          <styles xmi:type="notation:ShapeStyle" xmi:id="_qaR6xTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="12" italic="true" underline="true"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaR6xjzsEeyX-opQFu4xUg" x="252"/>
-        </children>
-        <styles xmi:type="notation:DiagramStyle" xmi:id="_qVb3AjzsEeyX-opQFu4xUg"/>
-        <edges xmi:type="notation:Edge" xmi:id="_qaadoDzsEeyX-opQFu4xUg" type="4001" element="_qZf3oDzsEeyX-opQFu4xUg" source="_qaL0IDzsEeyX-opQFu4xUg" target="_qaL0JzzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaadpDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaadpTzsEeyX-opQFu4xUg" y="-10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qaadpjzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaadpzzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qaadqDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaadqTzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_qaadoTzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_qaadojzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qaadozzsEeyX-opQFu4xUg" points="[-1, 0, 74, 60]$[-76, -60, -1, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qabEsDzsEeyX-opQFu4xUg" id="(0.5026455026455027,0.0)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qabEsTzsEeyX-opQFu4xUg" id="(0.5263157894736842,1.0)"/>
-        </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_qabEsjzsEeyX-opQFu4xUg" type="4001" element="_qZ5gQDzsEeyX-opQFu4xUg" source="_qaL0IDzsEeyX-opQFu4xUg" target="_qaL0IDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qabrwzzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qabrxDzsEeyX-opQFu4xUg" y="-10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qabrxTzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qabrxjzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qabrxzzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qabryDzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_qabrwDzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_qabrwTzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qabrwjzsEeyX-opQFu4xUg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qacS0DzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qacS0TzsEeyX-opQFu4xUg" id="(0.5,0.5)"/>
-        </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_qacS0jzsEeyX-opQFu4xUg" type="4001" element="_qZ6uYDzsEeyX-opQFu4xUg" source="_qaL0IDzsEeyX-opQFu4xUg" target="_qaMbNDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qac54DzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qac54TzsEeyX-opQFu4xUg" y="-10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qac54jzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qac54zzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qac55DzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qac55TzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_qacS0zzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_qacS1DzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qacS1TzsEeyX-opQFu4xUg" points="[-1, 0, -126, 60]$[124, -60, -1, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qadg8DzsEeyX-opQFu4xUg" id="(0.5026455026455027,0.0)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qadg8TzsEeyX-opQFu4xUg" id="(0.5263157894736842,1.0)"/>
-        </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_qaeIADzsEeyX-opQFu4xUg" type="4001" element="_qZ78gDzsEeyX-opQFu4xUg" source="_qaL0IDzsEeyX-opQFu4xUg" target="_qaOQYDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaeIBDzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaeIBTzsEeyX-opQFu4xUg" y="-10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qaeIBjzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaeIBzzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qaeICDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaeICTzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_qaeIATzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_qaeIAjzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qaeIAzzsEeyX-opQFu4xUg" points="[-1, 0, -26, 60]$[24, -60, -1, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qaevEDzsEeyX-opQFu4xUg" id="(0.5026455026455027,0.0)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qafWIDzsEeyX-opQFu4xUg" id="(0.5263157894736842,1.0)"/>
-        </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_qafWITzsEeyX-opQFu4xUg" type="4001" element="_qaFtgDzsEeyX-opQFu4xUg" source="_qaL0JzzsEeyX-opQFu4xUg" target="_qaL0IDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qafWJTzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qafWJjzsEeyX-opQFu4xUg" y="-10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qafWJzzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qafWKDzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qafWKTzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qafWKjzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_qafWIjzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_qafWIzzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qafWJDzsEeyX-opQFu4xUg" points="[-1, 0, -76, -60]$[74, 60, -1, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qaf9MDzsEeyX-opQFu4xUg" id="(0.5263157894736842,1.0)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qaf9MTzsEeyX-opQFu4xUg" id="(0.5026455026455027,0.0)"/>
-        </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_qaf9MjzsEeyX-opQFu4xUg" type="4001" element="_qaGUkjzsEeyX-opQFu4xUg" source="_qaPegzzsEeyX-opQFu4xUg" target="_qaL0IDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qaf9NjzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaf9NzzsEeyX-opQFu4xUg" y="-10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qaf9ODzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaf9OTzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qagkQDzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qagkQTzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_qaf9MzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_qaf9NDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qaf9NTzsEeyX-opQFu4xUg" points="[-1, 0, 118, 60]$[-120, -60, -1, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qahLUDzsEeyX-opQFu4xUg" id="(0.5172413793103449,0.0)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qahLUTzsEeyX-opQFu4xUg" id="(0.5026455026455027,1.0)"/>
-        </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_qahLUjzsEeyX-opQFu4xUg" type="4001" element="_qaGUlzzsEeyX-opQFu4xUg" source="_qaQFlDzsEeyX-opQFu4xUg" target="_qaL0IDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qahLVjzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qahLVzzsEeyX-opQFu4xUg" y="-10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qahLWDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qahLWTzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qahLWjzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qahLWzzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_qahLUzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_qahLVDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qahLVTzsEeyX-opQFu4xUg" points="[-1, 0, -110, 60]$[108, -60, -1, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qahyYDzsEeyX-opQFu4xUg" id="(0.5263157894736842,0.0)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qahyYTzsEeyX-opQFu4xUg" id="(0.5026455026455027,1.0)"/>
-        </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_qahyYjzsEeyX-opQFu4xUg" type="4001" element="_qaG7ojzsEeyX-opQFu4xUg" source="_qaQsoDzsEeyX-opQFu4xUg" target="_qaQFlDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qahyZjzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qahyZzzsEeyX-opQFu4xUg" y="-10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qaiZcDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaiZcTzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qaiZcjzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qaiZczzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_qahyYzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_qahyZDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qahyZTzsEeyX-opQFu4xUg" points="[-1, 0, -1, 60]$[-1, -60, -1, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qajAgDzsEeyX-opQFu4xUg" id="(0.5208333333333334,0.0)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qajAgTzsEeyX-opQFu4xUg" id="(0.5263157894736842,1.0)"/>
-        </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_qajAgjzsEeyX-opQFu4xUg" type="4001" element="_qaG7pzzsEeyX-opQFu4xUg" source="_qaRTsDzsEeyX-opQFu4xUg" target="_qaL0IDzsEeyX-opQFu4xUg">
-          <children xmi:type="notation:Node" xmi:id="_qajAhjzsEeyX-opQFu4xUg" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qajAhzzsEeyX-opQFu4xUg" y="-10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qajAiDzsEeyX-opQFu4xUg" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qajAiTzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <children xmi:type="notation:Node" xmi:id="_qajAijzsEeyX-opQFu4xUg" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qajAizzsEeyX-opQFu4xUg" y="10"/>
-          </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_qajAgzzsEeyX-opQFu4xUg"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_qajAhDzsEeyX-opQFu4xUg" fontName=".AppleSystemUIFont" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qajAhTzsEeyX-opQFu4xUg" points="[-1, 0, -1, 60]$[-1, -60, -1, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qajnkDzsEeyX-opQFu4xUg" id="(0.5178571428571429,0.0)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qajnkTzsEeyX-opQFu4xUg" id="(0.5026455026455027,1.0)"/>
-        </edges>
-      </data>
-    </ownedAnnotationEntries>
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_qaHisDzsEeyX-opQFu4xUg" source="DANNOTATION_CUSTOMIZATION_KEY">
-      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_qaHisTzsEeyX-opQFu4xUg"/>
-    </ownedAnnotationEntries>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_qV1foDzsEeyX-opQFu4xUg" name="ChangeRequest" outgoingEdges="_qZf3oDzsEeyX-opQFu4xUg _qZ5gQDzsEeyX-opQFu4xUg _qZ6uYDzsEeyX-opQFu4xUg _qZ78gDzsEeyX-opQFu4xUg" incomingEdges="_qZ5gQDzsEeyX-opQFu4xUg _qaFtgDzsEeyX-opQFu4xUg _qaGUkjzsEeyX-opQFu4xUg _qaGUlzzsEeyX-opQFu4xUg _qaG7pzzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poJRUJUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poJRUJUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_qWCT8DzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWeY0DzsEeyX-opQFu4xUg" name="oslc:shortTitle: XMLLiteral">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnaRgZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnaRgZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWp_ADzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWqmEDzsEeyX-opQFu4xUg" name="dcterms:description: XMLLiteral">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMpUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWrNIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWr0MDzsEeyX-opQFu4xUg" name="dcterms:title: XMLLiteral">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZDYJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWsbQDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWsbQTzsEeyX-opQFu4xUg" name="dcterms:identifier: String">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnX1QJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnX1QJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWtCUDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWtpYDzsEeyX-opQFu4xUg" name="dcterms:subject: String []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnYcUZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnYcUZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWu3gDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWu3gTzsEeyX-opQFu4xUg" name="dcterms:created: DateTime">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnXOMZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWvekDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWwFoDzsEeyX-opQFu4xUg" name="dcterms:modified: DateTime">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnYcUJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnYcUJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWwssDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWwssTzsEeyX-opQFu4xUg" name="oslc:serviceProvider: Resource []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqdJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqdJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWxTwDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWx60DzsEeyX-opQFu4xUg" name="oslc:instanceShape: Resource []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqcpUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pnZqcpUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWyh4DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWyh4TzsEeyX-opQFu4xUg" name="closeDate: DateTime">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWzI8DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qWzI8TzsEeyX-opQFu4xUg" name="status: String">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qWzwADzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qW0XEDzsEeyX-opQFu4xUg" name="closed: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YpUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YpUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qW0-IDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qW0-ITzsEeyX-opQFu4xUg" name="inProgress: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4Y5UdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4Y5UdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qW1lMDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qW2MQDzsEeyX-opQFu4xUg" name="fixed: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qW2MQTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qW2zUDzsEeyX-opQFu4xUg" name="approved: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qW3aYDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qW3aYTzsEeyX-opQFu4xUg" name="reviewed: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcpUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcpUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qW4BcDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qW4ogDzsEeyX-opQFu4xUg" name="verified: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfc5UdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfc5UdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qW5PkDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qW5PkTzsEeyX-opQFu4xUg" name="relatedChangeRequest: Resource []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qW52oDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qW52oTzsEeyX-opQFu4xUg" name="affectsPlanItem: Resource []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qW6dsDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" color="0,0,0">
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.LiteralProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXHSADzsEeyX-opQFu4xUg" name="authorizer: Agent []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qXH5EDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-          <labelFormat>italic</labelFormat>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXH5ETzsEeyX-opQFu4xUg" name="oslc:discussedBy: Discussion">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poTpYZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poTpYZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qXIgIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-          <labelFormat>italic</labelFormat>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXJHMDzsEeyX-opQFu4xUg" name="tracksRequirement: Requirement []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfeJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfeJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qXJHMTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-          <labelFormat>italic</labelFormat>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXJuQDzsEeyX-opQFu4xUg" name="implementsRequirement: Requirement []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qXKVUDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-          <labelFormat>italic</labelFormat>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXKVUTzsEeyX-opQFu4xUg" name="dcterms:creator: Person []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qXK8YDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-          <labelFormat>italic</labelFormat>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXK8YTzsEeyX-opQFu4xUg" name="dcterms:contributor: Person []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_pna4kZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qXLjcDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-          <labelFormat>italic</labelFormat>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXMKgDzsEeyX-opQFu4xUg" name="affectsRequirement: Requirement []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qXMxkDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-          <labelFormat>italic</labelFormat>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXNYoDzsEeyX-opQFu4xUg" name="tracksChangeSet: ChangeSet []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfd5UdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfd5UdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:Square" uid="_qXOmwDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" borderColor="114,73,110" color="0,0,0">
-          <labelFormat>italic</labelFormat>
-          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@subNodeMappings[name='DomainSpecification.Resource.ReferenceProperty']"/>
-      </ownedElements>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_qWC7ATzsEeyX-opQFu4xUg" name="Defect" outgoingEdges="_qaFtgDzsEeyX-opQFu4xUg" incomingEdges="_qZf3oDzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLGgpUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLGgpUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_qWEJIDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_qWEJIjzsEeyX-opQFu4xUg" name="Priority" incomingEdges="_qZ6uYDzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkJUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkJUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_qWEwMDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_qWFXQTzsEeyX-opQFu4xUg" name="State" incomingEdges="_qZ78gDzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkZUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkZUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_qWF-UDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_qWF-UjzsEeyX-opQFu4xUg" name="ChangeNotice" outgoingEdges="_qaGUkjzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkpUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkpUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_qWGlYDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_qWHMcTzsEeyX-opQFu4xUg" name="Task" outgoingEdges="_qaGUlzzsEeyX-opQFu4xUg" incomingEdges="_qaG7ojzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtk5UdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtk5UdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_qWHzgDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_qWIakDzsEeyX-opQFu4xUg" name="ReviewTask" outgoingEdges="_qaG7ojzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoJUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoJUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_qWJosDzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_qWLd4DzsEeyX-opQFu4xUg" name="Enhancement" outgoingEdges="_qaG7pzzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoZUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoZUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_qWME8DzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1" foregroundColor="255,255,255">
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']/@style"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.Resource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_qXWikDzsEeyX-opQFu4xUg" name="Property Constraints">
-      <target xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']"/>
-      <semanticElements xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_qXWikTzsEeyX-opQFu4xUg" showIcon="false" borderSize="1" borderSizeComputationExpression="1">
-        <labelFormat>bold</labelFormat>
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@style"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXXJoDzsEeyX-opQFu4xUg" name="closeDate: DateTime">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXfsgDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXfsgTzsEeyX-opQFu4xUg" name="status: String">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXgTkDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXgTkTzsEeyX-opQFu4xUg" name="closed: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YpUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4YpUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXg6oDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXg6oTzsEeyX-opQFu4xUg" name="inProgress: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4Y5UdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poJ4Y5UdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXg6ojzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXg6ozzsEeyX-opQFu4xUg" name="fixed: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXhhsDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXhhsTzsEeyX-opQFu4xUg" name="approved: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXiIwDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXiIwTzsEeyX-opQFu4xUg" name="reviewed: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcpUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfcpUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXiv0DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXjW4DzsEeyX-opQFu4xUg" name="verified: Boolean">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfc5UdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfc5UdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXj98DzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXj98TzsEeyX-opQFu4xUg" name="relatedChangeRequest: Resource []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXklADzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXklATzsEeyX-opQFu4xUg" name="affectsPlanItem: Resource []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXlMEDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXlMETzsEeyX-opQFu4xUg" name="affectedByDefect: Defect []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poNiwJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poNiwJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXlzIDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXmaMDzsEeyX-opQFu4xUg" name="tracksRequirement: Requirement []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfeJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfeJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXnBQDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXnBQTzsEeyX-opQFu4xUg" name="implementsRequirement: Requirement []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgJUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXnoUDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXnoUTzsEeyX-opQFu4xUg" name="affectsRequirement: Requirement []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poLGgZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXoPYDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXoPYTzsEeyX-opQFu4xUg" name="tracksChangeSet: ChangeSet []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfd5UdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfd5UdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXpdgDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXpdgTzsEeyX-opQFu4xUg" name="parent: ChangeRequest []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0JUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0JUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXpdgjzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXqEkDzsEeyX-opQFu4xUg" name="priority: Priority []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0ZUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0ZUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXqEkTzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXqEkjzsEeyX-opQFu4xUg" name="state: State">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0pUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0pUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXqroDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXqroTzsEeyX-opQFu4xUg" name="authorizer: Agent []">
-        <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
-        <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poKfdpUdEeq-KoPaR9_Cfg"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXrSsDzsEeyX-opQFu4xUg" labelSize="9" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.PropertiesList']/@subNodeMappings[name='DomainSpecification.PropertiesList.Property']"/>
-      </ownedElements>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_qXrSsTzsEeyX-opQFu4xUg" name="Configuration">
-      <target xmi:type="oslc4j_ai:MavenSpecificationConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration"/>
-      <semanticElements xmi:type="oslc4j_ai:MavenSpecificationConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_qXr5wDzsEeyX-opQFu4xUg" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,255,255">
-        <labelFormat>italic</labelFormat>
-        <labelFormat>underline</labelFormat>
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@style"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXr5wjzsEeyX-opQFu4xUg" name="General">
-        <target xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration/@generalConfiguration"/>
-        <semanticElements xmi:type="oslc4j_ai:GeneralConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration/@generalConfiguration"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXr5wzzsEeyX-opQFu4xUg" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='SpecificationConfiguration.GeneralConfiguration']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='SpecificationConfiguration.GeneralConfiguration']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" uid="_qXsg0DzsEeyX-opQFu4xUg" name="Project Configuration">
-        <target xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration/@projectConfiguration"/>
-        <semanticElements xmi:type="oslc4j_ai:MavenProjectConfiguration" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']/@configuration/@projectConfiguration"/>
-        <ownedStyle xmi:type="diagram:BundledImage" uid="_qXsg0TzsEeyX-opQFu4xUg" showIcon="false" labelAlignment="LEFT" labelPosition="node">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='SpecificationConfiguration.ProjectConfiguration']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@containerMappings[name='DomainSpecification.SpecificationConfiguration']/@subNodeMappings[name='SpecificationConfiguration.ProjectConfiguration']"/>
-      </ownedElements>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_qZf3oDzsEeyX-opQFu4xUg" name="affectedByDefect" sourceNode="_qV1foDzsEeyX-opQFu4xUg" targetNode="_qWC7ATzsEeyX-opQFu4xUg" endLabel="0..*">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poNiwJUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poNiwJUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_qZoagDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_qZoagjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_qZoagTzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_qZ5gQDzsEeyX-opQFu4xUg" name="parent" sourceNode="_qV1foDzsEeyX-opQFu4xUg" targetNode="_qV1foDzsEeyX-opQFu4xUg" endLabel="0..*">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0JUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0JUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_qZ6HUDzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_qZ6HUjzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_qZ6HUTzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_qZ6uYDzsEeyX-opQFu4xUg" name="priority" sourceNode="_qV1foDzsEeyX-opQFu4xUg" targetNode="_qWEJIjzsEeyX-opQFu4xUg" endLabel="0..*">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0ZUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0ZUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_qZ6uYTzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_qZ7VcDzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_qZ6uYjzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_qZ78gDzsEeyX-opQFu4xUg" name="state" sourceNode="_qV1foDzsEeyX-opQFu4xUg" targetNode="_qWFXQTzsEeyX-opQFu4xUg" endLabel="0..1">
-      <target xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0pUdEeq-KoPaR9_Cfg"/>
-      <semanticElements xmi:type="oslc4j_ai:ResourceProperty" href="oslcDomainSpecifications.xml#_poOJ0pUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_qZ78gTzsEeyX-opQFu4xUg" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']/@conditionnalStyles.0/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_qZ78gzzsEeyX-opQFu4xUg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_qZ78gjzsEeyX-opQFu4xUg" showIcon="false"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToReferenceProperty']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_qaFtgDzsEeyX-opQFu4xUg" sourceNode="_qWC7ATzsEeyX-opQFu4xUg" targetNode="_qV1foDzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLGgpUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_qaFtgTzsEeyX-opQFu4xUg" targetArrow="InputClosedArrow" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_qaFtgjzsEeyX-opQFu4xUg"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_qaGUkjzsEeyX-opQFu4xUg" sourceNode="_qWF-UjzsEeyX-opQFu4xUg" targetNode="_qV1foDzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtkpUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_qaGUkzzsEeyX-opQFu4xUg" targetArrow="InputClosedArrow" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_qaGUlDzsEeyX-opQFu4xUg"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_qaGUlzzsEeyX-opQFu4xUg" sourceNode="_qWHMcTzsEeyX-opQFu4xUg" targetNode="_qV1foDzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poLtk5UdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_qaGUmDzsEeyX-opQFu4xUg" targetArrow="InputClosedArrow" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_qaGUmTzsEeyX-opQFu4xUg"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_qaG7ojzsEeyX-opQFu4xUg" sourceNode="_qWIakDzsEeyX-opQFu4xUg" targetNode="_qWHMcTzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoJUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_qaG7ozzsEeyX-opQFu4xUg" targetArrow="InputClosedArrow" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_qaG7pDzsEeyX-opQFu4xUg"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']"/>
-    </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_qaG7pzzsEeyX-opQFu4xUg" sourceNode="_qWLd4DzsEeyX-opQFu4xUg" targetNode="_qV1foDzsEeyX-opQFu4xUg">
-      <target xmi:type="oslc4j_ai:Resource" href="oslcDomainSpecifications.xml#_poMUoZUdEeq-KoPaR9_Cfg"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_qaG7qDzsEeyX-opQFu4xUg" targetArrow="InputClosedArrow" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_qaG7qTzsEeyX-opQFu4xUg"/>
-      </ownedStyle>
-      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer/@edgeMappings[name='DomainSpecification.ResourceToParentResource']"/>
-    </ownedDiagramElements>
-    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']"/>
-    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_qU4dYDzsEeyX-opQFu4xUg"/>
-    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign#//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='DomainSpecificationDiagram']/@defaultLayer"/>
-    <target xmi:type="oslc4j_ai:DomainSpecification" href="oslcDomainSpecifications.xml#//@domainSpecifications[name='Change%20Management%20shapes']"/>
   </diagram:DSemanticDiagram>
 </xmi:XMI>


### PR DESCRIPTION
## Description

reverting back to previous version of Lyo models. Latest update assumed a new version of Sirius than that LyoDEsigner supports.

See https://github.com/eclipse/lyo/commit/23805817107933abe1666ee9b05573961f2bef0e

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [X] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [X] This PR does NOT break the API

