### PR TITLE
Implemented isReadable on  Oslc XML/RDF Providers 

### DIFF
--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/AbstractOslcRdfXmlProvider.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/AbstractOslcRdfXmlProvider.java
@@ -20,6 +20,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
@@ -29,6 +30,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Providers;
+
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFReader;
@@ -37,6 +39,7 @@ import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.util.FileUtils;
 import org.eclipse.lyo.oslc4j.core.OSLC4JConstants;
 import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.exception.MessageExtractor;
 import org.eclipse.lyo.oslc4j.core.model.Error;
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
@@ -48,388 +51,329 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author Russell Boykin, Alberto Giammaria, Chris Peters, Gianluca Bernardini, Andrew Berezovskyi
+ * @author Russell Boykin, Alberto Giammaria, Chris Peters, Gianluca Bernardini,
+ *         Andrew Berezovskyi
  */
-public abstract class AbstractOslcRdfXmlProvider
-{
-	private static final Logger log = LoggerFactory.getLogger(AbstractOslcRdfXmlProvider.class.getName
-			());
+public abstract class AbstractOslcRdfXmlProvider {
+    private static final Logger log = LoggerFactory.getLogger(AbstractOslcRdfXmlProvider.class.getName());
 
-	/**
-	 * System property {@value} : When "true", always abbreviate RDF/XML, even
-	 * when asked for application/rdf+xml. Otherwise, abbreviated RDF/XML is
-	 * only returned when application/xml is requested. Does not affect
-	 * text/turtle responses.
-	 *
-	 * @see RdfXmlAbbreviatedWriter
-	 */
-	@Deprecated
-	public static final String OSLC4J_ALWAYS_XML_ABBREV		  = "org.eclipse.lyo.oslc4j.alwaysXMLAbbrev";
+    /**
+     * System property {@value} : When "true", always abbreviate RDF/XML, even when
+     * asked for application/rdf+xml. Otherwise, abbreviated RDF/XML is only
+     * returned when application/xml is requested. Does not affect text/turtle
+     * responses.
+     *
+     * @see RdfXmlAbbreviatedWriter
+     */
+    @Deprecated
+    public static final String OSLC4J_ALWAYS_XML_ABBREV = "org.eclipse.lyo.oslc4j.alwaysXMLAbbrev";
 
-	/**
-	 * System property {@value} : When "true" (default), fail on when reading a
-	 * property value that is not a legal instance of a datatype. When "false",
-	 * skip over invalid values in extended properties.
-	 */
-	@Deprecated
-	public static final String OSLC4J_STRICT_DATATYPES		 = "org.eclipse.lyo.oslc4j.strictDatatypes";
+    /**
+     * System property {@value} : When "true" (default), fail on when reading a
+     * property value that is not a legal instance of a datatype. When "false", skip
+     * over invalid values in extended properties.
+     */
+    @Deprecated
+    public static final String OSLC4J_STRICT_DATATYPES = "org.eclipse.lyo.oslc4j.strictDatatypes";
 
-	private static final Annotation[] ANNOTATIONS_EMPTY_ARRAY = new Annotation[0];
-	private static final Class<Error> CLASS_OSLC_ERROR		  = Error.class;
-	private static final ErrorHandler ERROR_HANDLER			  = new ErrorHandler();
+    private static final Annotation[] ANNOTATIONS_EMPTY_ARRAY = new Annotation[0];
+    private static final Class<Error> CLASS_OSLC_ERROR = Error.class;
+    private static final ErrorHandler ERROR_HANDLER = new ErrorHandler();
 
-	private @Context HttpHeaders		  httpHeaders;		  // Available only on the server
-	protected @Context HttpServletRequest httpServletRequest; // Available only on the server
-	private @Context Providers			  providers;		  // Available on both client and server
+    private @Context HttpHeaders httpHeaders; // Available only on the server
+    protected @Context HttpServletRequest httpServletRequest; // Available only on the server
+    private @Context Providers providers; // Available on both client and server
 
-	protected AbstractOslcRdfXmlProvider()
-	{
-		super();
-	}
+    protected AbstractOslcRdfXmlProvider() {
+        super();
+    }
 
-	protected void writeTo(final Object[]						objects,
-						   final MediaType						baseMediaType,
-						   final MultivaluedMap<String, Object> map,
-						   final OutputStream					outputStream,
-						   final Map<String, Object>			properties,
-						   final String							descriptionURI,
-						   final String							responseInfoURI,
-						   final ResponseInfo<?>				responseInfo)
-				throws WebApplicationException
-	{
-		String serializationLanguage = getSerializationLanguage(baseMediaType);
+    protected void writeTo(final Object[] objects, final MediaType baseMediaType,
+            final MultivaluedMap<String, Object> map, final OutputStream outputStream,
+            final Map<String, Object> properties, final String descriptionURI, final String responseInfoURI,
+            final ResponseInfo<?> responseInfo) throws WebApplicationException {
+        String serializationLanguage = getSerializationLanguage(baseMediaType);
 
-		// This is a special case to handle RDNG GET on a ServiceProvider resource.
-		// RDNG can only consume RDF/XML-ABBREV although its sometimes sends Accept=application/rdf+xml.
-		// The org.eclipse.lyo.oslc4j.alwaysXMLAbbrevOnlyProviders system property is used
-		// to turn off this special case
-		if ((objects != null && objects[0] != null) &&
-			( objects[0] instanceof ServiceProviderCatalog || objects[0] instanceof ServiceProvider ) &&
-			serializationLanguage.equals(FileUtils.langXML) &&
-			"true".equals(System.getProperty("org.eclipse.lyo.oslc4j.alwaysXMLAbbrevOnlyProviders"))) {
-			serializationLanguage = FileUtils.langXMLAbbrev;
-			log.info("Using RDF/XML-ABBREV for ServiceProvider resources");
-		}
-
-		writeObjectsTo(objects,
-					   outputStream,
-					   properties,
-					   descriptionURI,
-					   responseInfoURI,
-					   responseInfo,
-					   serializationLanguage
-		);
-	}
-
-	private void writeObjectsTo(final Object[] objects, final OutputStream outputStream,
-			final Map<String, Object> properties, final String descriptionURI,
-			final String responseInfoURI, final ResponseInfo<?> responseInfo,
-			final String serializationLanguage) {
-		try
-		{
-			final Model model = JenaModelHelper.createJenaModel(descriptionURI,
-																responseInfoURI,
-																responseInfo,
-																objects,
-																properties);
-			RDFWriter writer = getRdfWriter(serializationLanguage, model);
-
-			if (serializationLanguage.equals(FileUtils.langXML) || serializationLanguage.equals(FileUtils.langXMLAbbrev))
-			{
-				// XML (and Jena) default to UTF-8, but many libs default to ASCII, so need
-				// to set this explicitly
-				writer.setProperty("showXmlDeclaration",
-								   "false");
-				String xmlDeclaration = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-				outputStream.write(xmlDeclaration.getBytes());
-			}
-			writer.write(model,
-						 outputStream,
-						 null);
-		}
-		catch (final Exception exception)
-		{
-			log.warn(MessageExtractor.getMessage("ErrorSerializingResource"));
-			throw new IllegalStateException(exception);
-		}
-	}
-
-	private RDFWriter getRdfWriter(final String serializationLanguage, final Model model) {
-		RDFWriter writer;
-		if	(serializationLanguage.equals(FileUtils.langXMLAbbrev))
-        {
-            writer = new RdfXmlAbbreviatedWriter();
+        // This is a special case to handle RDNG GET on a ServiceProvider resource.
+        // RDNG can only consume RDF/XML-ABBREV although its sometimes sends
+        // Accept=application/rdf+xml.
+        // The org.eclipse.lyo.oslc4j.alwaysXMLAbbrevOnlyProviders system property is
+        // used
+        // to turn off this special case
+        if ((objects != null && objects[0] != null)
+                && (objects[0] instanceof ServiceProviderCatalog || objects[0] instanceof ServiceProvider)
+                && serializationLanguage.equals(FileUtils.langXML)
+                && "true".equals(System.getProperty("org.eclipse.lyo.oslc4j.alwaysXMLAbbrevOnlyProviders"))) {
+            serializationLanguage = FileUtils.langXMLAbbrev;
+            log.info("Using RDF/XML-ABBREV for ServiceProvider resources");
         }
-        else
-        {
+
+        writeObjectsTo(objects, outputStream, properties, descriptionURI, responseInfoURI, responseInfo,
+                serializationLanguage);
+    }
+
+    private void writeObjectsTo(final Object[] objects, final OutputStream outputStream,
+            final Map<String, Object> properties, final String descriptionURI, final String responseInfoURI,
+            final ResponseInfo<?> responseInfo, final String serializationLanguage) {
+        try {
+            final Model model = JenaModelHelper.createJenaModel(descriptionURI, responseInfoURI, responseInfo, objects,
+                    properties);
+            RDFWriter writer = getRdfWriter(serializationLanguage, model);
+
+            if (serializationLanguage.equals(FileUtils.langXML)
+                    || serializationLanguage.equals(FileUtils.langXMLAbbrev)) {
+                // XML (and Jena) default to UTF-8, but many libs default to ASCII, so need
+                // to set this explicitly
+                writer.setProperty("showXmlDeclaration", "false");
+                String xmlDeclaration = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+                outputStream.write(xmlDeclaration.getBytes());
+            }
+            writer.write(model, outputStream, null);
+        } catch (final Exception exception) {
+            log.warn(MessageExtractor.getMessage("ErrorSerializingResource"));
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private RDFWriter getRdfWriter(final String serializationLanguage, final Model model) {
+        RDFWriter writer;
+        if (serializationLanguage.equals(FileUtils.langXMLAbbrev)) {
+            writer = new RdfXmlAbbreviatedWriter();
+        } else {
             writer = model.getWriter(serializationLanguage);
         }
-		writer.setProperty("showXmlDeclaration",
-                           "false");
-		writer.setErrorHandler(ERROR_HANDLER);
-		return writer;
-	}
+        writer.setProperty("showXmlDeclaration", "false");
+        writer.setErrorHandler(ERROR_HANDLER);
+        return writer;
+    }
 
-	protected void writeTo(final boolean						queryResult,
-						   final Object[]						objects,
-						   final MediaType						baseMediaType,
-						   final MultivaluedMap<String, Object> map,
-						   final OutputStream					outputStream)
-			  throws WebApplicationException
-	{
-		boolean isClientSide = false;
+    protected void writeTo(final boolean queryResult, final Object[] objects, final MediaType baseMediaType,
+            final MultivaluedMap<String, Object> map, final OutputStream outputStream) throws WebApplicationException {
+        boolean isClientSide = false;
 
-		try {
-			httpServletRequest.getMethod();
-		} catch (RuntimeException e) {
-			isClientSide = true;
-		}
+        try {
+            httpServletRequest.getMethod();
+        } catch (RuntimeException e) {
+            isClientSide = true;
+        }
 
-		String descriptionURI  = null;
-		// TODO Andrew@2019-04-18: stop using responseInfoURI nullity to detect Query results
-		String responseInfoURI = null;
+        String descriptionURI = null;
+        // TODO Andrew@2019-04-18: stop using responseInfoURI nullity to detect Query
+        // results
+        String responseInfoURI = null;
 
-		if (queryResult && ! isClientSide)
-		{
-			log.trace("Marshalling response objects as OSLC Query result (server-side only)");
+        if (queryResult && !isClientSide) {
+            log.trace("Marshalling response objects as OSLC Query result (server-side only)");
 
-			final String method = httpServletRequest.getMethod();
-			if ("GET".equals(method))
-			{
-				descriptionURI =  OSLC4JUtils.resolveURI(httpServletRequest,true);
-				responseInfoURI = descriptionURI;
+            final String method = httpServletRequest.getMethod();
+            if ("GET".equals(method)) {
+                descriptionURI = OSLC4JUtils.resolveURI(httpServletRequest, true);
+                responseInfoURI = descriptionURI;
 
-				final String queryString = httpServletRequest.getQueryString();
-				if ((queryString != null) &&
-					(ProviderHelper.isOslcQuery(queryString)))
-				{
-					responseInfoURI += "?" + queryString;
-				}
-			}
+                final String queryString = httpServletRequest.getQueryString();
+                if ((queryString != null) && (ProviderHelper.isOslcQuery(queryString))) {
+                    responseInfoURI += "?" + queryString;
+                }
+            }
 
-		}
+        }
 
-		final String serializationLanguage = getSerializationLanguage(baseMediaType);
+        final String serializationLanguage = getSerializationLanguage(baseMediaType);
 
-		@SuppressWarnings("unchecked")
-		final Map<String, Object> properties = isClientSide ?
-			null :
-			(Map<String, Object>)httpServletRequest.getAttribute(OSLC4JConstants.OSLC4J_SELECTED_PROPERTIES);
-		final String nextPageURI = isClientSide ?
-			null :
-			(String)httpServletRequest.getAttribute(OSLC4JConstants.OSLC4J_NEXT_PAGE);
-		final Integer totalCount = isClientSide ?
-			null :
-			(Integer)httpServletRequest.getAttribute(OSLC4JConstants.OSLC4J_TOTAL_COUNT);
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> properties = isClientSide ? null
+                : (Map<String, Object>) httpServletRequest.getAttribute(OSLC4JConstants.OSLC4J_SELECTED_PROPERTIES);
+        final String nextPageURI = isClientSide ? null
+                : (String) httpServletRequest.getAttribute(OSLC4JConstants.OSLC4J_NEXT_PAGE);
+        final Integer totalCount = isClientSide ? null
+                : (Integer) httpServletRequest.getAttribute(OSLC4JConstants.OSLC4J_TOTAL_COUNT);
 
-		ResponseInfo<?> responseInfo = new ResponseInfoArray<>(null, properties, totalCount,
-				nextPageURI);
+        ResponseInfo<?> responseInfo = new ResponseInfoArray<>(null, properties, totalCount, nextPageURI);
 
-		writeObjectsTo(
-				objects,
-				outputStream,
-				properties,
-				descriptionURI,
-				responseInfoURI,
-				responseInfo,
-				serializationLanguage
-		);
-	}
+        writeObjectsTo(objects, outputStream, properties, descriptionURI, responseInfoURI, responseInfo,
+                serializationLanguage);
+    }
 
-	/**
-	 * Determine whether to serialize in xml or abreviated xml based upon mediatype.
-	 * <p>
-	 * application/rdf+xml yields xml
-	 * <p>
-	 * applicaton/xml yields abbreviated xml
-	 */
-	private String getSerializationLanguage(final MediaType baseMediaType) {
+    /**
+     * Determine whether to serialize in xml or abreviated xml based upon mediatype.
+     * <p>
+     * application/rdf+xml yields xml
+     * <p>
+     * applicaton/xml yields abbreviated xml
+     */
+    private String getSerializationLanguage(final MediaType baseMediaType) {
 
-		if(baseMediaType == null) {
-			throw new IllegalArgumentException("Base media type can't be null");
-		}
+        if (baseMediaType == null) {
+            throw new IllegalArgumentException("Base media type can't be null");
+        }
 
-		List<Map.Entry<MediaType, String>> mediaPairs = new ArrayList<>();
-		mediaPairs.add(new AbstractMap.SimpleEntry<>(OslcMediaType.TEXT_TURTLE_TYPE,
-													 RDFLanguages.strLangTurtle));
-		mediaPairs.add(new AbstractMap.SimpleEntry<>(OslcMediaType.APPLICATION_JSON_LD_TYPE,
-													 RDFLanguages.strLangJSONLD));
-		if (OSLC4JUtils.alwaysAbbrevXML()) {
-			// application/rdf+xml will be forcefully abbreviated
-			mediaPairs.add(new AbstractMap.SimpleEntry<>(OslcMediaType.APPLICATION_RDF_XML_TYPE,
-														 FileUtils.langXMLAbbrev));
-		} else {
-			mediaPairs.add(new AbstractMap.SimpleEntry<>(OslcMediaType.APPLICATION_RDF_XML_TYPE,
-														 RDFLanguages.strLangRDFXML));
+        List<Map.Entry<MediaType, String>> mediaPairs = new ArrayList<>();
+        mediaPairs.add(new AbstractMap.SimpleEntry<>(OslcMediaType.TEXT_TURTLE_TYPE, RDFLanguages.strLangTurtle));
+        mediaPairs
+                .add(new AbstractMap.SimpleEntry<>(OslcMediaType.APPLICATION_JSON_LD_TYPE, RDFLanguages.strLangJSONLD));
+        if (OSLC4JUtils.alwaysAbbrevXML()) {
+            // application/rdf+xml will be forcefully abbreviated
+            mediaPairs.add(
+                    new AbstractMap.SimpleEntry<>(OslcMediaType.APPLICATION_RDF_XML_TYPE, FileUtils.langXMLAbbrev));
+        } else {
+            mediaPairs.add(
+                    new AbstractMap.SimpleEntry<>(OslcMediaType.APPLICATION_RDF_XML_TYPE, RDFLanguages.strLangRDFXML));
 
-		}
-		// application/xml will be abbreviated for compat reasons
-		mediaPairs.add(new AbstractMap.SimpleEntry<>(OslcMediaType.APPLICATION_XML_TYPE,
-													 FileUtils.langXMLAbbrev));
+        }
+        // application/xml will be abbreviated for compat reasons
+        mediaPairs.add(new AbstractMap.SimpleEntry<>(OslcMediaType.APPLICATION_XML_TYPE, FileUtils.langXMLAbbrev));
 
-		mediaPairs.add(new AbstractMap.SimpleEntry<>(OslcMediaType.TEXT_XML_TYPE,
-				 RDFLanguages.strLangRDFXML));
-		
-		for (Map.Entry<MediaType, String> mediaPair : mediaPairs) {
-			if (baseMediaType.isCompatible(mediaPair.getKey())) {
-				log.trace("Using '{}' writer for '{}' Accept media type",
-						  mediaPair.getValue(),
-						  mediaPair.getKey());
-				return mediaPair.getValue();
-			}
-		}
+        mediaPairs.add(new AbstractMap.SimpleEntry<>(OslcMediaType.TEXT_XML_TYPE, RDFLanguages.strLangRDFXML));
 
-		throw new IllegalArgumentException("Base media type can't be matched to any writer");
-	}
+        for (Map.Entry<MediaType, String> mediaPair : mediaPairs) {
+            if (baseMediaType.isCompatible(mediaPair.getKey())) {
+                log.trace("Using '{}' writer for '{}' Accept media type", mediaPair.getValue(), mediaPair.getKey());
+                return mediaPair.getValue();
+            }
+        }
 
-	protected Object[] readFrom(final Class<?>						 type,
-								final MediaType						 mediaType,
-								final MultivaluedMap<String, String> map,
-								final InputStream					 inputStream)
-			  throws WebApplicationException
-	{
-		final Model model = ModelFactory.createDefaultModel();
+        throw new IllegalArgumentException("Base media type can't be matched to any writer");
+    }
 
-		RDFReader reader = getRdfReader(mediaType, model);
+    protected static boolean isReadable(final Class<?> type, final MediaType actualMediaType,
+            final MediaType... requiredMediaTypes) {
+        if (type.getAnnotation(OslcResourceShape.class) != null) {
+            if (isCompatible(actualMediaType, requiredMediaTypes)) {
+                return true;
+            }
+        }
 
-		try
-		{
-			// Pass the empty string as the base URI. This allows Jena to
-			// resolve relative URIs commonly used to in reified statements
-			// for OSLC link labels. See this section of the CM specification
-			// for an example:
-			// http://open-services.net/bin/view/Main/CmSpecificationV2?sortcol=table;up=#Labels_for_Relationships
+        return false;
+    }
 
-			reader.read(model, inputStream, "");
+    protected static boolean isCompatible(final MediaType actualMediaType, final MediaType... requiredMediaTypes) {
+        for (final MediaType requiredMediaType : requiredMediaTypes) {
+            if (requiredMediaType.isCompatible(actualMediaType)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-			return JenaModelHelper.unmarshal(model, type);
-		}
-		catch (final Exception exception)
-		{
-			throw new WebApplicationException(exception,
-											  buildBadRequestResponse(exception,
-																	  mediaType,
-																	  map));
-		}
-	}
+    protected Object[] readFrom(final Class<?> type, final MediaType mediaType,
+            final MultivaluedMap<String, String> map, final InputStream inputStream) throws WebApplicationException {
+        final Model model = ModelFactory.createDefaultModel();
 
-	private RDFReader getRdfReader(final MediaType mediaType, final Model model) {
-		RDFReader reader;
-		final String language = getSerializationLanguage(mediaType);
-		if (language.equals(FileUtils.langXMLAbbrev))
-		{
-			reader = model.getReader(); // Default reader handles both xml and abbreviated xml
-		} else {
-			reader=model.getReader(language);
-		}
-		reader.setErrorHandler(ERROR_HANDLER);
-		return reader;
-	}
+        RDFReader reader = getRdfReader(mediaType, model);
 
-	protected Response buildBadRequestResponse(final Exception				   exception,
-											   final MediaType				   initialErrorMediaType,
-											   final MultivaluedMap<String, ?> map)
-	{
-		final MediaType determinedErrorMediaType = determineErrorMediaType(initialErrorMediaType,
-																		   map);
+        try {
+            // Pass the empty string as the base URI. This allows Jena to
+            // resolve relative URIs commonly used to in reified statements
+            // for OSLC link labels. See this section of the CM specification
+            // for an example:
+            // http://open-services.net/bin/view/Main/CmSpecificationV2?sortcol=table;up=#Labels_for_Relationships
 
-		final Error error = new Error();
+            reader.read(model, inputStream, "");
 
-		error.setStatusCode(String.valueOf(Response.Status.BAD_REQUEST.getStatusCode()));
-		error.setMessage(exception.getMessage());
+            return JenaModelHelper.unmarshal(model, type);
+        } catch (final Exception exception) {
+            throw new WebApplicationException(exception, buildBadRequestResponse(exception, mediaType, map));
+        }
+    }
 
-		final ResponseBuilder responseBuilder = Response.status(Response.Status.BAD_REQUEST);
-		return responseBuilder.type(determinedErrorMediaType).entity(error).build();
-	}
+    private RDFReader getRdfReader(final MediaType mediaType, final Model model) {
+        RDFReader reader;
+        final String language = getSerializationLanguage(mediaType);
+        if (language.equals(FileUtils.langXMLAbbrev)) {
+            reader = model.getReader(); // Default reader handles both xml and abbreviated xml
+        } else {
+            reader = model.getReader(language);
+        }
+        reader.setErrorHandler(ERROR_HANDLER);
+        return reader;
+    }
 
-	/**
-	 * We handle the case where a client requests an accept type different than their content type.
-	 * This will work correctly in the successful case.	 But, in the error case where our
-	 * MessageBodyReader/MessageBodyWriter fails internally, we respect the client's requested accept type.
-	 */
-	private MediaType determineErrorMediaType(final MediaType				  initialErrorMediaType,
-											  final MultivaluedMap<String, ?> map)
-	{
-		try
-		{
-			// HttpHeaders will not be available on the client side and will throw a NullPointerException
-			final List<MediaType> acceptableMediaTypes = httpHeaders.getAcceptableMediaTypes();
+    protected Response buildBadRequestResponse(final Exception exception, final MediaType initialErrorMediaType,
+            final MultivaluedMap<String, ?> map) {
+        final MediaType determinedErrorMediaType = determineErrorMediaType(initialErrorMediaType, map);
 
-			// Since we got here, we know we are executing on the server
+        final Error error = new Error();
 
-			if (acceptableMediaTypes != null)
-			{
-				for (final MediaType acceptableMediaType : acceptableMediaTypes)
-				{
-					// If a concrete media type with a MessageBodyWriter
-					if (isAcceptableMediaType(acceptableMediaType))
-					{
-						return acceptableMediaType;
-					}
-				}
-			}
-		}
-		catch (final NullPointerException exception)
-		{
-			// Ignore NullPointerException since this means the context has not been set since we are on the client
+        error.setStatusCode(String.valueOf(Response.Status.BAD_REQUEST.getStatusCode()));
+        error.setMessage(exception.getMessage());
 
-			// See if the MultivaluedMap for headers is available
-			if (map != null)
-			{
-				final Object acceptObject = map.getFirst("Accept");
+        final ResponseBuilder responseBuilder = Response.status(Response.Status.BAD_REQUEST);
+        return responseBuilder.type(determinedErrorMediaType).entity(error).build();
+    }
 
-				if (acceptObject instanceof String)
-				{
-					final String[] accepts = acceptObject.toString().split(",");
+    /**
+     * We handle the case where a client requests an accept type different than
+     * their content type. This will work correctly in the successful case. But, in
+     * the error case where our MessageBodyReader/MessageBodyWriter fails
+     * internally, we respect the client's requested accept type.
+     */
+    private MediaType determineErrorMediaType(final MediaType initialErrorMediaType,
+            final MultivaluedMap<String, ?> map) {
+        try {
+            // HttpHeaders will not be available on the client side and will throw a
+            // NullPointerException
+            final List<MediaType> acceptableMediaTypes = httpHeaders.getAcceptableMediaTypes();
 
-					double	  winningQ		   = 0.0D;
-					MediaType winningMediaType = null;
+            // Since we got here, we know we are executing on the server
 
-					for (final String accept : accepts)
-					{
-						final MediaType acceptMediaType = MediaType.valueOf(accept);
+            if (acceptableMediaTypes != null) {
+                for (final MediaType acceptableMediaType : acceptableMediaTypes) {
+                    // If a concrete media type with a MessageBodyWriter
+                    if (isAcceptableMediaType(acceptableMediaType)) {
+                        return acceptableMediaType;
+                    }
+                }
+            }
+        } catch (final NullPointerException exception) {
+            // Ignore NullPointerException since this means the context has not been set
+            // since we are on the client
 
-						// If a concrete media type with a MessageBodyWriter
-						if (isAcceptableMediaType(acceptMediaType))
-						{
-							final String stringQ = acceptMediaType.getParameters().get("q");
+            // See if the MultivaluedMap for headers is available
+            if (map != null) {
+                final Object acceptObject = map.getFirst("Accept");
 
-							final double q = stringQ == null ? 1.0D : Double.parseDouble(stringQ);
+                if (acceptObject instanceof String) {
+                    final String[] accepts = acceptObject.toString().split(",");
 
-							// Make sure and exclude blackballed media type
-							if (Double.compare(q, 0.0D) > 0)
-							{
-								if ((winningMediaType == null) ||
-									(Double.compare(q, winningQ) > 0))
-								{
-									winningMediaType = acceptMediaType;
-									winningQ		 = q;
-								}
-							}
-						}
-					}
+                    double winningQ = 0.0D;
+                    MediaType winningMediaType = null;
 
-					if (winningMediaType != null)
-					{
-						return winningMediaType;
-					}
-				}
-			}
-		}
+                    for (final String accept : accepts) {
+                        final MediaType acceptMediaType = MediaType.valueOf(accept);
 
-		return initialErrorMediaType;
-	}
+                        // If a concrete media type with a MessageBodyWriter
+                        if (isAcceptableMediaType(acceptMediaType)) {
+                            final String stringQ = acceptMediaType.getParameters().get("q");
 
-	/**
-	 * Only allow media types that are not wildcards and have a related MessageBodyWriter for OSLC Error.
-	 */
-	private boolean isAcceptableMediaType(final MediaType mediaType)
-	{
-		return (!mediaType.isWildcardType()) &&
-			   (!mediaType.isWildcardSubtype()) &&
-			   (providers.getMessageBodyWriter(CLASS_OSLC_ERROR,
-											   CLASS_OSLC_ERROR,
-											   ANNOTATIONS_EMPTY_ARRAY,
-											   mediaType) != null);
-	}
+                            final double q = stringQ == null ? 1.0D : Double.parseDouble(stringQ);
+
+                            // Make sure and exclude blackballed media type
+                            if (Double.compare(q, 0.0D) > 0) {
+                                if ((winningMediaType == null) || (Double.compare(q, winningQ) > 0)) {
+                                    winningMediaType = acceptMediaType;
+                                    winningQ = q;
+                                }
+                            }
+                        }
+                    }
+
+                    if (winningMediaType != null) {
+                        return winningMediaType;
+                    }
+                }
+            }
+        }
+
+        return initialErrorMediaType;
+    }
+
+    /**
+     * Only allow media types that are not wildcards and have a related
+     * MessageBodyWriter for OSLC Error.
+     */
+    private boolean isAcceptableMediaType(final MediaType mediaType) {
+        return (!mediaType.isWildcardType()) && (!mediaType.isWildcardSubtype()) && (providers
+                .getMessageBodyWriter(CLASS_OSLC_ERROR, CLASS_OSLC_ERROR, ANNOTATIONS_EMPTY_ARRAY, mediaType) != null);
+    }
+
 }

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlArrayProvider.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlArrayProvider.java
@@ -31,67 +31,52 @@ import javax.ws.rs.ext.Provider;
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
 
 /**
- * @author Russell Boykin, Alberto Giammaria, Chris Peters, Gianluca Bernardini, Andrew Berezovskyi
+ * @author Russell Boykin, Alberto Giammaria, Chris Peters, Gianluca Bernardini,
+ *         Andrew Berezovskyi
  */
 @Provider
-@Produces({OslcMediaType.APPLICATION_RDF_XML})
-@Consumes({OslcMediaType.APPLICATION_RDF_XML})
-public class OslcRdfXmlArrayProvider
-	   extends AbstractOslcRdfXmlProvider
-	   implements MessageBodyReader<Object[]>,
-				  MessageBodyWriter<Object[]>
-{
-	public OslcRdfXmlArrayProvider()
-	{
-		super();
-	}
+@Produces({ OslcMediaType.APPLICATION_RDF_XML })
+@Consumes({ OslcMediaType.APPLICATION_RDF_XML })
+public class OslcRdfXmlArrayProvider extends AbstractOslcRdfXmlProvider
+        implements MessageBodyReader<Object[]>, MessageBodyWriter<Object[]> {
+    public OslcRdfXmlArrayProvider() {
+        super();
+    }
 
-	@Override
-	public boolean isWriteable(final Class<?> type, final Type genericType,
-			final Annotation[] annotations, final MediaType mediaType) {
-		return true;
-	}
+    @Override
+    public boolean isWriteable(final Class<?> type, final Type genericType, final Annotation[] annotations,
+            final MediaType mediaType) {
+        return true;
+    }
 
-	@Override
-	public boolean isReadable(final Class<?> type, final Type genericType,
-			final Annotation[] annotations, final MediaType mediaType) {
-		return true;
-	}
+    @Override
+    public boolean isReadable(final Class<?> type, final Type genericType, final Annotation[] annotations,
+            final MediaType mediaType) {
+        if (type.isArray()) {
+            return isReadable(type.getComponentType(), mediaType, OslcMediaType.APPLICATION_RDF_XML_TYPE,
+                    OslcMediaType.APPLICATION_XML_TYPE, OslcMediaType.TEXT_XML_TYPE);
+        }
+        return false;
+    }
 
-	@Override
-	public void writeTo(final Object[]						 objects,
-						final Class<?>						 type,
-						final Type							 genericType,
-						final Annotation[]					 annotations,
-						final MediaType						 mediaType,
-						final MultivaluedMap<String, Object> map,
-						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException {
+    @Override
+    public void writeTo(final Object[] objects, final Class<?> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType, final MultivaluedMap<String, Object> map,
+            final OutputStream outputStream) throws IOException, WebApplicationException {
 
-		writeTo(ProviderHelper.isQueryResult(type, annotations), objects, mediaType, map,
-				outputStream);
-	}
+        writeTo(ProviderHelper.isQueryResult(type, annotations), objects, mediaType, map, outputStream);
+    }
 
-	@Override
-	public Object[] readFrom(final Class<Object[]>				  type,
-							 final Type							  genericType,
-							 final Annotation[]					  annotations,
-							 final MediaType					  mediaType,
-							 final MultivaluedMap<String, String> map,
-							 final InputStream					  inputStream)
-		   throws IOException,
-				  WebApplicationException
-	{
-		return readFrom(type.getComponentType(),
-						mediaType,
-						map,
-						inputStream);
-	}
+    @Override
+    public Object[] readFrom(final Class<Object[]> type, final Type genericType, final Annotation[] annotations,
+            final MediaType mediaType, final MultivaluedMap<String, String> map, final InputStream inputStream)
+            throws IOException, WebApplicationException {
+        return readFrom(type.getComponentType(), mediaType, map, inputStream);
+    }
 
-	@Override
-	public long getSize(final Object[] objects, final Class<?> type, final Type genericType,
-			final Annotation[] annotations, final MediaType mediaType) {
-		return ProviderHelper.CANNOT_BE_DETERMINED_IN_ADVANCE;
-	}
+    @Override
+    public long getSize(final Object[] objects, final Class<?> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType) {
+        return ProviderHelper.CANNOT_BE_DETERMINED_IN_ADVANCE;
+    }
 }

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlCollectionProvider.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlCollectionProvider.java
@@ -51,188 +51,133 @@ import org.slf4j.LoggerFactory;
 
 /**
  *
- * @author Russell Boykin, Alberto Giammaria, Chris Peters, Gianluca Bernardini, Andrew Berezovskyi
+ * @author Russell Boykin, Alberto Giammaria, Chris Peters, Gianluca Bernardini,
+ *         Andrew Berezovskyi
  */
 @Provider
-@Produces({OslcMediaType.APPLICATION_RDF_XML})
-@Consumes({OslcMediaType.APPLICATION_RDF_XML})
-public class OslcRdfXmlCollectionProvider
-	   extends AbstractOslcRdfXmlProvider
-	   implements MessageBodyReader<Collection<Object>>,
-				  MessageBodyWriter<Collection<Object>>
-{
-	private final static Logger log = LoggerFactory.getLogger(OslcRdfXmlCollectionProvider.class);
+@Produces({ OslcMediaType.APPLICATION_RDF_XML })
+@Consumes({ OslcMediaType.APPLICATION_RDF_XML })
+public class OslcRdfXmlCollectionProvider extends AbstractOslcRdfXmlProvider
+        implements MessageBodyReader<Collection<Object>>, MessageBodyWriter<Collection<Object>> {
+    private final static Logger log = LoggerFactory.getLogger(OslcRdfXmlCollectionProvider.class);
 
-	public OslcRdfXmlCollectionProvider()
-	{
-		super();
-	}
+    public OslcRdfXmlCollectionProvider() {
+        super();
+    }
 
-	@Override
-	public boolean isWriteable(final Class<?>	  type,
-							   final Type		  genericType,
-							   final Annotation[] annotations,
-							   final MediaType	  mediaType)
-	{
-		if ((Collection.class.isAssignableFrom(type)) &&
-			(genericType instanceof ParameterizedType))
-		{
-			final ParameterizedType parameterizedType = (ParameterizedType) genericType;
+    @Override
+    public boolean isWriteable(final Class<?> type, final Type genericType, final Annotation[] annotations,
+            final MediaType mediaType) {
+        if ((Collection.class.isAssignableFrom(type)) && (genericType instanceof ParameterizedType)) {
+            final ParameterizedType parameterizedType = (ParameterizedType) genericType;
 
-			final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+            final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
 
-			if (actualTypeArguments.length == 1)
-			{
-				return actualTypeArguments[0] instanceof Class;
-			}
-			else {
-				log.error("Collection type must have exactly one generic type");
-			}
-		}
+            if (actualTypeArguments.length == 1) {
+                return actualTypeArguments[0] instanceof Class;
+            } else {
+                log.error("Collection type must have exactly one generic type");
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	@Override
-	public void writeTo(final Collection<Object>			 collection,
-						final Class<?>						 type,
-						final Type							 genericType,
-						final Annotation[]					 annotations,
-						final MediaType						 mediaType,
-						final MultivaluedMap<String, Object> map,
-						final OutputStream outputStream)
-		   throws IOException,
-				  WebApplicationException
-	{
-		final ParameterizedType parameterizedType = (ParameterizedType) genericType;
-		final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+    @Override
+    public void writeTo(final Collection<Object> collection, final Class<?> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType, final MultivaluedMap<String, Object> map,
+            final OutputStream outputStream) throws IOException, WebApplicationException {
+        final ParameterizedType parameterizedType = (ParameterizedType) genericType;
+        final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
 
-		writeTo(ProviderHelper.isQueryResult((Class<?>)actualTypeArguments[0], annotations),
-				collection.toArray(new Object[0]),
-				mediaType,
-				map,
-				outputStream);
-	}
+        writeTo(ProviderHelper.isQueryResult((Class<?>) actualTypeArguments[0], annotations),
+                collection.toArray(new Object[0]), mediaType, map, outputStream);
+    }
 
-	@Override
-	public boolean isReadable(final Class<?>	 type,
-							  final Type		 genericType,
-							  final Annotation[] annotations,
-							  final MediaType	 mediaType)
-	{
-		if ((Collection.class.isAssignableFrom(type)) &&
-			(genericType instanceof ParameterizedType))
-		{
-			final ParameterizedType parameterizedType = (ParameterizedType) genericType;
+    @Override
+    public boolean isReadable(final Class<?> type, final Type genericType, final Annotation[] annotations,
+            final MediaType mediaType) {
+        if ((Collection.class.isAssignableFrom(type)) && (genericType instanceof ParameterizedType)) {
+            final ParameterizedType parameterizedType = (ParameterizedType) genericType;
 
-			final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+            final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
 
-			if (actualTypeArguments.length == 1)
-			{
-				final Type actualTypeArgument = actualTypeArguments[0];
+            if (actualTypeArguments.length == 1) {
+                final Type actualTypeArgument = actualTypeArguments[0];
 
-				if (URI.class.equals(actualTypeArgument))
-				{
-					log.error("Support for reading Collection<URI> is not implemented");
-					return true;
-				} 
+                if (URI.class.equals(actualTypeArgument)) {
+                    log.error("Support for reading Collection<URI> is not implemented");
+                    return true;
+                }
 
-				if (actualTypeArgument instanceof Class)
-				{
-					return true;
-				}
-			}
-		}
+                if (actualTypeArgument instanceof Class) {
+                    return true;
+                }
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	@Override
-	public Collection<Object> readFrom(final Class<Collection<Object>>		type,
-									   final Type							genericType,
-									   final Annotation[]					annotations,
-									   final MediaType						mediaType,
-									   final MultivaluedMap<String, String> map,
-									   final InputStream					inputStream)
-		   throws IOException,
-				  WebApplicationException
-	{
-		if (genericType instanceof ParameterizedType)
-		{
-			final ParameterizedType parameterizedType = (ParameterizedType) genericType;
+    @Override
+    public Collection<Object> readFrom(final Class<Collection<Object>> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType, final MultivaluedMap<String, String> map,
+            final InputStream inputStream) throws IOException, WebApplicationException {
+        if (genericType instanceof ParameterizedType) {
+            final ParameterizedType parameterizedType = (ParameterizedType) genericType;
 
-			final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+            final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
 
-			if (actualTypeArguments.length == 1)
-			{
-				final Type actualTypeArgument = actualTypeArguments[0];
+            if (actualTypeArguments.length == 1) {
+                final Type actualTypeArgument = actualTypeArguments[0];
 
-				if (actualTypeArgument instanceof Class)
-				{
-					final Object[] objects = readFrom((Class<?>) actualTypeArgument,
-													  mediaType,
-													  map,
-													  inputStream);
+                if (actualTypeArgument instanceof Class) {
+                    final Object[] objects = readFrom((Class<?>) actualTypeArgument, mediaType, map, inputStream);
 
-					final Collection<Object> collection;
+                    final Collection<Object> collection;
 
-					// Handle the Collection, List, Deque, Queue interfaces.
-					// Handle the AbstractCollection, AbstractList, AbstractSequentialList classes
-					if ((Collection.class.equals(type)) ||
-						(List.class.equals(type))||
-						(Deque.class.equals(type)) ||
-						(Queue.class.equals(type)) ||
-						(AbstractCollection.class.equals(type)) ||
-						(AbstractList.class.equals(type)) ||
-						(AbstractSequentialList.class.equals(type)))
-					{
-						collection = new LinkedList<>();
-					}
-					// Handle the Set interface
-					// Handle the AbstractSet class
-					else if ((Set.class.equals(type)) ||
-							 (AbstractSet.class.equals(type)))
-					{
-						collection = new HashSet<>();
-					}
-					// Handle the SortedSet and NavigableSet interfaces
-					else if ((SortedSet.class.equals(type)) ||
-							 (NavigableSet.class.equals(type)))
-					{
-						collection = new TreeSet<>();
-					}
-					// Not handled above.  Let's try newInstance with possible failure.
-					else
-					{
-						try
-						{
-							@SuppressWarnings("cast")
-							final Collection<Object> tempCollection = type.newInstance();
+                    // Handle the Collection, List, Deque, Queue interfaces.
+                    // Handle the AbstractCollection, AbstractList, AbstractSequentialList classes
+                    if ((Collection.class.equals(type)) || (List.class.equals(type)) || (Deque.class.equals(type))
+                            || (Queue.class.equals(type)) || (AbstractCollection.class.equals(type))
+                            || (AbstractList.class.equals(type)) || (AbstractSequentialList.class.equals(type))) {
+                        collection = new LinkedList<>();
+                    }
+                    // Handle the Set interface
+                    // Handle the AbstractSet class
+                    else if ((Set.class.equals(type)) || (AbstractSet.class.equals(type))) {
+                        collection = new HashSet<>();
+                    }
+                    // Handle the SortedSet and NavigableSet interfaces
+                    else if ((SortedSet.class.equals(type)) || (NavigableSet.class.equals(type))) {
+                        collection = new TreeSet<>();
+                    }
+                    // Not handled above. Let's try newInstance with possible failure.
+                    else {
+                        try {
+                            @SuppressWarnings("cast")
+                            final Collection<Object> tempCollection = type.newInstance();
 
-							collection = tempCollection;
-						}
-						catch (final Exception exception)
-						{
-							throw new WebApplicationException(exception,
-															  buildBadRequestResponse(exception,
-																					  mediaType,
-																					  map));
-						}
-					}
+                            collection = tempCollection;
+                        } catch (final Exception exception) {
+                            throw new WebApplicationException(exception,
+                                    buildBadRequestResponse(exception, mediaType, map));
+                        }
+                    }
 
-					collection.addAll(Arrays.asList(objects));
+                    collection.addAll(Arrays.asList(objects));
 
-					return collection;
-				}
-			}
-		}
+                    return collection;
+                }
+            }
+        }
 
-		return null;
-	}
+        return null;
+    }
 
-	@Override
-	public long getSize(final Collection<Object> collection, final Class<?> type,
-			final Type genericType, final Annotation[] annotation, final MediaType mediaType) {
-		return ProviderHelper.CANNOT_BE_DETERMINED_IN_ADVANCE;
-	}
+    @Override
+    public long getSize(final Collection<Object> collection, final Class<?> type, final Type genericType,
+            final Annotation[] annotation, final MediaType mediaType) {
+        return ProviderHelper.CANNOT_BE_DETERMINED_IN_ADVANCE;
+    }
 }

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcXmlProvider.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcXmlProvider.java
@@ -16,13 +16,13 @@ package org.eclipse.lyo.oslc4j.provider.jena;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
-
 import javax.ws.rs.ext.Provider;
+
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
 
 @Provider
-@Produces({OslcMediaType.APPLICATION_XML, OslcMediaType.TEXT_XML})
-@Consumes({OslcMediaType.APPLICATION_XML, OslcMediaType.TEXT_XML})
+@Produces({ OslcMediaType.APPLICATION_XML, OslcMediaType.TEXT_XML })
+@Consumes({ OslcMediaType.APPLICATION_XML, OslcMediaType.TEXT_XML })
 public class OslcXmlProvider extends OslcRdfXmlProvider {
 
 }

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/MessageBodyReaderTest.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/MessageBodyReaderTest.java
@@ -1,0 +1,65 @@
+package org.eclipse.lyo.oslc4j.provider.jena;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
+import org.eclipse.lyo.oslc4j.provider.jena.test.resources.ResourceWithoutShape;
+import org.eclipse.lyo.oslc4j.provider.jena.test.resources.TestResource;
+import org.junit.Test;
+
+public class MessageBodyReaderTest {
+
+    @Test
+    public void testOslcXmlProvider() {
+        OslcXmlProvider provider = new OslcXmlProvider();
+
+        boolean isReadable = provider.isReadable(TestResource.class, null, TestResource.class.getAnnotations(),
+                MediaType.APPLICATION_XML_TYPE);
+        assertTrue(isReadable);
+
+        isReadable = provider.isReadable(TestResource.class, null, TestResource.class.getAnnotations(),
+                OslcMediaType.APPLICATION_RDF_XML_TYPE);
+        assertTrue(isReadable);
+
+        isReadable = provider.isReadable(ResourceWithoutShape.class, null, ResourceWithoutShape.class.getAnnotations(),
+                MediaType.APPLICATION_XML_TYPE);
+        assertFalse(isReadable);
+
+        isReadable = provider.isReadable(TestResource.class, null, TestResource.class.getAnnotations(),
+                MediaType.APPLICATION_JSON_TYPE);
+        assertFalse(isReadable);
+
+        isReadable = provider.isReadable(Collection.class, null, TestResource.class.getAnnotations(),
+                MediaType.APPLICATION_JSON_TYPE);
+        assertFalse(isReadable);
+    }
+
+    @Test
+    public void testOslcArrayProvider() {
+
+        OslcRdfXmlArrayProvider provider = new OslcRdfXmlArrayProvider();
+
+        boolean isReadable = provider.isReadable(TestResource[].class, null, TestResource.class.getAnnotations(),
+                MediaType.APPLICATION_XML_TYPE);
+        assertTrue(isReadable);
+
+        isReadable = provider.isReadable(TestResource[].class, null, TestResource.class.getAnnotations(),
+                OslcMediaType.APPLICATION_RDF_XML_TYPE);
+        assertTrue(isReadable);
+
+        isReadable = provider.isReadable(ResourceWithoutShape[].class, null,
+                ResourceWithoutShape.class.getAnnotations(), OslcMediaType.APPLICATION_RDF_XML_TYPE);
+        assertFalse(isReadable);
+
+        isReadable = provider.isReadable(TestResource[].class, null, TestResource.class.getAnnotations(),
+                OslcMediaType.APPLICATION_JSON_TYPE);
+        assertFalse(isReadable);
+
+    }
+
+}

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/resources/ResourceWithoutShape.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/resources/ResourceWithoutShape.java
@@ -1,0 +1,8 @@
+package org.eclipse.lyo.oslc4j.provider.jena.test.resources;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class ResourceWithoutShape {
+
+}


### PR DESCRIPTION
## Description

OslcXmlProvider(s) returned always true for isReadable. This has been changed to verify the type and annotations first.
Without this fix, XML entities have been read by the OslcXmlProvider instead of e.g. an JaxbProvider which has lead to errors.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #226 ; 

_(use exactly this syntax to link to issues, one issue per statement only!)_
