### PR TITLE
Handling inlined properties that happen to be null

### DIFF
--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PreviewFactory.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PreviewFactory.java
@@ -76,12 +76,12 @@ public class PreviewFactory {
                         Collection<AbstractResource> rs = (Collection<AbstractResource>) getterMethod.invoke(aResource);
                         List<org.eclipse.lyo.server.ui.model.Link> l = new ArrayList<>();
                         for (AbstractResource r: rs) {
-                            l.add(constructLink(r.getAbout().toString(), r.toString()));
+                            l.add((null == r ? null : constructLink(r.getAbout().toString(), r.toString())));
                         }
                         value = constructPropertyValue(PropertyDefintion.RepresentationType.LINK, multiple, l);
                     } else {
                     	AbstractResource r = (AbstractResource) getterMethod.invoke(aResource);
-                        value = constructPropertyValue(PropertyDefintion.RepresentationType.LINK, multiple, constructLink(r.getAbout().toString(), r.toString()));
+                        value = constructPropertyValue(PropertyDefintion.RepresentationType.LINK, multiple, (null == r ? null : constructLink(r.getAbout().toString(), r.toString())));
                     }
             	}
             	else {


### PR DESCRIPTION
## Description

Handling inlined properties that happen to be null

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [X] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [X] This PR does NOT break the API

