### PR TITLE
Ordering resources by their subject IDs when doing a query to store.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - 🧨 Lyo is now built using JDK 11
 - 🧨 Jena is upgraded to 4.1.0
   - Jena renamed `RDFReader/RDFWriter` to `RDFReaderI/RDFWriterI`
+  - LyoStore: Ordering resources by their subject IDs when doing a query to store.
 
 
 ### Deprecated


### PR DESCRIPTION
Signed-off-by: Jad El-khoury <jad.el.khoury@scania.com>



## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API
