### PR TITLE
Adding OSLC4JConstants#LYO_STORE_PAGING_UNSAFE to disable/enable ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - 🧨 Lyo is now built using JDK 11
 - 🧨 Jena is upgraded to 4.1.0
   - Jena renamed `RDFReader/RDFWriter` to `RDFReaderI/RDFWriterI`
-  - LyoStore: Ordering resources by their subject IDs when doing a query to store.
+  - LyoStore: Ordering resources by their subject IDs when doing a query to store. This ordering can be disabled with a call to `OSLC4JUtils.setLyoStorePagingUnsafe(true)`
 
 
 ### Deprecated

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JConstants.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JConstants.java
@@ -51,4 +51,12 @@ public interface OSLC4JConstants {
 	 * properties.
 	 */
 	String OSLC4J_STRICT_DATATYPES = OSLC4J + "strictDatatypes";
+
+    /**
+     * System property {@value} : When "false" (default), add an OrderBy clause to the queries in LyoStore that involve paging.
+     * When "true", do not add such an OrderBy clause, in the hope that the triplestore sorting algorithm is stable-
+     * properties.
+     */
+    String LYO_STORE_PAGING_UNSAFE = OSLC4J + "unsafePaging";
+	
 }

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
@@ -738,4 +738,18 @@ public class OSLC4JUtils {
 		}
 		return null;
 	}
+	
+	 /**
+     * @see OSLC4JConstants#LYO_STORE_PAGING_UNSAFE
+     * @return the boolean value of org.eclipse.lyo.oslc4j.unsafePaging
+     * Default is false if not set.
+     */
+    public static boolean isLyoStorePagingUnsafe() {
+        return parseBooleanPropertyOrDefault(OSLC4JConstants.LYO_STORE_PAGING_UNSAFE, false);
+    }
+
+    public static void setLyoStorePagingUnsafe(boolean value) {
+        System.setProperty(OSLC4JConstants.LYO_STORE_PAGING_UNSAFE, Boolean.toString(value));
+    }
+
 }

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
@@ -67,6 +67,7 @@ import org.eclipse.lyo.core.query.SimpleTerm.Type;
 import org.eclipse.lyo.core.query.StringValue;
 import org.eclipse.lyo.core.query.UriRefValue;
 import org.eclipse.lyo.core.query.Value;
+import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
@@ -610,8 +611,10 @@ public class SparqlStoreImpl implements Store {
             distinctResourcesQuery.addFilter(regex);
         }
 
-        //Order the response by the subject, to ensure stable responses when using limit and offset below.
-        distinctResourcesQuery.addOrderBy("?s", Order.ASCENDING);
+        
+        if ((limit > 0 || offset > 0) && (! OSLC4JUtils.isLyoStorePagingUnsafe())) {
+            distinctResourcesQuery.addOrderBy("?s", Order.ASCENDING);
+        }
         
         if (limit > 0) {
             distinctResourcesQuery.setLimit(limit);


### PR DESCRIPTION
## Description

Adding OSLC4JConstants#LYO_STORE_PAGING_UNSAFE to disable/enable ordering

## Checklist

- [X] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [X] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [X] This PR does NOT break the API

