### PR TITLE
Deprecate IQueryGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Deprecated
 
+- `IQueryGenerator` is deprecated and will be removed in Lyo 6
+
 ### Removed
 - 🧨 **Support for JDK 8 was removed**
 - 🧨 `oslc-java-client` was removed

--- a/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/sparql/IQueryGenerator.java
+++ b/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/sparql/IQueryGenerator.java
@@ -16,6 +16,7 @@ package org.eclipse.lyo.trs.client.handlers.sparql;
 
 import java.util.List;
 
+@Deprecated
 public interface IQueryGenerator {
     List<String> getQueries();
 }


### PR DESCRIPTION
## Description

See #93

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API **Will be removed in Lyo 6**
