### PR TITLE
Fix hanging build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
 						-P dev,gpg-sign,eclipse-deploy
 				'''
 				// sh 'gpg --verify my-app/target/my-app-1.0-SNAPSHOT.jar.asc'
-				sshagent(['git.eclipse.org-bot-ssh']) {
+				sshagent(['projects-storage.eclipse.org-bot-ssh']) {
 					sh '''
 					DOCS_HOME=/home/data/httpd/download.eclipse.org/lyo/docs/all
 					VERSION=$(mvn -q \
@@ -68,7 +68,7 @@ pipeline {
 				branch 'master'
 			}
 			steps {
-				sshagent(['git.eclipse.org-bot-ssh']) {
+				sshagent(['projects-storage.eclipse.org-bot-ssh']) {
 					sh '''
 					DOCS_HOME=/home/data/httpd/download.eclipse.org/lyo/docs/all
 					VERSION=$(mvn -q \


### PR DESCRIPTION
"FATAL: [ssh-agent] Could not find specified credentials" is caused by using the wrong ID for the SSH credentials.

## Description

Fix the CI build

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API


