### PR TITLE
Removes duplicated type declarations that are not needed since Java 8 (7?)

### DIFF
--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/JEEFormAuthenticator.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/JEEFormAuthenticator.java
@@ -143,7 +143,7 @@ public class JEEFormAuthenticator implements ClientRequestFilter, ClientResponse
 			.target(request.getUri())
 			.request(request.getMediaType());
         retryBuilder.property(FORM_AUTHENTICATOR_REUSED, "true"); // prevent infinite loops
-        MultivaluedMap<String, Object> newHeaders = new MultivaluedHashMap<String, Object>();
+        MultivaluedMap<String, Object> newHeaders = new MultivaluedHashMap<>();
         newHeaders.putAll(request.getHeaders());
         newHeaders.add(COOKIE, cookies);
 		retryBuilder.headers(newHeaders);

--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/RootServicesHelper.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/RootServicesHelper.java
@@ -275,7 +275,7 @@ public class RootServicesHelper {
             throw new IllegalStateException("Server returned something else than JSON in the response");
         }
         ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> jsonData = new HashMap<String, Object>();
+        Map<String, Object> jsonData = new HashMap<>();
         jsonData = mapper.readValue(content, Map.class);
         String consumerKey = (String) jsonData.get("key");
         logger.debug("Consumer should redirect user to this approval URL, to approve the OAuth consumer: " + getConsumerApprovalUrl(consumerKey));

--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/query/OslcQueryResult.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/query/OslcQueryResult.java
@@ -230,7 +230,7 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 	 */
 	public String[] getMembersUrls() {
 		initializeRdf();
-		ArrayList<String> membersUrls = new ArrayList<String>();
+		ArrayList<String> membersUrls = new ArrayList<>();
         Selector select = getMemberSelector();
 		StmtIterator iter = rdfModel.listStatements(select);
 		while (iter.hasNext()) {

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureLinkType.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureLinkType.java
@@ -42,9 +42,9 @@ import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 public class ArchitectureLinkType
 extends AbstractResource
 {
-	private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+	private final Set<URI>      contributors                = new TreeSet<>();
+    private final Set<URI>      creators                    = new TreeSet<>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<>();
 
 
     private Date     created;

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureResource.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/ArchitectureResource.java
@@ -44,10 +44,10 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public class ArchitectureResource
 extends AbstractResource
 {
-	private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<String>   dctermsTypes                = new TreeSet<String>();
-    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+	private final Set<URI>      contributors                = new TreeSet<>();
+    private final Set<URI>      creators                    = new TreeSet<>();
+    private final Set<String>   dctermsTypes                = new TreeSet<>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<>();
 
 
     private Date     created;

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationPlan.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationPlan.java
@@ -43,11 +43,11 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public class AutomationPlan
 extends AbstractResource
 {
-	private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
-    private final Set<String>   subjects                    = new TreeSet<String>();
-    private final Set<Property> parameterDefinitions        = new TreeSet<Property>();
+	private final Set<URI>      contributors                = new TreeSet<>();
+    private final Set<URI>      creators                    = new TreeSet<>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<>();
+    private final Set<String>   subjects                    = new TreeSet<>();
+    private final Set<Property> parameterDefinitions        = new TreeSet<>();
 
     private Date     created;
     private String   description;

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationRequest.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationRequest.java
@@ -45,12 +45,12 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public class AutomationRequest
 extends AbstractResource
 {
-	private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
-    private final Set<String>   subjects                    = new TreeSet<String>();
-    private final Set<URI>      states                      = new TreeSet<URI>();
-    private final Set<ParameterInstance> inputParameters    = new TreeSet<ParameterInstance>();
+	private final Set<URI>      contributors                = new TreeSet<>();
+    private final Set<URI>      creators                    = new TreeSet<>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<>();
+    private final Set<String>   subjects                    = new TreeSet<>();
+    private final Set<URI>      states                      = new TreeSet<>();
+    private final Set<ParameterInstance> inputParameters    = new TreeSet<>();
 
     private Date     created;
     private String   description;

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationResult.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/AutomationResult.java
@@ -45,15 +45,15 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public class AutomationResult
 extends AbstractResource
 {
-	private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
-    private final Set<String>   subjects                    = new TreeSet<String>();
-    private final Set<URI>      states                      = new TreeSet<URI>();
-    private final Set<URI>      verdicts                    = new TreeSet<URI>();
-    private final Set<URI>      contributions               = new TreeSet<URI>();
-    private final Set<ParameterInstance> inputParameters    = new TreeSet<ParameterInstance>();
-    private final Set<ParameterInstance> outputParameters   = new TreeSet<ParameterInstance>();
+	private final Set<URI>      contributors                = new TreeSet<>();
+    private final Set<URI>      creators                    = new TreeSet<>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<>();
+    private final Set<String>   subjects                    = new TreeSet<>();
+    private final Set<URI>      states                      = new TreeSet<>();
+    private final Set<URI>      verdicts                    = new TreeSet<>();
+    private final Set<URI>      contributions               = new TreeSet<>();
+    private final Set<ParameterInstance> inputParameters    = new TreeSet<>();
+    private final Set<ParameterInstance> outputParameters   = new TreeSet<>();
 
     private Date     created;
     private String   identifier;

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/ChangeRequest.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/ChangeRequest.java
@@ -44,26 +44,26 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public class ChangeRequest
        extends AbstractResource
 {
-    private final Set<Link>     affectedByDefects           = new HashSet<Link>();
-    private final Set<Link>     affectsPlanItems            = new HashSet<Link>();
-    private final Set<Link>     affectsRequirements         = new HashSet<Link>();
-    private final Set<Link>     affectsTestResults          = new HashSet<Link>();
-    private final Set<Link>     blocksTestExecutionRecords  = new HashSet<Link>();
-    private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<String>   dctermsTypes                = new TreeSet<String>();
-    private final Set<Link>     implementsRequirements      = new HashSet<Link>();
-    private final Set<Link>     relatedChangeRequests       = new HashSet<Link>();
-    private final Set<Link>     relatedResources            = new HashSet<Link>(); // TODO - Extension to point to any other OSLC resource(s).
-    private final Set<Link>     relatedTestCases            = new HashSet<Link>();
-    private final Set<Link>     relatedTestExecutionRecords = new HashSet<Link>();
-    private final Set<Link>     relatedTestPlans            = new HashSet<Link>();
-    private final Set<Link>     relatedTestScripts          = new HashSet<Link>();
-    private final Set<String>   subjects                    = new TreeSet<String>();
-    private final Set<Link>     testedByTestCases           = new HashSet<Link>();
-    private final Set<Link>     tracksChangeSets            = new HashSet<Link>();
-    private final Set<Link>     tracksRequirements          = new HashSet<Link>();
-    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+    private final Set<Link>     affectedByDefects           = new HashSet<>();
+    private final Set<Link>     affectsPlanItems            = new HashSet<>();
+    private final Set<Link>     affectsRequirements         = new HashSet<>();
+    private final Set<Link>     affectsTestResults          = new HashSet<>();
+    private final Set<Link>     blocksTestExecutionRecords  = new HashSet<>();
+    private final Set<URI>      contributors                = new TreeSet<>();
+    private final Set<URI>      creators                    = new TreeSet<>();
+    private final Set<String>   dctermsTypes                = new TreeSet<>();
+    private final Set<Link>     implementsRequirements      = new HashSet<>();
+    private final Set<Link>     relatedChangeRequests       = new HashSet<>();
+    private final Set<Link>     relatedResources            = new HashSet<>(); // TODO - Extension to point to any other OSLC resource(s).
+    private final Set<Link>     relatedTestCases            = new HashSet<>();
+    private final Set<Link>     relatedTestExecutionRecords = new HashSet<>();
+    private final Set<Link>     relatedTestPlans            = new HashSet<>();
+    private final Set<Link>     relatedTestScripts          = new HashSet<>();
+    private final Set<String>   subjects                    = new TreeSet<>();
+    private final Set<Link>     testedByTestCases           = new HashSet<>();
+    private final Set<Link>     tracksChangeSets            = new HashSet<>();
+    private final Set<Link>     tracksRequirements          = new HashSet<>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<>();
 
     private Boolean  approved;
     private Boolean  closed;

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/ParameterInstance.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/ParameterInstance.java
@@ -41,7 +41,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public final class ParameterInstance
 extends AbstractResource implements Comparable<ParameterInstance>
 {
-    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<>();
 
     private String   name;
     private String   value;

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/Property.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/Property.java
@@ -52,7 +52,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public final class Property extends AbstractResource implements Comparable<Property> {
 	private static final QName PROPERTY_ALLOWED_VALUE = new QName(OslcConstants.OSLC_CORE_NAMESPACE, "allowedValue");
 	private static final QName PROPERTY_DEFAULT_VALUE = new QName(OslcConstants.OSLC_CORE_NAMESPACE, "defaultValue");
-	private final List<URI> range = new ArrayList<URI>();
+	private final List<URI> range = new ArrayList<>();
 
     private URI allowedValuesRef;
 	private String description;
@@ -377,7 +377,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 	 */
 	@Deprecated
 	public void addAllowedValue(final String allowedValue) {
-		ArrayList<Object> newValues = new ArrayList<Object>();
+		ArrayList<Object> newValues = new ArrayList<>();
 		@SuppressWarnings("unchecked")
         Collection<Object> allowedValues = (Collection<Object>) getExtendedProperties().get(PROPERTY_ALLOWED_VALUE);
 		if (allowedValues != null) {
@@ -394,7 +394,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 	@Deprecated
     public String[] getAllowedValues() {
 		// Be compatible with the old behavior and only include String values.
-		ArrayList<String> stringValues = new ArrayList<String>();
+		ArrayList<String> stringValues = new ArrayList<>();
 		@SuppressWarnings("unchecked")
         Collection<Object> values = (Collection<Object>) getExtendedProperties().get(PROPERTY_ALLOWED_VALUE);
 		if (values == null) {

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/QmResource.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/QmResource.java
@@ -39,7 +39,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public abstract class QmResource
        extends AbstractResource
 {
-    private final Set<URI>      rdfTypes                    = new TreeSet<URI>();
+    private final Set<URI>      rdfTypes                    = new TreeSet<>();
 
     private Date     created;
     private String   identifier;

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/Requirement.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/Requirement.java
@@ -48,39 +48,39 @@ public class Requirement
 	private String description;
 	private String identifier;
 	private String   shortTitle;
-	private final Set<String>   subjects					= new TreeSet<String>();
-	private final Set<URI>	  creators					= new TreeSet<URI>();
-	private final Set<URI>	  contributors				= new TreeSet<URI>();
+	private final Set<String>   subjects					= new TreeSet<>();
+	private final Set<URI>	  creators					= new TreeSet<>();
+	private final Set<URI>	  contributors				= new TreeSet<>();
 	private Date created;
 	private Date modified;
-	private final Set<URI>	  rdfTypes					= new TreeSet<URI>();
+	private final Set<URI>	  rdfTypes					= new TreeSet<>();
 	private URI	  serviceProvider;
 	private URI	  instanceShape;
 
 
 	// OSLC Links
-	private final Set<Link>	 elaboratedBy				= new HashSet<Link>();
-	private final Set<Link>	 elaborates		 			= new HashSet<Link>();
+	private final Set<Link>	 elaboratedBy				= new HashSet<>();
+	private final Set<Link>	 elaborates		 			= new HashSet<>();
 
-	private final Set<Link>	 specifiedBy		   		= new HashSet<Link>();
-	private final Set<Link>	 specifies  					= new HashSet<Link>();
+	private final Set<Link>	 specifiedBy		   		= new HashSet<>();
+	private final Set<Link>	 specifies  					= new HashSet<>();
 
-	private final Set<Link>	 affectedBy					= new HashSet<Link>();
+	private final Set<Link>	 affectedBy					= new HashSet<>();
 
-	private final Set<Link>	 trackedBy			  	  	= new HashSet<Link>();
+	private final Set<Link>	 trackedBy			  	  	= new HashSet<>();
 
-	private final Set<Link>	 implementedBy				= new HashSet<Link>();
+	private final Set<Link>	 implementedBy				= new HashSet<>();
 
-	private final Set<Link>	 validatedBy					= new HashSet<Link>();
+	private final Set<Link>	 validatedBy					= new HashSet<>();
 
-	private final Set<Link>	 satisfiedBy					= new HashSet<Link>();
-	private final Set<Link>	 satisfies					= new HashSet<Link>();
+	private final Set<Link>	 satisfiedBy					= new HashSet<>();
+	private final Set<Link>	 satisfies					= new HashSet<>();
 
-	private final Set<Link>	 decomposedBy				= new HashSet<Link>();
-	private final Set<Link>	 decomposes					= new HashSet<Link>();
+	private final Set<Link>	 decomposedBy				= new HashSet<>();
+	private final Set<Link>	 decomposes					= new HashSet<>();
 
-	private final Set<Link>	 constrainedBy				= new HashSet<Link>();
-	private final Set<Link>	 constrains					= new HashSet<Link>();
+	private final Set<Link>	 constrainedBy				= new HashSet<>();
+	private final Set<Link>	 constrains					= new HashSet<>();
 
 
 	public Requirement()

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/RequirementCollection.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/RequirementCollection.java
@@ -34,7 +34,7 @@ public class RequirementCollection
        extends Requirement
 {
 	// The only extra field is uses
-	private final Set<URI>      uses	 = new TreeSet<URI>();
+	private final Set<URI>      uses	 = new TreeSet<>();
 
     public RequirementCollection()
     {

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/TestCase.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/TestCase.java
@@ -41,13 +41,13 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public class TestCase
        extends QmResource
 {
-    private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<Link>     relatedChangeRequests       = new HashSet<Link>();
-    private final Set<String>   subjects                    = new TreeSet<String>();
-    private final Set<Link>     testsChangeRequests         = new HashSet<Link>();
-    private final Set<Link>     usesTestScripts             = new HashSet<Link>();
-    private final Set<Link>     validatesRequirements       = new HashSet<Link>();
+    private final Set<URI>      contributors                = new TreeSet<>();
+    private final Set<URI>      creators                    = new TreeSet<>();
+    private final Set<Link>     relatedChangeRequests       = new HashSet<>();
+    private final Set<String>   subjects                    = new TreeSet<>();
+    private final Set<Link>     testsChangeRequests         = new HashSet<>();
+    private final Set<Link>     usesTestScripts             = new HashSet<>();
+    private final Set<Link>     validatesRequirements       = new HashSet<>();
 
     private String   description;
 

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/TestExecutionRecord.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/TestExecutionRecord.java
@@ -39,10 +39,10 @@ import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
 public class TestExecutionRecord
        extends QmResource
 {
-    private final Set<Link>     blockedByChangeRequests       = new HashSet<Link>();
-    private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<Link>     relatedChangeRequests       = new HashSet<Link>();
+    private final Set<Link>     blockedByChangeRequests       = new HashSet<>();
+    private final Set<URI>      contributors                = new TreeSet<>();
+    private final Set<URI>      creators                    = new TreeSet<>();
+    private final Set<Link>     relatedChangeRequests       = new HashSet<>();
 
     private Link     reportsOnTestPlan;
     private URI      runsOnTestEnvironment;

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/TestPlan.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/TestPlan.java
@@ -41,12 +41,12 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public class TestPlan
        extends QmResource
 {
-	private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<Link>     relatedChangeRequests       = new HashSet<Link>();
-    private final Set<String>   subjects                    = new TreeSet<String>();
-    private final Set<Link>     usesTestCases               = new HashSet<Link>();
-    private final Set<Link>     validatesRequirementCollections = new HashSet<Link>();
+	private final Set<URI>      contributors                = new TreeSet<>();
+    private final Set<URI>      creators                    = new TreeSet<>();
+    private final Set<Link>     relatedChangeRequests       = new HashSet<>();
+    private final Set<String>   subjects                    = new TreeSet<>();
+    private final Set<Link>     usesTestCases               = new HashSet<>();
+    private final Set<Link>     validatesRequirementCollections = new HashSet<>();
 
     private String   description;
 

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/TestResult.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/TestResult.java
@@ -41,7 +41,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public class TestResult
        extends QmResource
 {
-    private final Set<Link>     affectedByChangeRequests       = new HashSet<Link>();
+    private final Set<Link>     affectedByChangeRequests       = new HashSet<>();
 
     private Link     executesTestScript;
     private Link     reportsOnTestCase;

--- a/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/TestScript.java
+++ b/client/oslc-java-client-resources/src/main/java/org/eclipse/lyo/client/oslc/resources/TestScript.java
@@ -41,10 +41,10 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 public class TestScript
        extends QmResource
 {
-    private final Set<URI>      contributors                = new TreeSet<URI>();
-    private final Set<URI>      creators                    = new TreeSet<URI>();
-    private final Set<Link>     relatedChangeRequests       = new HashSet<Link>();
-    private final Set<Link>     validatesRequirements       = new HashSet<Link>();
+    private final Set<URI>      contributors                = new TreeSet<>();
+    private final Set<URI>      creators                    = new TreeSet<>();
+    private final Set<Link>     relatedChangeRequests       = new HashSet<>();
+    private final Set<Link>     validatesRequirements       = new HashSet<>();
 
     private URI      executionInstructions;
     private String   description;

--- a/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/QueryUtils.java
+++ b/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/QueryUtils.java
@@ -42,21 +42,21 @@ public class QueryUtils
 	 * A property list that selects all properties
 	 */
 	static public final Properties WILDCARD_PROPERTY_LIST = (Properties)
-		Proxy.newProxyInstance(Properties.class.getClassLoader(), 
+		Proxy.newProxyInstance(Properties.class.getClassLoader(),
 				new Class<?>[] { Properties.class },
 				new PropertiesInvocationHandler());
-	
+
 	/**
 	 * Parse a oslc.prefix clause into a map between prefixes
 	 * and corresponding URIs
-	 * 
+	 *
 	 * <p><b>Note</b>: {@link Object#toString()} of result has been overridden to
 	 * return input expression.
-	 * 
+	 *
 	 * @param prefixExpression the oslc.prefix expression
-	 * 
+	 *
 	 * @return the prefix map
-	 * 
+	 *
 	 * @throws ParseException
 	 */
 	public static Map<String, String>
@@ -65,53 +65,53 @@ public class QueryUtils
 	) throws ParseException
 	{
 		if (prefixExpression == null) {
-			return new HashMap<String, String>();
+			return new HashMap<>();
 		}
-		
+
 		OslcPrefixParser parser = new OslcPrefixParser(prefixExpression);
-		
+
 		try {
-			
-			CommonTree rawTree = parser.oslc_prefixes().getTree();			 
+
+			CommonTree rawTree = parser.oslc_prefixes().getTree();
 
 			checkErrors(parser.getErrors());;
-			
+
 			PrefixMap prefixMap =
 				new PrefixMap(rawTree.getChildCount());
-			
+
 			for (int index = 0; index < rawTree.getChildCount(); index++) {
-				
+
 				Tree rawPrefix = rawTree.getChild(index);
-				
+
 				if (rawPrefix.getType() == Token.INVALID_TOKEN_TYPE) {
 					throw ((CommonErrorNode)rawPrefix).trappedException;
 				}
-				
+
 				String pn = rawPrefix.getChild(0).getText();
 				String uri = rawPrefix.getChild(1).getText();
-				
+
 				uri = uri.substring(1, uri.length() - 1);
-				
+
 				prefixMap.put(pn, uri);
 			}
-			
+
 			return prefixMap;
-			
+
 		} catch (RecognitionException e) {
 			throw new ParseException(e);
 		}
 	}
-	
+
 	/**
 	 * Parse a oslc.where expression
-	 *	
+	 *
 	 * @param whereExpression contents of an oslc.where HTTP query
 	 * parameter
 	 * @param prefixMap map between XML namespace prefixes and
 	 * associated URLs
-	 * 
+	 *
 	 * @return the parsed where clause
-	 * 
+	 *
 	 * @throws ParseException
 	 */
 	public static WhereClause
@@ -121,42 +121,42 @@ public class QueryUtils
 	) throws ParseException
 	{
 		OslcWhereParser parser = new OslcWhereParser(whereExpression);
-		
+
 		try {
-			
+
 			OslcWhereParser.oslc_where_return resultTree =
-				parser.oslc_where();			
+				parser.oslc_where();
 
 			checkErrors(parser.getErrors());;
-			
+
 			CommonTree rawTree = (CommonTree)resultTree.getTree();
 			Tree child = rawTree.getChild(0);
-			
+
 			if (child.getType() == Token.INVALID_TOKEN_TYPE) {
 				throw ((CommonErrorNode)child).trappedException;
 			}
-			
+
 			return (WhereClause)
-				Proxy.newProxyInstance(CompoundTerm.class.getClassLoader(), 
+				Proxy.newProxyInstance(CompoundTerm.class.getClassLoader(),
 						new Class<?>[] { CompoundTerm.class, WhereClause.class },
 						new CompoundTermInvocationHandler(
 								rawTree, true, prefixMap));
-			
+
 		} catch (RecognitionException e) {
 			throw new ParseException(e);
 		}
 	}
-	
+
 	/**
 	 * Parse a oslc.select expression
-	 *	
+	 *
 	 * @param selectExpression contents of an oslc.select HTTP query
 	 * parameter
 	 * @param prefixMap map between XML namespace prefixes and
 	 * associated URLs
-	 * 
+	 *
 	 * @return the parsed select clause
-	 * 
+	 *
 	 * @throws ParseException
 	 */
 	public static SelectClause
@@ -166,42 +166,42 @@ public class QueryUtils
 	) throws ParseException
 	{
 		OslcSelectParser parser = new OslcSelectParser(selectExpression);
-		
+
 		try {
-			
+
 			OslcSelectParser.oslc_select_return resultTree =
-				parser.oslc_select();			 
+				parser.oslc_select();
 
 			checkErrors(parser.getErrors());;
-			
+
 			CommonTree rawTree = (CommonTree)resultTree.getTree();
-			
+
 			if (rawTree.getType() == Token.INVALID_TOKEN_TYPE) {
 				throw ((CommonErrorNode)rawTree).trappedException;
-			}			 
-			
+			}
+
 			return (SelectClause)
-				Proxy.newProxyInstance(SelectClause.class.getClassLoader(), 
+				Proxy.newProxyInstance(SelectClause.class.getClassLoader(),
 						new Class<?>[] { SelectClause.class, Properties.class },
 						new PropertiesInvocationHandler(
 								(CommonTree)resultTree.getTree(),
 								prefixMap));
-			
+
 		} catch (RecognitionException e) {
 			throw new ParseException(e);
 		}
 	}
-	
+
 	/**
 	 * Parse a oslc.properties expression
-	 *	
+	 *
 	 * @param propertiesExpression contents of an oslc.properties HTTP query
 	 * parameter
 	 * @param prefixMap map between XML namespace prefixes and
 	 * associated URLs
-	 * 
+	 *
 	 * @return the parsed properties clause
-	 * 
+	 *
 	 * @throws ParseException
 	 */
 	public static PropertiesClause
@@ -211,42 +211,42 @@ public class QueryUtils
 	) throws ParseException
 	{
 		OslcSelectParser parser = new OslcSelectParser(propertiesExpression);
-		
+
 		try {
 
 			OslcSelectParser.oslc_select_return resultTree =
-				parser.oslc_select();			 
+				parser.oslc_select();
 
 			checkErrors(parser.getErrors());;
-			
+
 			CommonTree rawTree = (CommonTree)resultTree.getTree();
-			
+
 			if (rawTree.getType() == Token.INVALID_TOKEN_TYPE) {
 				throw ((CommonErrorNode)rawTree).trappedException;
 			}
-			
+
 			return (PropertiesClause)
-				Proxy.newProxyInstance(PropertiesClause.class.getClassLoader(), 
+				Proxy.newProxyInstance(PropertiesClause.class.getClassLoader(),
 						new Class<?>[] { PropertiesClause.class, Properties.class },
 						new PropertiesInvocationHandler(
 								(CommonTree)resultTree.getTree(),
 								prefixMap));
-			
+
 		} catch (RecognitionException e) {
 			throw new ParseException(e);
 		}
 	}
-	
+
 	/**
 	 * Parse a oslc.orderBy expression
-	 *	
+	 *
 	 * @param orderByExpression contents of an oslc.orderBy HTTP query
 	 * parameter
 	 * @param prefixMap map between XML namespace prefixes and
 	 * associated URLs
-	 * 
+	 *
 	 * @return the parsed order by clause
-	 * 
+	 *
 	 * @throws ParseException
 	 */
 	public static OrderByClause
@@ -256,41 +256,41 @@ public class QueryUtils
 	) throws ParseException
 	{
 		OslcOrderByParser parser = new OslcOrderByParser(orderByExpression);
-		
+
 		try {
-			
+
 			OslcOrderByParser.oslc_order_by_return resultTree =
 				parser.oslc_order_by();
 
 			checkErrors(parser.getErrors());;
-			
+
 			CommonTree rawTree = (CommonTree)resultTree.getTree();
 			Tree child = rawTree.getChild(0);
-			
+
 			if (child.getType() == Token.INVALID_TOKEN_TYPE) {
 				throw ((CommonErrorNode)child).trappedException;
 			}
-			
+
 			return (OrderByClause)
-					Proxy.newProxyInstance(OrderByClause.class.getClassLoader(), 
+					Proxy.newProxyInstance(OrderByClause.class.getClassLoader(),
 							new Class<?>[] { OrderByClause.class, SortTerms.class },
 							new SortTermsInvocationHandler(rawTree, prefixMap));
-			
+
 		} catch (RecognitionException e) {
 			throw new ParseException(e);
 		}
 	}
-	
+
 	/**
 	 * Create a map representation of the {@link Properties} returned
 	 * from parsing oslc.properties or olsc.select URL query
 	 * parameters suitable for generating a property result from an
 	 * HTTP GET request.<p>
-	 * 
+	 *
 	 * The map keys are the property names; i.e. the local name of the
 	 * property concatenated to the XML namespace of the property.	The
 	 * values of the map are:<p>
-	 * 
+	 *
 	 * <ul>
 	 * <li> Wildcard, if all
 	 * properties at this level are to be output.  No recursion
@@ -299,120 +299,120 @@ public class QueryUtils
 	 * the named property is to be output, without recursion</li>
 	 * <li> a nested property list to recurse through</li>
 	 * </ul>
-	 * 
+	 *
 	 * @param properties
-	 * 
+	 *
 	 * @return the property map
 	 */
 	public static Map<String, Object>
 	invertSelectedProperties(final Properties properties)
 	{
 		List<Property> children = properties.children();
-		Map<String, Object> result = new HashMap<String, Object>(children.size());
-		
+		Map<String, Object> result = new HashMap<>(children.size());
+
 		for (Property property : children) {
-			
+
 			PName pname = null;
 			String propertyName = null;
-			
+
 			if (! property.isWildcard()) {
 				pname = property.identifier();
 				propertyName = pname.namespace + pname.local;
 			}
-			
+
 			switch (property.type()) {
 			case IDENTIFIER:
 				if (property.isWildcard()) {
-					
+
 					if (result instanceof SingletonWildcardProperties) {
 						break;
 					}
-					
+
 					if (result instanceof NestedWildcardProperties) {
 						result = new BothWildcardPropertiesImpl(
 								(NestedWildcardPropertiesImpl)result);
 					} else {
 						result = new SingletonWildcardPropertiesImpl();
 					}
-					
+
 					break;
-					
+
 				} else {
-					
+
 					if (result instanceof SingletonWildcardProperties) {
 						break;
 					}
 				}
-				
+
 				result.put(propertyName,
 						   OSLC4JConstants.OSL4J_PROPERTY_SINGLETON);
-				
+
 				break;
-				
+
 			case NESTED_PROPERTY:
 				if (property.isWildcard()) {
-					
-					if (! (result instanceof NestedWildcardProperties)) {						 
+
+					if (! (result instanceof NestedWildcardProperties)) {
 						if (result instanceof SingletonWildcardProperties) {
 							result = new BothWildcardPropertiesImpl();
 						} else {
 							result = new NestedWildcardPropertiesImpl(result);
 						}
-						
+
 						((NestedWildcardPropertiesImpl)result).commonNestedProperties =
 							invertSelectedProperties((NestedProperty)property);
-						
+
 				   } else {
 						mergePropertyMaps(
 							((NestedWildcardProperties)result).commonNestedProperties(),
 							invertSelectedProperties((NestedProperty)property));
 				   }
-					
+
 					break;
 				}
-				
+
 				result.put(propertyName,
 						   invertSelectedProperties(
 								   (NestedProperty)property));
-				
+
 				break;
 			}
 		}
-		
+
 		if (! (result instanceof NestedWildcardProperties)) {
 			return result;
 		}
-		
+
 		Map<String, Object> commonNestedProperties =
 			((NestedWildcardProperties)result).commonNestedProperties();
-		
+
 		for (Map.Entry<String, Object> propertyMapping : result.entrySet()) {
-			
+
 			@SuppressWarnings("unchecked")
 			Map<String, Object> nestedProperties =
 				(Map<String, Object>)propertyMapping.getValue();
-			
+
 			if (nestedProperties == OSLC4JConstants.OSL4J_PROPERTY_SINGLETON) {
 				result.put(propertyMapping.getKey(), commonNestedProperties);
 			} else {
 				mergePropertyMaps(nestedProperties, commonNestedProperties);
 			}
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Parse a oslc.searchTerms expression
-	 * 
+	 *
 	 * <p><b>Note</b>: {@link Object#toString()} of result has been overridden to
 	 * return input expression.
-	 *	
+	 *
 	 * @param searchTermsExpression contents of an oslc.searchTerms HTTP query
 	 * parameter
-	 * 
+	 *
 	 * @return the parsed search terms clause
-	 * 
+	 *
 	 * @throws ParseException
 	 */
 	public static SearchTermsClause
@@ -421,39 +421,39 @@ public class QueryUtils
 	) throws ParseException
 	{
 		OslcSearchTermsParser parser = new OslcSearchTermsParser(searchTermsExpression);
-		
+
 		try {
-			
+
 			OslcSearchTermsParser.oslc_search_terms_return resultTree =
-				parser.oslc_search_terms();			   
+				parser.oslc_search_terms();
 
 			checkErrors(parser.getErrors());;
-			
+
 			CommonTree rawTree = (CommonTree)resultTree.getTree();
 			Tree child = rawTree.getChild(0);
-			
+
 			if (child.getType() == Token.INVALID_TOKEN_TYPE) {
 				throw ((CommonErrorNode)child).trappedException;
 			}
-			
+
 			StringList stringList = new StringList(rawTree.getChildCount());
-			
+
 			for (int index = 0; index < rawTree.getChildCount(); index++) {
-				
+
 				Tree string = rawTree.getChild(index);
-				
+
 				String rawString = string.getText();
-				
+
 				stringList.add(rawString.substring(1, rawString.length()-1));
 			}
-			
+
 			return stringList;
-			
+
 		} catch (RecognitionException e) {
 			throw new ParseException(e);
 		}
 	}
-	
+
 	/**
 	 * Implementation of a {@link SearchTermsClause} interface
 	 */
@@ -465,32 +465,32 @@ public class QueryUtils
 		{
 			super(size);
 		}
-		
+
 		public String
 		toString()
 		{
 			StringBuffer buffer = new StringBuffer();
 			boolean first = true;
-			
+
 			for (String string : this) {
-				
+
 				if (first) {
 					first = false;
 				} else {
 					buffer.append(',');
 				}
-				
+
 				buffer.append('"');
 				buffer.append(string);
 				buffer.append('"');
 			}
-			
+
 			return buffer.toString();
 		}
-		
+
 		private static final long serialVersionUID = 1943909246265711359L;
 	}
-	
+
 	/**
 	 * Implementation of a Map<String, String> prefixMap
 	 */
@@ -501,34 +501,34 @@ public class QueryUtils
 		{
 			super(size);
 		}
-		
+
 		public String
 		toString()
 		{
 			StringBuffer buffer = new StringBuffer();
 			Iterator<String> keys = this.keySet().iterator();
 			boolean first = true;
-			
+
 			while (keys.hasNext()) {
-				
+
 				if (first) {
 					first = false;
 				} else {
 					buffer.append(',');
 				}
-				
+
 				String key = keys.next();
-				
+
 				buffer.append(key);
 				buffer.append('=');
 				buffer.append('<');
 				buffer.append(this.get(key));
 				buffer.append('>');
 			}
-			
+
 			return buffer.toString();
 		}
-		
+
 		private static final long serialVersionUID = 1943909246265711359L;
 	}
 	/**
@@ -546,7 +546,7 @@ public class QueryUtils
 
 		private static final long serialVersionUID = -5490896670186283412L;
 	}
-	
+
 	/**
 	 * Implementation of {@link NestedWildcardProperties}
 	 */
@@ -559,24 +559,24 @@ public class QueryUtils
 		{
 			super(accumulated);
 		}
-		
+
 		protected
 		NestedWildcardPropertiesImpl()
 		{
 			super(0);
 		}
-		
+
 		public Map<String, Object>
 		commonNestedProperties()
 		{
 			return commonNestedProperties;
 		}
-		
+
 		protected Map<String, Object> commonNestedProperties =
-			new HashMap<String, Object>();
+            new HashMap<>();
 		private static final long serialVersionUID = -938983371894966574L;
 	}
-	
+
 	/**
 	 * Implementation of both {@link SingletonWildcardProperties} and
 	 * {@link NestedWildcardProperties}
@@ -589,22 +589,22 @@ public class QueryUtils
 		BothWildcardPropertiesImpl()
 		{
 		}
-		
+
 		public
 		BothWildcardPropertiesImpl(NestedWildcardPropertiesImpl accumulated)
 		{
 			this();
-			
+
 			commonNestedProperties = accumulated.commonNestedProperties();
 		}
 
 		private static final long serialVersionUID = 654939845613307220L;
 	}
-	
+
 	/**
 	 * Merge into {@link #lhs} properties those of {@link #rhs} property
 	 * map, merging any common, nested property maps
-	 * 
+	 *
 	 * @param lhs target of property map merge
 	 * @param rhs source of property map merge
 	 */
@@ -615,9 +615,9 @@ public class QueryUtils
 	)
 	{
 		Iterator<String> propertyNames = rhs.keySet().iterator();
-		
+
 		while (propertyNames.hasNext()) {
-			
+
 			String propertyName = propertyNames.next();
 			@SuppressWarnings("unchecked")
 			Map<String, Object> lhsNestedProperties =
@@ -625,19 +625,19 @@ public class QueryUtils
 			@SuppressWarnings("unchecked")
 			Map<String, Object> rhsNestedProperties =
 				(Map<String, Object>)rhs.get(propertyName);
-			
+
 			if (lhsNestedProperties == rhsNestedProperties) {
 				continue;
 			}
-			
+
 			if (lhsNestedProperties == null ||
 				lhsNestedProperties == OSLC4JConstants.OSL4J_PROPERTY_SINGLETON) {
-				
+
 				lhs.put(propertyName, rhsNestedProperties);
-				
+
 				continue;
 			}
-			
+
 			mergePropertyMaps(lhsNestedProperties, rhsNestedProperties);
 		}
 	}
@@ -645,9 +645,9 @@ public class QueryUtils
 	/**
 	 * Check list of errors from parsing some expression, generating
 	 * @{link {@link ParseException} if there are any.
-	 * 
+	 *
 	 * @param errors list of errors, hopefully empty
-	 * 
+	 *
 	 * @throws ParseException
 	 */
 	private static void
@@ -656,21 +656,21 @@ public class QueryUtils
 		if (errors.isEmpty()) {
 			return;
 		}
-			
+
 		StringBuffer buffer = new StringBuffer();
 		boolean first = true;
-		
+
 		for (String error : errors) {
-			
+
 			if (first) {
 				first = false;
 			} else {
 				buffer.append('\n');
 			}
-			
+
 			buffer.append(error);
 		}
-		
+
 		throw new ParseException(buffer.toString());
 	}
 }

--- a/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/impl/CompoundTermInvocationHandler.java
+++ b/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/impl/CompoundTermInvocationHandler.java
@@ -44,11 +44,11 @@ public class CompoundTermInvocationHandler extends SimpleTermInvocationHandler
 		super(isTopLevel ? null : tree,
 			  isTopLevel ? Type.TOP_LEVEL : Type.NESTED,
 			  prefixMap);
-		
+
 		this.tree = tree;
 		this.isTopLevel = isTopLevel;
 	}
-	
+
 	/**
 	 * @see java.lang.reflect.InvocationHandler#invoke(java.lang.Object, java.lang.reflect.Method, java.lang.Object[])
 	 */
@@ -62,49 +62,49 @@ public class CompoundTermInvocationHandler extends SimpleTermInvocationHandler
 	{
 		String methodName = method.getName();
 		boolean isChildren = methodName.equals("children");
-		
+
 		if (! isChildren &&
 			! methodName.equals("toString")) {
 			return super.invoke(proxy, method, args);
 		}
-		
+
 		if (children != null) {
 			return children;
 		}
-		
+
 		Tree currentTree =
 			isTopLevel ?
 				tree :
 				tree.getChild(1);
-		
+
 		children =
-			new ArrayList<SimpleTerm>(
-					currentTree.getChildCount() - (isTopLevel ? 0 : 1));
-		
+            new ArrayList<>(
+                currentTree.getChildCount() - (isTopLevel ? 0 : 1));
+
 		for (int index = 0; index < currentTree.getChildCount(); index++) {
-			
+
 			Tree child = currentTree.getChild(index);
-			
+
 			Object simpleTerm;
-			
+
 			switch(child.getType()) {
 			case OslcWhereParser.SIMPLE_TERM:
-				simpleTerm = 
-					Proxy.newProxyInstance(ComparisonTerm.class.getClassLoader(), 
+				simpleTerm =
+					Proxy.newProxyInstance(ComparisonTerm.class.getClassLoader(),
 							new Class<?>[] { ComparisonTerm.class },
 							new ComparisonTermInvocationHandler(
 									child, prefixMap));
 				break;
 			case OslcWhereParser.IN_TERM:
-				simpleTerm = 
-					Proxy.newProxyInstance(InTerm.class.getClassLoader(), 
+				simpleTerm =
+					Proxy.newProxyInstance(InTerm.class.getClassLoader(),
 							new Class<?>[] { InTerm.class },
 							new InTermInvocationHandler(
 									child, prefixMap));
 				break;
 			case OslcWhereParser.COMPOUND_TERM:
-				simpleTerm = 
-					Proxy.newProxyInstance(CompoundTerm.class.getClassLoader(), 
+				simpleTerm =
+					Proxy.newProxyInstance(CompoundTerm.class.getClassLoader(),
 							new Class<?>[] { CompoundTerm.class },
 							new CompoundTermInvocationHandler(
 									child, false, prefixMap));
@@ -112,43 +112,43 @@ public class CompoundTermInvocationHandler extends SimpleTermInvocationHandler
 			default:
 				throw new IllegalStateException("unimplemented type of simple term: " + child.getText());
 			}
-			
+
 			children.add((SimpleTerm)simpleTerm);
 		}
-		
+
 		children = Collections.unmodifiableList(children);
-		
+
 		if (isChildren) {
 			return children;
 		}
-		
+
 		StringBuffer buffer = new StringBuffer();
-		
+
 		if (! isTopLevel) {
 			buffer.append(((CompoundTerm)proxy).property().toString());
 			buffer.append('{');
 		}
-		
+
 		boolean first = true;
-		
+
 		for (SimpleTerm term : children) {
-			
+
 			if (first) {
 				first = false;
 			} else {
 				buffer.append(" and ");
 			}
-			
+
 			buffer.append(term.toString());
 		}
-		
+
 		if (! isTopLevel) {
 			buffer.append('}');
 		}
-		
+
 		return buffer.toString();
 	}
-	
+
 	private final Tree tree;
 	private final boolean isTopLevel;
 	private List<SimpleTerm> children = null;

--- a/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/impl/InTermInvocationHandler.java
+++ b/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/impl/InTermInvocationHandler.java
@@ -38,7 +38,7 @@ class InTermInvocationHandler extends SimpleTermInvocationHandler
 	{
 		super(tree, Type.IN_TERM, prefixMap);
 	}
-	
+
 	/**
 	 * @see java.lang.reflect.InvocationHandler#invoke(java.lang.Object, java.lang.reflect.Method, java.lang.Object[])
 	 */
@@ -52,59 +52,59 @@ class InTermInvocationHandler extends SimpleTermInvocationHandler
 	{
 		String methodName = method.getName();
 		boolean isValues = methodName.equals("values");
-		
+
 		if (! isValues &&
 			! methodName.equals("toString")) {
 			return super.invoke(proxy, method, args);
 		}
-		
+
 		if (values == null) {
-			
+
 			Tree currentTree = tree.getChild(1);
-			
-			values = new ArrayList<Value>(currentTree.getChildCount() - 1);
-			
+
+			values = new ArrayList<>(currentTree.getChildCount() - 1);
+
 			for (int index = 0; index < currentTree.getChildCount(); index++) {
-				
+
 				Tree treeValue = currentTree.getChild(index);
-				
+
 				Value value =
 					ComparisonTermInvocationHandler.createValue(
 							treeValue, "unspported literal value type",
 							prefixMap);
-				
+
 				values.add(value);
 			}
-			
+
 			values = Collections.unmodifiableList(values);
 		}
-		
+
 		if (isValues) {
 			return values;
 		}
-		
+
 		StringBuffer buffer = new StringBuffer();
-		
+
 		buffer.append(((InTerm)proxy).property().toString());
 		buffer.append(" in [");
-		
+
 		boolean first = true;
-		
+
 		for (Value value : values) {
-			
+
 			if (first) {
 				first = false;
 			} else {
 				buffer.append(',');
 			}
-			
+
 			buffer.append(value.toString());
 		}
-		
+
 		buffer.append(']');
-		
+
 		return buffer.toString();
 	}
-	
+
 	private List<Value> values = null;
 }

--- a/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/impl/PropertiesInvocationHandler.java
+++ b/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/impl/PropertiesInvocationHandler.java
@@ -45,7 +45,7 @@ public class PropertiesInvocationHandler implements InvocationHandler
 		this.tree = tree;
 		this.prefixMap = prefixMap;
 	}
-	
+
 	/**
 	 * Construct a {@link Properties} proxy that has a single
 	 * {@link Wildcard} child
@@ -55,15 +55,15 @@ public class PropertiesInvocationHandler implements InvocationHandler
 	{
 		this.tree = null;
 		this.prefixMap = null;
-		
-		children = new ArrayList<Property>(1);
-		
+
+		children = new ArrayList<>(1);
+
 		children.add((Property)Proxy.newProxyInstance(
-						Wildcard.class.getClassLoader(), 
+						Wildcard.class.getClassLoader(),
 						new Class<?>[] { Wildcard.class },
 						new WildcardInvocationHandler()));
    }
-	
+
 	/**
 	 * @see java.lang.reflect.InvocationHandler#invoke(java.lang.Object, java.lang.reflect.Method, java.lang.Object[])
 	 */
@@ -75,28 +75,28 @@ public class PropertiesInvocationHandler implements InvocationHandler
 	) throws Throwable
 	{
 		boolean isChildren = method.getName().equals("children");
-		
+
 		if (isChildren && children != null) {
 			return children;
 		}
-		
+
 		children = createChildren(tree, prefixMap);
-		
+
 		if (isChildren) {
 			return children;
 		}
-		
+
 		StringBuffer buffer = childrenToString(new StringBuffer(), children);
-		
+
 		return buffer.toString();
 	}
-	
+
 	/**
 	 * Generate a list of property children from a parse tree node
-	 * 
+	 *
 	 * @param tree
 	 * @param prefixMap
-	 * 
+	 *
 	 * @return the resulting property list
 	 */
 	static List<Property>
@@ -105,25 +105,25 @@ public class PropertiesInvocationHandler implements InvocationHandler
 		Map<String, String> prefixMap
 	)
 	{
-		List<Property> children = new ArrayList<Property>(tree.getChildCount());
-		
+		List<Property> children = new ArrayList<>(tree.getChildCount());
+
 		for (int index = 0; index < tree.getChildCount(); index++) {
 
 			Tree treeChild = tree.getChild(index);
-			
+
 			Property property;
-			
+
 			switch (treeChild.getType())
 			{
 			case OslcSelectParser.WILDCARD:
 				property = (Property)
-					Proxy.newProxyInstance(Wildcard.class.getClassLoader(), 
+					Proxy.newProxyInstance(Wildcard.class.getClassLoader(),
 							new Class<?>[] { Wildcard.class },
 							new WildcardInvocationHandler());
 				break;
 			case OslcSelectParser.PREFIXED_NAME:
 				property = (Property)
-					Proxy.newProxyInstance(Identifier.class.getClassLoader(), 
+					Proxy.newProxyInstance(Identifier.class.getClassLoader(),
 							new Class<?>[] { Identifier.class },
 							new PropertyInvocationHandler(
 									(CommonTree)treeChild.getChild(0),
@@ -132,27 +132,27 @@ public class PropertiesInvocationHandler implements InvocationHandler
 			default:
 			case OslcSelectParser.NESTED_PROPERTIES:
 				property = (Property)
-					Proxy.newProxyInstance(NestedProperty.class.getClassLoader(), 
+					Proxy.newProxyInstance(NestedProperty.class.getClassLoader(),
 							new Class<?>[] { NestedProperty.class },
 							new NestedPropertyInvocationHandler(treeChild,
 																prefixMap));
 				break;
 			}
-			
+
 			children.add(property);
 		}
-		
+
 		children = Collections.unmodifiableList(children);
-		
+
 		return children;
 	}
-	
+
 	/**
 	 * Generate string representation of a children property list
-	 * 
+	 *
 	 * @param buffer
 	 * @param children
-	 * 
+	 *
 	 * @return the buffer representation of the property list
 	 */
 	static StringBuffer
@@ -162,21 +162,21 @@ public class PropertiesInvocationHandler implements InvocationHandler
 	)
 	{
 		boolean first = true;
-		 
+
 		 for (Property property : children) {
-			 
+
 			 if (first) {
 				 first = false;
 			 } else {
 				 buffer.append(',');
 			 }
-			 
+
 			 buffer.append(property.toString());
 		 }
-		
+
 		 return buffer;
 	}
-	
+
 	private final CommonTree tree;
 	protected final Map<String, String> prefixMap;
 	private List<Property> children = null;

--- a/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/impl/SortTermsInvocationHandler.java
+++ b/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/impl/SortTermsInvocationHandler.java
@@ -41,7 +41,7 @@ public class SortTermsInvocationHandler implements InvocationHandler
 		this.tree = tree;
 		this.prefixMap = prefixMap;
 	}
-	
+
 	/**
 	 * @see java.lang.reflect.InvocationHandler#invoke(java.lang.Object, java.lang.reflect.Method, java.lang.Object[])
 	 */
@@ -54,26 +54,26 @@ public class SortTermsInvocationHandler implements InvocationHandler
 	) throws Throwable
 	{
 		if (children == null) {
-			
-			children = new ArrayList<SortTerm>(tree.getChildCount());
-			
+
+			children = new ArrayList<>(tree.getChildCount());
+
 			for (int index = 0; index < tree.getChildCount(); index++) {
-				
+
 				Tree child = tree.getChild(index);
-				
+
 				Object simpleTerm;
-				
+
 				switch(child.getType()) {
 				case OslcOrderByParser.SIMPLE_TERM:
-					simpleTerm = 
-						Proxy.newProxyInstance(SimpleSortTerm.class.getClassLoader(), 
+					simpleTerm =
+						Proxy.newProxyInstance(SimpleSortTerm.class.getClassLoader(),
 								new Class<?>[] { SimpleSortTerm.class },
 								new SimpleSortTermInvocationHandler(
 										child, prefixMap));
 					break;
 				case OslcOrderByParser.SCOPED_TERM:
-					simpleTerm = 
-						Proxy.newProxyInstance(ScopedSortTerm.class.getClassLoader(), 
+					simpleTerm =
+						Proxy.newProxyInstance(ScopedSortTerm.class.getClassLoader(),
 								new Class<?>[] { ScopedSortTerm.class },
 								new ScopedSortTermInvocationHandler(
 										child, prefixMap));
@@ -81,31 +81,31 @@ public class SortTermsInvocationHandler implements InvocationHandler
 				default:
 					throw new IllegalStateException("unimplemented type of sort term: " + child.getText());
 				}
-				
+
 				children.add((SortTerm)simpleTerm);
 			}
-			
+
 			children = Collections.unmodifiableList(children);
 		}
-		
-		if (method.getName().equals("children")) {		  
+
+		if (method.getName().equals("children")) {
 			return children;
 		}
-		
+
 		StringBuffer buffer = new StringBuffer();
 		boolean first = true;
-		
+
 		for (SortTerm term : children) {
-			
+
 			if (first) {
 				first = false;
 			} else {
 				buffer.append(',');
 			}
-			
+
 			buffer.append(term.toString());
 		}
-		
+
 		return buffer.toString();
 	}
 

--- a/core/oslc-trs/src/main/java/org/eclipse/lyo/core/trs/Base.java
+++ b/core/oslc-trs/src/main/java/org/eclipse/lyo/core/trs/Base.java
@@ -39,12 +39,12 @@ import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
  * Container where each member references a Resource that was in the Resource
  * Set at the time the Base was computed. HTTP GET on a Base URI returns an RDF
  * container with the following structure:
- * 
+ *
  * <pre>
  * {@literal @prefix trs: <http://open-services.net/ns/core/trs#> .}
  * {@literal @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .}
  * {@literal @prefix ldp: <http://www.w3.org/ns/ldp#> .}
- * 
+ *
  * {@code
  * <https://.../baseResources>
  *	a ldp:Container;
@@ -57,7 +57,7 @@ import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
  *	rdfs:member <http://cm1.example.com/bugs/200> .
  * }
  * </pre>
- * 
+ *
  * <p>
  * Each Resource in the Resource Set MUST be referenced from the container using
  * an rdfs:member predicate. The Base MAY be broken into multiple pages in which
@@ -66,7 +66,7 @@ import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
  * will contain a subset of the Base’s rdfs:member predicates. In addition, it
  * will contain another triple, whose subject is the page resource itself (i.e.,
  * not the Base resource), with a reference to the next page:
- * 
+ *
  * <pre>
  * {@code
  * <https://.../baseResources/page1>
@@ -75,13 +75,13 @@ import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
  *	 ldp:nextPage <https://../baseResources/page2> .
  * }
  * </pre>
- * 
+ *
  * <p>
  * The last page in the list is indicated by a ldp:nextPage value of rdf:nil.
  * The Tracked Resource Set protocol does not attach significance to the order
  * in which a Server enumerates the resources in the Base or breaks the Base up
  * into pages.
- * 
+ *
  * <p>
  * The first page of a Base MUST include a trs:cutoffEvent property, whose value
  * is the URI of the most recent Change Event in the corresponding Change Log
@@ -92,7 +92,7 @@ import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
  * in the non-truncated portion of the Change Log. When the trs:cutoffEvent is
  * rdf:nil, the Base enumerates the (possibly empty) Resource Set at the
  * beginning of time.
- * 
+ *
  * <p>
  * Because of the highly dynamic nature of the Resource Set, a Server may have
  * difficulty enumerating the exact set of resources at a point in time. Because
@@ -107,7 +107,7 @@ import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
  * dereferenced the Tracked Resource Set URI. The Client might only see a
  * corrective Change Event when it processes the Change Log resource obtained by
  * dereferencing the Tracked Resource Set URI on later occasions.
- * 
+ *
  * <p>
  * When a Base is broken into pages, the Client will discover and retrieve Base
  * page resources to determine the Resources in the Base. A Client MUST retrieve
@@ -120,7 +120,7 @@ import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
  * necessarily an approximation of the Resource Set which, when corrected by
  * Change Events after the Base’s cutoff event, yields the correct set of member
  * Resources in the Resource Set.
- * 
+ *
  * <p>
  * A Server MUST refer to a given resource using the exact same URI in the Base
  * ( rdfs:member reference) and every Change Event ( trs:changed reference) for
@@ -133,7 +133,7 @@ public class Base extends AbstractResource {
 	private List<URI> members;
 	private URI cutoffEvent;
 	private Page nextPage;
-	
+
 	/**
 	 * @return the members
 	 */
@@ -143,11 +143,11 @@ public class Base extends AbstractResource {
 	@OslcTitle("Member")
 	public List<URI> getMembers() {
 		if(members == null){
-			members = new ArrayList<URI>();
+			members = new ArrayList<>();
 		}
 		return members;
 	}
-	
+
 	/**
 	 * @param members the members to set
 	 */
@@ -177,7 +177,7 @@ public class Base extends AbstractResource {
 	 * The OslcHidden annotation works around a limitation in OSLC4J.  If we do
 	 * not hide the nextPage variable we get an incorrect ldp:nextPage reference
 	 * in the Base.
-	 * 
+	 *
 	 * @return the nextPage
 	 */
 	@OslcHidden(value=true)

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JConstants.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JConstants.java
@@ -25,7 +25,7 @@ public interface OSLC4JConstants {
 	String OSLC4J_USE_BEAN_CLASS_FOR_PARSING = OSLC4J + "useBeanClassForParsing";
 	String OSLC4J_INFER_TYPE_FROM_SHAPE      = OSLC4J + "inferTypeFromResourceShape";
 
-	Map<String, Object> OSL4J_PROPERTY_SINGLETON = new HashMap<String, Object>(0);
+	Map<String, Object> OSL4J_PROPERTY_SINGLETON = new HashMap<>(0);
 
 	String OSLC4J_SELECTED_PROPERTIES = OSLC4J + "selected.properties";
 	String OSLC4J_NEXT_PAGE           = OSLC4J + "next.page";

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/OslcGlobalNamespaceProvider.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/OslcGlobalNamespaceProvider.java
@@ -20,37 +20,37 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcSchema;
 
 /**
  * Defines the global namespace prefix mappings.
- * The global namespace mappings do not take precedence 
- * over any other namespace mappings definition, which means 
- * that in case of conflict the {@link OslcSchema} will 
- * override the prefix. 
- * 
- * This class is a singleton instance, that can be obtained 
- * calling {@link #getInstance()}, since it works with 
+ * The global namespace mappings do not take precedence
+ * over any other namespace mappings definition, which means
+ * that in case of conflict the {@link OslcSchema} will
+ * override the prefix.
+ *
+ * This class is a singleton instance, that can be obtained
+ * calling {@link #getInstance()}, since it works with
  * any request even if there are no annotation mapping.
- * 
+ *
  * @author Daniel Figueiredo Caetano
  *
  */
 public class OslcGlobalNamespaceProvider {
 
 	private static OslcGlobalNamespaceProvider instance;
-	
+
 	private Map<String, String> prefixDefinitionMap;
-	
+
 	/**
 	 * Private construct for singleton pattern.
 	 */
 	private OslcGlobalNamespaceProvider()
 	{
-		this.prefixDefinitionMap = new HashMap<String, String>();
+		this.prefixDefinitionMap = new HashMap<>();
 	}
-	
+
 	/**
 	 * Gets the unique instance of this class.
 	 * @return singleton class instance.
 	 */
-	public static OslcGlobalNamespaceProvider getInstance() 
+	public static OslcGlobalNamespaceProvider getInstance()
 	{
 		if(null == instance) {
 			synchronized (OslcGlobalNamespaceProvider.class) {
@@ -63,17 +63,17 @@ public class OslcGlobalNamespaceProvider {
 	}
 
 	/**
-	 * Gets the Global namespace mappings, these mappings are 
-	 * applied to all operations, even without the annotation 
+	 * Gets the Global namespace mappings, these mappings are
+	 * applied to all operations, even without the annotation
 	 * mappings.
-	 * 
+	 *
 	 * key	 - prefix
 	 * value - namespace
-	 * 
+	 *
 	 * @return empty hash map instance if there are no global
 	 *	namespace mappings.
 	 */
-	public Map<String, String> getPrefixDefinitionMap() 
+	public Map<String, String> getPrefixDefinitionMap()
 	{
 		return prefixDefinitionMap;
 	}
@@ -81,16 +81,16 @@ public class OslcGlobalNamespaceProvider {
 	/**
 	 * Sets the global prefix definition map with the given map.
 	 * Note that this operation overrides the current map.
-	 * 
+	 *
 	 * @param prefixDefinitionMap that will replace the current.
 	 */
-	public void setPrefixDefinitionMap(Map<String, String> prefixDefinitionMap) 
+	public void setPrefixDefinitionMap(Map<String, String> prefixDefinitionMap)
 	{
-		if(null == prefixDefinitionMap) 
+		if(null == prefixDefinitionMap)
 		{
 			this.prefixDefinitionMap.clear();
-		} 
-		else 
+		}
+		else
 		{
 			this.prefixDefinitionMap = prefixDefinitionMap;
 		}

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/AbstractResource.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/AbstractResource.java
@@ -23,8 +23,8 @@ import javax.xml.namespace.QName;
 
 public abstract class AbstractResource implements IExtendedResource {
 	private URI about;
-	private Collection<URI> types = new ArrayList<URI>();
-	private Map<QName, Object> extendedProperties = new HashMap<QName, Object>();
+	private Collection<URI> types = new ArrayList<>();
+	private Map<QName, Object> extendedProperties = new HashMap<>();
 
 	protected AbstractResource(final URI about) {
 		super();
@@ -45,7 +45,7 @@ public abstract class AbstractResource implements IExtendedResource {
 	public final void setAbout(final URI about) {
 		this.about = about;
 	}
-	
+
 	@Override
 	public void setExtendedProperties(final Map<QName, Object> properties)
 	{

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/AllowedValues.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/AllowedValues.java
@@ -54,7 +54,7 @@ public final class AllowedValues extends AbstractResource {
     @Deprecated
     public String[] getAllowedValues() {
         // Be compatible with the old behavior and only include String values.
-        ArrayList<String> stringValues = new ArrayList<String>();
+        ArrayList<String> stringValues = new ArrayList<>();
         Collection<?> values = (Collection<?>) getExtendedProperties().get(PROPERTY_ALLOWED_VALUE);
         for (Object o : values) {
             if (o instanceof String) {

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/CreationFactory.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/CreationFactory.java
@@ -33,9 +33,9 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Creation Factory Resource Shape", describes = OslcConstants.TYPE_CREATION_FACTORY)
 public class CreationFactory extends AbstractResource {
-	private final SortedSet<URI> resourceShapes = new TreeSet<URI>();
-	private final SortedSet<URI> resourceTypes = new TreeSet<URI>();
-	private final SortedSet<URI> usages = new TreeSet<URI>();
+	private final SortedSet<URI> resourceShapes = new TreeSet<>();
+	private final SortedSet<URI> resourceTypes = new TreeSet<>();
+	private final SortedSet<URI> usages = new TreeSet<>();
 
 	private URI creation;
 	private String label;

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Dialog.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Dialog.java
@@ -31,8 +31,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Dialog Resource Shape", describes = OslcConstants.TYPE_DIALOG)
 public class Dialog extends AbstractResource {
-	private final SortedSet<URI> resourceTypes = new TreeSet<URI>();
-	private final SortedSet<URI> usages = new TreeSet<URI>();
+	private final SortedSet<URI> resourceTypes = new TreeSet<>();
+	private final SortedSet<URI> usages = new TreeSet<>();
 
 	private URI dialog;
 	private String hintHeight;

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Property.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Property.java
@@ -92,7 +92,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 	public URI getAllowedValuesRef() {
 		return allowedValuesRef;
 	}
-	
+
 	public Object getDefaultValueObject() {
 		return getExtendedProperties().get(PROPERTY_DEFAULT_VALUE);
 	}
@@ -351,7 +351,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 	public void setValueType(final ValueType valueType) {
 		this.valueType = valueType;
 	}
-	
+
 	public void setValueType(final URI valueType) {
 		if (valueType != null) {
 			this.valueType = ValueType.fromString(valueType.toString());
@@ -359,16 +359,16 @@ public final class Property extends AbstractResource implements Comparable<Prope
 			this.valueType = null;
 		}
 	}
-	
+
 	public Collection<?> getAllowedValuesCollection() {
 		Collection<?> allowedValues = (Collection<?>) getExtendedProperties().get(PROPERTY_ALLOWED_VALUE);
 		if (allowedValues == null) {
 			return Collections.emptyList();
 		}
-		
+
 		return allowedValues;
 	}
-	
+
 	public void setAllowedValuesCollection(final Collection<?> values) {
 		if (values == null) {
 			getExtendedProperties().remove(PROPERTY_ALLOWED_VALUE);
@@ -388,7 +388,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		if (allowedValues != null) {
 			newValues.addAll(allowedValues);
 		}
-		
+
 		newValues.add(allowedValue);
 		setAllowedValuesCollection(newValues);
 	}
@@ -399,7 +399,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 	@Deprecated
 	public String[] getAllowedValues() {
 		// Be compatible with the old behavior and only include String values.
-		ArrayList<String> stringValues = new ArrayList<String>();
+		ArrayList<String> stringValues = new ArrayList<>();
 		@SuppressWarnings("unchecked")
 		Collection<Object> values = (Collection<Object>) getExtendedProperties().get(PROPERTY_ALLOWED_VALUE);
 		if (values == null) {
@@ -422,5 +422,5 @@ public final class Property extends AbstractResource implements Comparable<Prope
 	public void setAllowedValues(final String[] allowedValues) {
 		getExtendedProperties().put(PROPERTY_ALLOWED_VALUE, allowedValues);
 	}
-	
+
 }

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/QueryCapability.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/QueryCapability.java
@@ -33,8 +33,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Query Capability Resource Shape", describes = OslcConstants.TYPE_QUERY_CAPABILITY)
 public class QueryCapability extends AbstractResource {
-	private final SortedSet<URI> resourceTypes = new TreeSet<URI>();
-	private final SortedSet<URI> usages = new TreeSet<URI>();
+	private final SortedSet<URI> resourceTypes = new TreeSet<>();
+	private final SortedSet<URI> usages = new TreeSet<>();
 
 	private String label;
 	private URI queryBase;

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShape.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShape.java
@@ -35,8 +35,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Resource Shape Resource Shape", describes = OslcConstants.TYPE_RESOURCE_SHAPE)
 public final class ResourceShape extends AbstractResource {
-	private final SortedSet<URI> describes= new TreeSet<URI>();
-	private final TreeMap<URI, Property> properties = new TreeMap<URI, Property>();
+	private final SortedSet<URI> describes= new TreeSet<>();
+	private final TreeMap<URI, Property> properties = new TreeMap<>();
 
     private String name;
 	private String title;
@@ -57,7 +57,7 @@ public final class ResourceShape extends AbstractResource {
 	public void addProperty(final Property property) {
 		this.properties.put(property.getPropertyDefinition(), property);
 	}
-	
+
 	//Bugzilla 392780
 	public Property getProperty(URI definition) {
 		return properties.get(definition);
@@ -135,7 +135,7 @@ public final class ResourceShape extends AbstractResource {
 	public void setTitle(final String title) {
 		this.title = title;
 	}
-	
+
     public void setDescription(final String description) {
         this.description = description;
     }

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
@@ -49,7 +49,7 @@ public class ResourceShapeFactory {
 	protected static final int METHOD_NAME_START_GET_LENGTH = METHOD_NAME_START_GET.length();
 	protected static final int METHOD_NAME_START_IS_LENGTH  = METHOD_NAME_START_IS.length();
 
-	protected static final Map<Class<?>, ValueType> CLASS_TO_VALUE_TYPE = new HashMap<Class<?>, ValueType>();
+	protected static final Map<Class<?>, ValueType> CLASS_TO_VALUE_TYPE = new HashMap<>();
 
 	static {
 		// Primitive types
@@ -84,7 +84,7 @@ public class ResourceShapeFactory {
 													final String resourceShapePath,
 													final Class<?> resourceClass)
 		   throws OslcCoreApplicationException, URISyntaxException {
-		final HashSet<Class<?>> verifiedClasses = new HashSet<Class<?>>();
+		final HashSet<Class<?>> verifiedClasses = new HashSet<>();
 		verifiedClasses.add(resourceClass);
 
 		return createResourceShape(baseURI, resourceShapesPath, resourceShapePath, resourceClass, verifiedClasses);
@@ -125,7 +125,7 @@ public class ResourceShapeFactory {
 			resourceShape.addDescribeItem(new URI(describesItem));
 		}
 
-		final Set<String> propertyDefinitions = new HashSet<String>();
+		final Set<String> propertyDefinitions = new HashSet<>();
 
 		for (final Method method : resourceClass.getMethods()) {
 			if (method.getParameterTypes().length == 0) {
@@ -285,7 +285,7 @@ public class ResourceShapeFactory {
 
         validateUserSpecifiedValueType(resourceClass, method, valueType, representation, componentType);
         validateUserSpecifiedRepresentation(resourceClass, method, representation, componentType);
-		if ((ValueType.LocalResource.equals(valueType)) 
+		if ((ValueType.LocalResource.equals(valueType))
 		    || (ValueType.Resource.equals(valueType) && (null != representation) && (Representation.Inline.equals(representation)))) {
 			// If this is a nested class we potentially have not yet verified
 			if (verifiedClasses.add(componentType)) {
@@ -471,7 +471,7 @@ public class ResourceShapeFactory {
 	    // User-specified representation is reference and component is not URI
 		// or
 		// user-specified representation is inline and component is a standard class
-	    
+
 	    if (null == userSpecifiedRepresentation) {
 	        return;
 	    }

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResponseInfo.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResponseInfo.java
@@ -33,12 +33,12 @@ public abstract class ResponseInfo<T extends Object>
 	)
 	{
 		super(resource, properties);
-		
+
 		this.totalCount = totalCount;
 		this.nextPage = nextPage;
-		this.container = new FilteredResource<T>(resource, properties);
+		this.container = new FilteredResource<>(resource, properties);
 	}
-	
+
 	public
 	ResponseInfo(
 		T resource,
@@ -49,19 +49,19 @@ public abstract class ResponseInfo<T extends Object>
 	{
 		this(resource, properties, totalCount,
 			 nextPage == null ? null : nextPage.toString());
-		this.container = new FilteredResource<T>(resource, properties);
+		this.container = new FilteredResource<>(resource, properties);
 	}
-	
+
 	public Integer
 	totalCount() { return totalCount; }
-	
+
 	public String
 	nextPage() { return nextPage; }
-	
+
 	private final Integer totalCount;
 	private final String nextPage;
 	private FilteredResource<T> container;
-	
+
 	public FilteredResource<T> getContainer() {
 		return container;
 	}

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Service.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Service.java
@@ -34,11 +34,11 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Service Resource Shape", describes = OslcConstants.TYPE_SERVICE)
 public class Service extends AbstractResource {
-	private final List<Dialog> creationDialogs = new ArrayList<Dialog>();
-	private final List<CreationFactory> creationFactories = new ArrayList<CreationFactory>();
-	private final List<QueryCapability> queryCapabilities = new ArrayList<QueryCapability>();
-	private final List<Dialog> selectionDialogs = new ArrayList<Dialog>();
-	private final List<URI> usages = new ArrayList<URI>();
+	private final List<Dialog> creationDialogs = new ArrayList<>();
+	private final List<CreationFactory> creationFactories = new ArrayList<>();
+	private final List<QueryCapability> queryCapabilities = new ArrayList<>();
+	private final List<Dialog> selectionDialogs = new ArrayList<>();
+	private final List<URI> usages = new ArrayList<>();
 
 	private URI domain;
 

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProvider.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProvider.java
@@ -37,9 +37,9 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Service Provider Resource Shape", describes = OslcConstants.TYPE_SERVICE_PROVIDER)
 public class ServiceProvider extends AbstractResource{
-	private final SortedSet<URI> details = new TreeSet<URI>();
-	private final List<PrefixDefinition> prefixDefinitions = new ArrayList<PrefixDefinition>();
-	private final List<Service> services = new ArrayList<Service>();
+	private final SortedSet<URI> details = new TreeSet<>();
+	private final List<PrefixDefinition> prefixDefinitions = new ArrayList<>();
+	private final List<Service> services = new ArrayList<>();
 
 	private Date   created; // TODO - ServiceProvider.created nice to have, but not required.
 	private String description;

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProviderCatalog.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProviderCatalog.java
@@ -36,9 +36,9 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Service Provider Catalog Resource Shape", describes = OslcConstants.TYPE_SERVICE_PROVIDER_CATALOG)
 public class ServiceProviderCatalog extends AbstractResource {
-	private final SortedSet<URI> domains = new TreeSet<URI>();
-	private final SortedSet<URI> referencedServiceProviderCatalogs = new TreeSet<URI>();
-	private final List<ServiceProvider> serviceProviders = new ArrayList<ServiceProvider>();
+	private final SortedSet<URI> domains = new TreeSet<>();
+	private final SortedSet<URI> referencedServiceProviderCatalogs = new TreeSet<>();
+	private final List<ServiceProvider> serviceProviders = new ArrayList<>();
 
 	private String description;
 	private OAuthConfiguration oauthConfiguration;

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProviderFactory.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProviderFactory.java
@@ -44,7 +44,7 @@ public final class ServiceProviderFactory {
 	public static ServiceProvider createServiceProvider(final String baseURI, final String genericBaseURI, final String title, final String description, final Publisher publisher, final Class<?>[] resourceClasses) throws OslcCoreApplicationException, URISyntaxException {
 		return initServiceProvider(new ServiceProvider(), baseURI, genericBaseURI, title, description, publisher, resourceClasses, null);
 	}
-	
+
 	public static ServiceProvider createServiceProvider(final String baseURI, final String genericBaseURI, final String title, final String description, final Publisher publisher, final Class<?>[] resourceClasses, final Map<String,Object> pathParameterValues) throws OslcCoreApplicationException, URISyntaxException {
 		return initServiceProvider(new ServiceProvider(), baseURI, genericBaseURI, title, description, publisher, resourceClasses, pathParameterValues);
 	}
@@ -54,7 +54,7 @@ public final class ServiceProviderFactory {
 		serviceProvider.setDescription(description);
 		serviceProvider.setPublisher(publisher);
 
-		final Map<String, Service> serviceMap = new HashMap<String, Service>();
+		final Map<String, Service> serviceMap = new HashMap<>();
 
 		for (final Class<?> resourceClass : resourceClasses) {
 			final OslcService serviceAnnotation = resourceClass.getAnnotation(OslcService.class);

--- a/core/oslc4j-core/src/test/java/org/eclipse/lyo/oslc4j/core/test/OslcGlobalNamespaceProviderTest.java
+++ b/core/oslc4j-core/src/test/java/org/eclipse/lyo/oslc4j/core/test/OslcGlobalNamespaceProviderTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 /**
  * Tests the behavior of {@link OslcGlobalNamespaceProvider}.
- * 
+ *
  * @author Daniel Figueiredo Caetano
  *
  */
@@ -40,14 +40,14 @@ public class OslcGlobalNamespaceProviderTest {
 		);
 		OslcGlobalNamespaceProvider secondGlobalNamespaceProvider = OslcGlobalNamespaceProvider.getInstance();
 		Assert.assertSame(
-				"There should be only one instance of the OslcGlobalNamespaceProvider class", 
-				globalNamespaceProvider, 
+				"There should be only one instance of the OslcGlobalNamespaceProvider class",
+				globalNamespaceProvider,
 				secondGlobalNamespaceProvider
 		);
 	}
-	
+
 	/**
-	 * Tests if the map can be set to another new map or to null. 
+	 * Tests if the map can be set to another new map or to null.
 	 */
 	@Test
 	public void testSetNullMap() {
@@ -66,13 +66,13 @@ public class OslcGlobalNamespaceProviderTest {
 				"Map should be cleared and never set to null.",
 				globalNamespaceProvider.getPrefixDefinitionMap().isEmpty()
 		);
-		Map<String, String> namespaceMappings = new HashMap<String, String>(1);
+		Map<String, String> namespaceMappings = new HashMap<>(1);
 		namespaceMappings.put("any", "http://any.test.com#");
 		globalNamespaceProvider.setPrefixDefinitionMap(namespaceMappings);
 		Assert.assertFalse(
-				"Global Namespace Map could not be set.", 
+				"Global Namespace Map could not be set.",
 				globalNamespaceProvider.getPrefixDefinitionMap().isEmpty()
 		);
 	}
-	
+
 }

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaProvidersRegistry.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaProvidersRegistry.java
@@ -18,7 +18,7 @@ import java.util.Set;
 
 public final class JenaProvidersRegistry
 {
-	private static Set<Class<?>> PROVIDERS = new HashSet<Class<?>>();
+	private static Set<Class<?>> PROVIDERS = new HashSet<>();
 
 	static
 	{
@@ -48,7 +48,7 @@ public final class JenaProvidersRegistry
 	 */
 	public static final Set<Class<?>> getProviders()
 	{
-		return new HashSet<Class<?>>(PROVIDERS);
+		return new HashSet<>(PROVIDERS);
 	}
 
 	public static final Set<Class<?>> setProviders (Set<Class<?>> providers)
@@ -58,7 +58,7 @@ public final class JenaProvidersRegistry
 			PROVIDERS.clear();
 			PROVIDERS.addAll(providers);
 		}
-		return new HashSet<Class<?>>(PROVIDERS);
+		return new HashSet<>(PROVIDERS);
 	}
 
 	public static final Set<Class<?>> removeProviders (Set<Class<?>> providers)
@@ -67,6 +67,6 @@ public final class JenaProvidersRegistry
 		{
 			PROVIDERS.removeAll(providers);
 		}
-		return new HashSet<Class<?>>(PROVIDERS);
+		return new HashSet<>(PROVIDERS);
 	}
 }

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaSimpleProvidersRegistry.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaSimpleProvidersRegistry.java
@@ -18,7 +18,7 @@ import java.util.Set;
 
 public final class JenaSimpleProvidersRegistry
 {
-	private static final Set<Class<?>> PROVIDERS = new HashSet<Class<?>>();
+	private static final Set<Class<?>> PROVIDERS = new HashSet<>();
 
 	static
 	{
@@ -38,6 +38,6 @@ public final class JenaSimpleProvidersRegistry
 	 */
 	public static final Set<Class<?>> getProviders()
 	{
-		return new HashSet<Class<?>>(PROVIDERS);
+		return new HashSet<>(PROVIDERS);
 	}
 }

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaUpdatedProvidersRegistry.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaUpdatedProvidersRegistry.java
@@ -18,7 +18,7 @@ import java.util.Set;
 
 public final class JenaUpdatedProvidersRegistry
 {
-	private static final Set<Class<?>> PROVIDERS = new HashSet<Class<?>>();
+	private static final Set<Class<?>> PROVIDERS = new HashSet<>();
 
 	static
 	{
@@ -38,6 +38,6 @@ public final class JenaUpdatedProvidersRegistry
 	 */
 	public static final Set<Class<?>> getProviders()
 	{
-		return new HashSet<Class<?>>(PROVIDERS);
+		return new HashSet<>(PROVIDERS);
 	}
 }

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/core/test/customnamespace/AnyNamespaceProvider.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/core/test/customnamespace/AnyNamespaceProvider.java
@@ -24,10 +24,10 @@ import org.eclipse.lyo.oslc4j.core.model.IOslcCustomNamespaceProvider;
 
 /**
  * Used to test the custom namespace mappings feature.
- * This class just return a custom prefix to ensure that this 
+ * This class just return a custom prefix to ensure that this
  * prefix will be added when Jena or Json Helper is reading
  * the default annotation mappings.
- * 
+ *
  * @author Daniel Figueiredo Caetano
  *
  */
@@ -35,14 +35,14 @@ public class AnyNamespaceProvider implements IOslcCustomNamespaceProvider {
 
 	/**
 	 * Creates a map with a custom prefix, used for tests.
-	 * 
+	 *
 	 * @return always a new map.
 	 */
 	@Override
 	public Map<String, String> getCustomNamespacePrefixes() {
-		Map<String, String> customNamespacePrefixes = new HashMap<String, String>(1);
+		Map<String, String> customNamespacePrefixes = new HashMap<>(1);
 		customNamespacePrefixes.put(CUSTOM_PREFIX, CUSTOM_URL);
 		return customNamespacePrefixes;
 	}
-	
+
 }

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/shapefactory/resources/ShapeWithWorkingReferences.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/shapefactory/resources/ShapeWithWorkingReferences.java
@@ -86,8 +86,8 @@ public class ShapeWithWorkingReferences
     private String identifier;
     // Start of user code attributeAnnotation:inlinesMany
     // End of user code
-    private Set<InlinedShape> inlinesMany = new HashSet<InlinedShape>();
-    
+    private Set<InlinedShape> inlinesMany = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -95,38 +95,38 @@ public class ShapeWithWorkingReferences
     public ShapeWithWorkingReferences()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public ShapeWithWorkingReferences(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_sdDomainConstants.SHAPEWITHWORKINGREFERENCES_PATH,
         ShapeWithWorkingReferences.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local ShapeWithWorkingReferences Resource} - update ShapeWithWorkingReferences.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -135,19 +135,19 @@ public class ShapeWithWorkingReferences
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addInlinesMany(final InlinedShape inlinesMany)
     {
         this.inlinesMany.add(inlinesMany);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:referencesAsLocal
     // End of user code
     @OslcName("referencesAsLocal")
@@ -162,7 +162,7 @@ public class ShapeWithWorkingReferences
         // End of user code
         return referencesAsLocal;
     }
-    
+
     // Start of user code getterAnnotation:inlines
     // End of user code
     @OslcName("inlines")
@@ -178,7 +178,7 @@ public class ShapeWithWorkingReferences
         // End of user code
         return inlines;
     }
-    
+
     // Start of user code getterAnnotation:referencesAsResource
     // End of user code
     @OslcName("referencesAsResource")
@@ -193,7 +193,7 @@ public class ShapeWithWorkingReferences
         // End of user code
         return referencesAsResource;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -207,7 +207,7 @@ public class ShapeWithWorkingReferences
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:inlinesMany
     // End of user code
     @OslcName("inlinesMany")
@@ -223,8 +223,8 @@ public class ShapeWithWorkingReferences
         // End of user code
         return inlinesMany;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:referencesAsLocal
     // End of user code
     public void setReferencesAsLocal(final LocalShape referencesAsLocal )
@@ -232,11 +232,11 @@ public class ShapeWithWorkingReferences
         // Start of user code setterInit:referencesAsLocal
         // End of user code
         this.referencesAsLocal = referencesAsLocal;
-    
+
         // Start of user code setterFinalize:referencesAsLocal
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:inlines
     // End of user code
     public void setInlines(final InlinedShape inlines )
@@ -244,11 +244,11 @@ public class ShapeWithWorkingReferences
         // Start of user code setterInit:inlines
         // End of user code
         this.inlines = inlines;
-    
+
         // Start of user code setterFinalize:inlines
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:referencesAsResource
     // End of user code
     public void setReferencesAsResource(final Link referencesAsResource )
@@ -256,11 +256,11 @@ public class ShapeWithWorkingReferences
         // Start of user code setterInit:referencesAsResource
         // End of user code
         this.referencesAsResource = referencesAsResource;
-    
+
         // Start of user code setterFinalize:referencesAsResource
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -268,11 +268,11 @@ public class ShapeWithWorkingReferences
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:inlinesMany
     // End of user code
     public void setInlinesMany(final Set<InlinedShape> inlinesMany )
@@ -284,10 +284,10 @@ public class ShapeWithWorkingReferences
         {
             this.inlinesMany.addAll(inlinesMany);
         }
-    
+
         // Start of user code setterFinalize:inlinesMany
         // End of user code
     }
-    
-    
+
+
 }

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/JenaOslcNameTest.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/JenaOslcNameTest.java
@@ -37,9 +37,9 @@ import org.apache.jena.vocabulary.RDF;
 
 /**
  * Tests Jena working with different combinations of OslcName annotation.
- * 
+ *
  * @author Fabio Negrello
- * 
+ *
  */
 public class JenaOslcNameTest {
 
@@ -49,7 +49,7 @@ public class JenaOslcNameTest {
 	/**
 	 * Checks that OslcName annotation with empty string does not add RDF type
 	 * to the resource.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -63,7 +63,7 @@ public class JenaOslcNameTest {
 	/**
 	 * Checks that OslcName annotation with empty string does not add default
 	 * RDF type to the resource but adds the ones specified by addTypes method.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -79,7 +79,7 @@ public class JenaOslcNameTest {
 
 	/**
 	 * Checks that OslcName annotation adds RDF type to the resource.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -94,7 +94,7 @@ public class JenaOslcNameTest {
 	/**
 	 * Checks that the absence of OslcName annotation adds default RDF type to
 	 * the resource.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -107,7 +107,7 @@ public class JenaOslcNameTest {
 	}
 
 	private void verifyRDFTypes(String[] expectedRDFTypes, List<RDFNode> actualRDFTypes) {
-		List<String> actualRdfTypesList = new ArrayList<String>();
+		List<String> actualRdfTypesList = new ArrayList<>();
 		for (RDFNode node : actualRDFTypes) {
 			actualRdfTypesList.add(node.toString());
 		}
@@ -119,7 +119,7 @@ public class JenaOslcNameTest {
 
 	/**
 	 * Creates a new instance adding some test values.
-	 * 
+	 *
 	 */
 	private <T extends AbstractResource> T createResource(Class<T> resourceClass) throws Exception {
 		T resource = resourceClass.newInstance();

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/JsonLdTest.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/JsonLdTest.java
@@ -107,7 +107,7 @@ public class JsonLdTest {
         sp.setDescription("Hello world");
         final Collection<ServiceProvider> objects = ImmutableList.of(sp);
         provider.writeTo(
-                new ArrayList<Object>(objects),
+            new ArrayList<>(objects),
                 objects.getClass(),
                 objects.getClass().getGenericSuperclass(),
                 ServiceProvider.class.getAnnotations(),

--- a/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/AbstractOslcRdfJsonProvider.java
+++ b/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/AbstractOslcRdfJsonProvider.java
@@ -149,7 +149,7 @@ public abstract class AbstractOslcRdfJsonProvider
 				null :
 				(Integer)httpServletRequest.getAttribute(OSLC4JConstants.OSLC4J_TOTAL_COUNT);
 
-		ResponseInfo<?> responseInfo = new ResponseInfoArray<Object>(null, properties, totalCount, nextPageURI);
+		ResponseInfo<?> responseInfo = new ResponseInfoArray<>(null, properties, totalCount, nextPageURI);
 
 		try
 		{

--- a/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/Json4JProvidersRegistry.java
+++ b/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/Json4JProvidersRegistry.java
@@ -22,7 +22,7 @@ import java.util.Set;
 @Deprecated
 public final class Json4JProvidersRegistry
 {
-	private static final Set<Class<?>> PROVIDERS = new HashSet<Class<?>>();
+	private static final Set<Class<?>> PROVIDERS = new HashSet<>();
 
 	static
 	{
@@ -42,6 +42,6 @@ public final class Json4JProvidersRegistry
 	 */
 	public static final Set<Class<?>> getProviders()
 	{
-		return new HashSet<Class<?>>(PROVIDERS);
+		return new HashSet<>(PROVIDERS);
 	}
 }

--- a/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/Json4JSimpleProvidersRegistry.java
+++ b/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/Json4JSimpleProvidersRegistry.java
@@ -22,7 +22,7 @@ import java.util.Set;
 @Deprecated
 public final class Json4JSimpleProvidersRegistry
 {
-	private static final Set<Class<?>> PROVIDERS = new HashSet<Class<?>>();
+	private static final Set<Class<?>> PROVIDERS = new HashSet<>();
 
 	static
 	{
@@ -42,6 +42,6 @@ public final class Json4JSimpleProvidersRegistry
 	 */
 	public static final Set<Class<?>> getProviders()
 	{
-		return new HashSet<Class<?>>(PROVIDERS);
+		return new HashSet<>(PROVIDERS);
 	}
 }

--- a/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/Json4JUpdatedProvidersRegistry.java
+++ b/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/Json4JUpdatedProvidersRegistry.java
@@ -22,7 +22,7 @@ import java.util.Set;
 @Deprecated
 public final class Json4JUpdatedProvidersRegistry
 {
-	private static final Set<Class<?>> PROVIDERS = new HashSet<Class<?>>();
+	private static final Set<Class<?>> PROVIDERS = new HashSet<>();
 
 	static
 	{
@@ -42,6 +42,6 @@ public final class Json4JUpdatedProvidersRegistry
 	 */
 	public static final Set<Class<?>> getProviders()
 	{
-		return new HashSet<Class<?>>(PROVIDERS);
+		return new HashSet<>(PROVIDERS);
 	}
 }

--- a/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/JsonHelper.java
+++ b/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/JsonHelper.java
@@ -162,8 +162,8 @@ public final class JsonHelper
 	{
 		final JSONObject resultJSONObject = new JSONObject();
 
-		final Map<String, String> namespaceMappings		   = new TreeMap<String, String>();
-		final Map<String, String> reverseNamespaceMappings = new HashMap<String, String>();
+		final Map<String, String> namespaceMappings		   = new TreeMap<>();
+		final Map<String, String> reverseNamespaceMappings = new HashMap<>();
 
 		// Add all global namespace mappings, since they have lower precedence
 		Map<String, String> globalPrefixDefinitionMap = OslcGlobalNamespaceProvider.getInstance().getPrefixDefinitionMap();
@@ -178,7 +178,7 @@ public final class JsonHelper
 
 			for (final Object object : objects)
 			{
-				HashMap<Object,JSONObject> visitedObjects = new HashMap<Object,JSONObject>();
+				HashMap<Object,JSONObject> visitedObjects = new HashMap<>();
 				final JSONObject jsonObject = handleSingleResource(object,
 																   new JSONObject(),
 																   namespaceMappings,
@@ -223,7 +223,7 @@ public final class JsonHelper
 				resultJSONObject.put(rdfPrefix + JSON_PROPERTY_DELIMITER + JSON_PROPERTY_SUFFIX_TYPE,
 								 containerTypesJSONArray);
 
-				Map<Object,JSONObject> visitedObjects = new HashMap<Object,JSONObject>();
+				Map<Object,JSONObject> visitedObjects = new HashMap<>();
 				addExtendedProperties(namespaceMappings,
 									  reverseNamespaceMappings,
 									  resultJSONObject,
@@ -280,7 +280,7 @@ public final class JsonHelper
 					resultJSONObject.put(oslcPrefix + JSON_PROPERTY_DELIMITER + JSON_PROPERTY_SUFFIX_RESPONSE_INFO,
 										responseInfoJSONObject);
 
-					Map<Object,JSONObject> visitedObjects = new HashMap<Object,JSONObject>();
+					Map<Object,JSONObject> visitedObjects = new HashMap<>();
 					addExtendedProperties(namespaceMappings,
 										  reverseNamespaceMappings,
 										  responseInfoJSONObject,
@@ -292,7 +292,7 @@ public final class JsonHelper
 		}
 		else if (objects.length == 1)
 		{
-			HashMap<Object,JSONObject> visitedObjects = new HashMap<Object,JSONObject>();
+			HashMap<Object,JSONObject> visitedObjects = new HashMap<>();
 			handleSingleResource(objects[0],
 								 resultJSONObject,
 								 namespaceMappings,
@@ -328,9 +328,9 @@ public final class JsonHelper
 				  OslcCoreApplicationException,
 				  URISyntaxException
 	{
-		final List<Object>		  beans					   = new ArrayList<Object>();
-		final Map<String, String> namespaceMappings		   = new HashMap<String, String>();
-		final Map<String, String> reverseNamespaceMappings = new HashMap<String, String>();
+		final List<Object>		  beans					   = new ArrayList<>();
+		final Map<String, String> namespaceMappings		   = new HashMap<>();
+		final Map<String, String> reverseNamespaceMappings = new HashMap<>();
 
 		// First read the prefixes and set up maps so we can create full property definition values later
 		final Object prefixes = jsonObject.opt(JSON_PROPERTY_PREFIXES);
@@ -365,7 +365,7 @@ public final class JsonHelper
 			throw new OslcCoreMissingNamespaceDeclarationException(OslcConstants.RDF_NAMESPACE);
 		}
 
-		final Map<Class<?>, Map<String, Method>> classPropertyDefinitionsToSetMethods = new HashMap<Class<?>, Map<String, Method>>();
+		final Map<Class<?>, Map<String, Method>> classPropertyDefinitionsToSetMethods = new HashMap<>();
 
 		JSONArray jsonArray = null;
 
@@ -415,7 +415,7 @@ public final class JsonHelper
 					else
 					{
 						final Object bean = beanClass.newInstance();
-						HashSet<String> rdfTypes = new HashSet<String>();
+						HashSet<String> rdfTypes = new HashSet<>();
 
 						fromJSON(rdfPrefix,
 								 namespaceMappings,
@@ -433,7 +433,7 @@ public final class JsonHelper
 		else
 		{
 			final Object bean = beanClass.newInstance();
-			HashSet<String> rdfTypes = new HashSet<String>();
+			HashSet<String> rdfTypes = new HashSet<>();
 
 			fromJSON(rdfPrefix,
 					 namespaceMappings,
@@ -1189,7 +1189,7 @@ public final class JsonHelper
 										 nestedProperties);
 		}
 
-		Map<Object, JSONObject> visitedObjects = new HashMap<Object,JSONObject>();
+		Map<Object, JSONObject> visitedObjects = new HashMap<>();
 		return handleSingleResource(object,
 									new JSONObject(),
 									namespaceMappings,
@@ -1237,7 +1237,7 @@ public final class JsonHelper
 															  (URI) value);
 
 		// Add any reified statements.
-		Map<Object, JSONObject> visitedObjects = new HashMap<Object,JSONObject>();
+		Map<Object, JSONObject> visitedObjects = new HashMap<>();
 		buildResourceAttributes(namespaceMappings,
 								reverseNamespaceMappings,
 								reifiedResource,
@@ -1589,7 +1589,7 @@ public final class JsonHelper
 		if (bean instanceof IExtendedResource)
 		{
 			extendedResource = (IExtendedResource) bean;
-			extendedProperties = new HashMap<QName, Object>();
+			extendedProperties = new HashMap<>();
 			extendedResource.setExtendedProperties(extendedProperties);
 		}
 		else
@@ -1747,7 +1747,7 @@ public final class JsonHelper
 		if (jsonValue instanceof JSONArray)
 		{
 			final JSONArray jsonArray = (JSONArray) jsonValue;
-			final ArrayList<Object> collection = new ArrayList<Object>();
+			final ArrayList<Object> collection = new ArrayList<>();
 			final Iterator<?> i = jsonArray.iterator();
 			while (i.hasNext())
 			{
@@ -1779,7 +1779,7 @@ public final class JsonHelper
 			final AbstractResource any = new AnyResource();
 			fromJSON(rdfPrefix,
 					 jsonNamespaceMappings,
-					 new HashMap<Class<?>, Map<String, Method>>(),
+                new HashMap<>(),
 					 o,
 					 AnyResource.class,
 					 any,
@@ -2028,7 +2028,7 @@ public final class JsonHelper
 
 			if (isRdfContainerNode && container == null)
 			{
-				jsonArray = new ArrayList<Object>();
+				jsonArray = new ArrayList<>();
 
 				JSONObject listNode = (JSONObject) jsonValue;
 				while (listNode != null
@@ -2058,7 +2058,7 @@ public final class JsonHelper
 				jsonArray = array;
 			}
 
-			final ArrayList<Object> tempList = new ArrayList<Object>();
+			final ArrayList<Object> tempList = new ArrayList<>();
 
 			for (final Object jsonArrayEntryObject : jsonArray)
 			{
@@ -2110,20 +2110,20 @@ public final class JsonHelper
 				(AbstractList.class			  == setMethodParameterClass) ||
 				(AbstractSequentialList.class == setMethodParameterClass))
 			{
-				collection = new LinkedList<Object>();
+				collection = new LinkedList<>();
 			}
 			// Handle the Set interface
 			// Handle the AbstractSet class
 			else if ((Set.class			 == setMethodParameterClass) ||
 					 (AbstractSet.class	 == setMethodParameterClass))
 			{
-				collection = new HashSet<Object>();
+				collection = new HashSet<>();
 			}
 			// Handle the SortedSet and NavigableSet interfaces
 			else if ((SortedSet.class	 == setMethodParameterClass) ||
 					 (NavigableSet.class == setMethodParameterClass))
 			{
-				collection = new TreeSet<Object>();
+				collection = new TreeSet<>();
 			}
 			// Not handled above. Let's try newInstance with possible failure.
 			else
@@ -2287,7 +2287,7 @@ public final class JsonHelper
 	private static Map<String, Method> createPropertyDefinitionToSetMethods(final Class<?> beanClass)
 			throws OslcCoreApplicationException
 	{
-		final Map<String, Method> result = new HashMap<String, Method>();
+		final Map<String, Method> result = new HashMap<>();
 		final Method[] methods = beanClass.getMethods();
 		for (final Method method : methods)
 		{

--- a/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonCollectionProvider.java
+++ b/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonCollectionProvider.java
@@ -195,20 +195,20 @@ public class OslcRdfJsonCollectionProvider
 						(AbstractList.class.equals(type)) ||
 						(AbstractSequentialList.class.equals(type)))
 					{
-						collection = new LinkedList<Object>();
+						collection = new LinkedList<>();
 					}
 					// Handle the Set interface
 					// Handle the AbstractSet class
 					else if ((Set.class.equals(type)) ||
 							 (AbstractSet.class.equals(type)))
 					{
-						collection = new HashSet<Object>();
+						collection = new HashSet<>();
 					}
 					// Handle the SortedSet and NavigableSet interfaces
 					else if ((SortedSet.class.equals(type)) ||
 							 (NavigableSet.class.equals(type)))
 					{
-						collection = new TreeSet<Object>();
+						collection = new TreeSet<>();
 					}
 					// Not handled above.  Let's try newInstance with possible failure.
 					else

--- a/core/oslc4j-json4j-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/json4j/test/JsonOslcNameTest.java
+++ b/core/oslc4j-json4j-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/json4j/test/JsonOslcNameTest.java
@@ -128,7 +128,7 @@ public class JsonOslcNameTest {
 	}
 
 	private void verifyRDFTypes(String[] expectedRDFTypes, JSONArray rdfTypes) throws JSONException {
-		List<String> actualRdfTypesList = new ArrayList<String>();
+		List<String> actualRdfTypesList = new ArrayList<>();
 		for (Object node : rdfTypes) {
 			OrderedJSONObject obj = (OrderedJSONObject) node;
 			String type = obj.values().iterator().next().toString();

--- a/core/shacl/src/main/java/org/eclipse/lyo/shacl/Property.java
+++ b/core/shacl/src/main/java/org/eclipse/lyo/shacl/Property.java
@@ -527,7 +527,7 @@ public class Property extends AbstractResource {
 
     private Object[] appendValue(Object[] obj, Object newObj) {
 
-        ArrayList<Object> temp = new ArrayList<Object>(Arrays.asList(obj));
+        ArrayList<Object> temp = new ArrayList<>(Arrays.asList(obj));
         temp.add(newObj);
         return temp.toArray();
 

--- a/core/shacl/src/main/java/org/eclipse/lyo/shacl/ShaclShapeFactory.java
+++ b/core/shacl/src/main/java/org/eclipse/lyo/shacl/ShaclShapeFactory.java
@@ -114,7 +114,7 @@ public final class ShaclShapeFactory extends ResourceShapeFactory {
      */
     public static Shape createShaclShape(final Class<?> resourceClass)
             throws OslcCoreApplicationException, URISyntaxException, ParseException {
-        final HashSet<Class<?>> verifiedClasses = new HashSet<Class<?>>();
+        final HashSet<Class<?>> verifiedClasses = new HashSet<>();
         verifiedClasses.add(resourceClass);
 
         return createShaclShape(resourceClass, verifiedClasses);
@@ -135,7 +135,7 @@ public final class ShaclShapeFactory extends ResourceShapeFactory {
 
         populateFromClassLevelAnnotations(shaclShape, resourceClass);
 
-        final Set<String> propertyDefinitions = new HashSet<String>();
+        final Set<String> propertyDefinitions = new HashSet<>();
 
         // Create Properties. Also check if shacl annotations are available or not.
         createProperties(resourceClass, verifiedClasses, shaclShape, propertyDefinitions, true);
@@ -228,7 +228,7 @@ public final class ShaclShapeFactory extends ResourceShapeFactory {
      */
     private static List<URI> populateIgnoredProperties(final ShaclIgnoredProperties shaclIgnoredProperties)
             throws URISyntaxException {
-        List<URI> ignoredPropertiesList = new ArrayList<URI>();
+        List<URI> ignoredPropertiesList = new ArrayList<>();
         for (String ignoredProperty : shaclIgnoredProperties.values()) {
             ignoredPropertiesList.add(new URI(ignoredProperty));
         }

--- a/core/shacl/src/main/java/org/eclipse/lyo/shacl/Shape.java
+++ b/core/shacl/src/main/java/org/eclipse/lyo/shacl/Shape.java
@@ -34,7 +34,7 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 @OslcResourceShape(title = "Shacl Resource Shape", describes = ShaclConstants.TYPE_SHACL_SHAPE)
 public final class Shape extends AbstractResource {
     //Core Constraints
-    private final Map<URI, Property> properties = new HashMap<URI, Property>();
+    private final Map<URI, Property> properties = new HashMap<>();
     //Targets
     private URI targetClass;
     private URI targetNode;

--- a/core/shacl/src/main/java/org/eclipse/lyo/shacl/ValidationReport.java
+++ b/core/shacl/src/main/java/org/eclipse/lyo/shacl/ValidationReport.java
@@ -57,8 +57,8 @@ public class ValidationReport
     private Boolean conforms;
     // Start of user code attributeAnnotation:result
     // End of user code
-    private HashSet<ValidationResult> result = new HashSet<ValidationResult>();
-    
+    private HashSet<ValidationResult> result = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -67,35 +67,35 @@ public class ValidationReport
            throws URISyntaxException
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public ValidationReport(final URI about)
            throws URISyntaxException
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
-    
+
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         ShDomainConstants.VALIDATIONREPORT_PATH,
         ValidationReport.class);
     }
-    
-    
+
+
     public void addResult(final ValidationResult result)
     {
         this.result.add(result);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:conforms
     // End of user code
     @OslcName("conforms")
@@ -109,7 +109,7 @@ public class ValidationReport
         // End of user code
         return conforms;
     }
-    
+
     // Start of user code getterAnnotation:result
     // End of user code
     @OslcName("result")
@@ -124,8 +124,8 @@ public class ValidationReport
         // End of user code
         return result;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:conforms
     // End of user code
     public void setConforms(final Boolean conforms )
@@ -133,11 +133,11 @@ public class ValidationReport
         // Start of user code setterInit:conforms
         // End of user code
         this.conforms = conforms;
-    
+
         // Start of user code setterFinalize:conforms
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:result
     // End of user code
     public void setResult(final HashSet<ValidationResult> result )
@@ -149,7 +149,7 @@ public class ValidationReport
         {
             this.result.addAll(result);
         }
-    
+
         // Start of user code setterFinalize:result
         // End of user code
     }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/LinkType.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/LinkType.java
@@ -82,13 +82,13 @@ public class LinkType
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:identifier
     // End of user code
     private String identifier;
@@ -97,17 +97,17 @@ public class LinkType
     private Date modified;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:comment
     // End of user code
     private String comment;
     // Start of user code attributeAnnotation:label
     // End of user code
     private String label;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -115,38 +115,38 @@ public class LinkType
     public LinkType()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public LinkType(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_amDomainConstants.LINKTYPE_PATH,
         LinkType.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local LinkType Resource} - update LinkType.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -155,36 +155,36 @@ public class LinkType
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         result = String.format("%s (LinkType; id=%s)", this.getLabel(), this.getIdentifier());
 
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -200,7 +200,7 @@ public class LinkType
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -215,7 +215,7 @@ public class LinkType
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -231,7 +231,7 @@ public class LinkType
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -246,7 +246,7 @@ public class LinkType
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -261,7 +261,7 @@ public class LinkType
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -277,7 +277,7 @@ public class LinkType
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -293,7 +293,7 @@ public class LinkType
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:comment
     // End of user code
     @OslcName("comment")
@@ -308,7 +308,7 @@ public class LinkType
         // End of user code
         return comment;
     }
-    
+
     // Start of user code getterAnnotation:label
     // End of user code
     @OslcName("label")
@@ -323,8 +323,8 @@ public class LinkType
         // End of user code
         return label;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -336,11 +336,11 @@ public class LinkType
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -348,11 +348,11 @@ public class LinkType
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -364,11 +364,11 @@ public class LinkType
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -376,11 +376,11 @@ public class LinkType
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -388,11 +388,11 @@ public class LinkType
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -404,11 +404,11 @@ public class LinkType
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -420,11 +420,11 @@ public class LinkType
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:comment
     // End of user code
     public void setComment(final String comment )
@@ -432,11 +432,11 @@ public class LinkType
         // Start of user code setterInit:comment
         // End of user code
         this.comment = comment;
-    
+
         // Start of user code setterFinalize:comment
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:label
     // End of user code
     public void setLabel(final String label )
@@ -444,10 +444,10 @@ public class LinkType
         // Start of user code setterInit:label
         // End of user code
         this.label = label;
-    
+
         // Start of user code setterFinalize:label
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Resource.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Resource.java
@@ -81,13 +81,13 @@ public class Resource
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -105,35 +105,35 @@ public class Resource
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<String> type = new HashSet<String>();
+    private Set<String> type = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:shortTitle
     // End of user code
     private String shortTitle;
     // Start of user code attributeAnnotation:external
     // End of user code
-    private Set<Link> external = new HashSet<Link>();
+    private Set<Link> external = new HashSet<>();
     // Start of user code attributeAnnotation:trace
     // End of user code
-    private Set<Link> trace = new HashSet<Link>();
+    private Set<Link> trace = new HashSet<>();
     // Start of user code attributeAnnotation:refine
     // End of user code
-    private Set<Link> refine = new HashSet<Link>();
+    private Set<Link> refine = new HashSet<>();
     // Start of user code attributeAnnotation:derives
     // End of user code
-    private Set<Link> derives = new HashSet<Link>();
+    private Set<Link> derives = new HashSet<>();
     // Start of user code attributeAnnotation:elaborates
     // End of user code
-    private Set<Link> elaborates = new HashSet<Link>();
+    private Set<Link> elaborates = new HashSet<>();
     // Start of user code attributeAnnotation:satisfy
     // End of user code
-    private Set<Link> satisfy = new HashSet<Link>();
-    
+    private Set<Link> satisfy = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -141,38 +141,38 @@ public class Resource
     public Resource()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public Resource(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_amDomainConstants.RESOURCE_PATH,
         Resource.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local Resource Resource} - update Resource.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -181,69 +181,69 @@ public class Resource
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addType(final String type)
     {
         this.type.add(type);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addExternal(final Link external)
     {
         this.external.add(external);
     }
-    
+
     public void addTrace(final Link trace)
     {
         this.trace.add(trace);
     }
-    
+
     public void addRefine(final Link refine)
     {
         this.refine.add(refine);
     }
-    
+
     public void addDerives(final Link derives)
     {
         this.derives.add(derives);
     }
-    
+
     public void addElaborates(final Link elaborates)
     {
         this.elaborates.add(elaborates);
     }
-    
+
     public void addSatisfy(final Link satisfy)
     {
         this.satisfy.add(satisfy);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -259,7 +259,7 @@ public class Resource
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -274,7 +274,7 @@ public class Resource
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -290,7 +290,7 @@ public class Resource
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -305,7 +305,7 @@ public class Resource
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -320,7 +320,7 @@ public class Resource
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -335,7 +335,7 @@ public class Resource
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:source
     // End of user code
     @OslcName("source")
@@ -348,7 +348,7 @@ public class Resource
         // End of user code
         return source;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -363,7 +363,7 @@ public class Resource
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -377,7 +377,7 @@ public class Resource
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -393,7 +393,7 @@ public class Resource
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -409,7 +409,7 @@ public class Resource
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:shortTitle
     // End of user code
     @OslcName("shortTitle")
@@ -424,7 +424,7 @@ public class Resource
         // End of user code
         return shortTitle;
     }
-    
+
     // Start of user code getterAnnotation:external
     // End of user code
     @OslcName("external")
@@ -439,7 +439,7 @@ public class Resource
         // End of user code
         return external;
     }
-    
+
     // Start of user code getterAnnotation:trace
     // End of user code
     @OslcName("trace")
@@ -454,7 +454,7 @@ public class Resource
         // End of user code
         return trace;
     }
-    
+
     // Start of user code getterAnnotation:refine
     // End of user code
     @OslcName("refine")
@@ -469,7 +469,7 @@ public class Resource
         // End of user code
         return refine;
     }
-    
+
     // Start of user code getterAnnotation:derives
     // End of user code
     @OslcName("derives")
@@ -484,7 +484,7 @@ public class Resource
         // End of user code
         return derives;
     }
-    
+
     // Start of user code getterAnnotation:elaborates
     // End of user code
     @OslcName("elaborates")
@@ -499,7 +499,7 @@ public class Resource
         // End of user code
         return elaborates;
     }
-    
+
     // Start of user code getterAnnotation:satisfy
     // End of user code
     @OslcName("satisfy")
@@ -514,8 +514,8 @@ public class Resource
         // End of user code
         return satisfy;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -527,11 +527,11 @@ public class Resource
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -539,11 +539,11 @@ public class Resource
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -555,11 +555,11 @@ public class Resource
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -567,11 +567,11 @@ public class Resource
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -579,11 +579,11 @@ public class Resource
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -591,11 +591,11 @@ public class Resource
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:source
     // End of user code
     public void setSource(final URI source )
@@ -603,11 +603,11 @@ public class Resource
         // Start of user code setterInit:source
         // End of user code
         this.source = source;
-    
+
         // Start of user code setterFinalize:source
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -615,11 +615,11 @@ public class Resource
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<String> type )
@@ -631,11 +631,11 @@ public class Resource
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -647,11 +647,11 @@ public class Resource
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -663,11 +663,11 @@ public class Resource
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:shortTitle
     // End of user code
     public void setShortTitle(final String shortTitle )
@@ -675,11 +675,11 @@ public class Resource
         // Start of user code setterInit:shortTitle
         // End of user code
         this.shortTitle = shortTitle;
-    
+
         // Start of user code setterFinalize:shortTitle
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:external
     // End of user code
     public void setExternal(final Set<Link> external )
@@ -691,11 +691,11 @@ public class Resource
         {
             this.external.addAll(external);
         }
-    
+
         // Start of user code setterFinalize:external
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:trace
     // End of user code
     public void setTrace(final Set<Link> trace )
@@ -707,11 +707,11 @@ public class Resource
         {
             this.trace.addAll(trace);
         }
-    
+
         // Start of user code setterFinalize:trace
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:refine
     // End of user code
     public void setRefine(final Set<Link> refine )
@@ -723,11 +723,11 @@ public class Resource
         {
             this.refine.addAll(refine);
         }
-    
+
         // Start of user code setterFinalize:refine
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:derives
     // End of user code
     public void setDerives(final Set<Link> derives )
@@ -739,11 +739,11 @@ public class Resource
         {
             this.derives.addAll(derives);
         }
-    
+
         // Start of user code setterFinalize:derives
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:elaborates
     // End of user code
     public void setElaborates(final Set<Link> elaborates )
@@ -755,11 +755,11 @@ public class Resource
         {
             this.elaborates.addAll(elaborates);
         }
-    
+
         // Start of user code setterFinalize:elaborates
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:satisfy
     // End of user code
     public void setSatisfy(final Set<Link> satisfy )
@@ -771,10 +771,10 @@ public class Resource
         {
             this.satisfy.addAll(satisfy);
         }
-    
+
         // Start of user code setterFinalize:satisfy
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationPlan.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationPlan.java
@@ -83,13 +83,13 @@ public class AutomationPlan
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -101,29 +101,29 @@ public class AutomationPlan
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:parameterDefinition
     // End of user code
-    private Set<Link> parameterDefinition = new HashSet<Link>();
+    private Set<Link> parameterDefinition = new HashSet<>();
     // Start of user code attributeAnnotation:usesExecutionEnvironment
     // End of user code
-    private Set<Link> usesExecutionEnvironment = new HashSet<Link>();
+    private Set<Link> usesExecutionEnvironment = new HashSet<>();
     // Start of user code attributeAnnotation:futureAction
     // End of user code
-    private Set<Link> futureAction = new HashSet<Link>();
-    
+    private Set<Link> futureAction = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -131,38 +131,38 @@ public class AutomationPlan
     public AutomationPlan()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public AutomationPlan(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_autoDomainConstants.AUTOMATIONPLAN_PATH,
         AutomationPlan.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local AutomationPlan Resource} - update AutomationPlan.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -171,59 +171,59 @@ public class AutomationPlan
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addParameterDefinition(final Link parameterDefinition)
     {
         this.parameterDefinition.add(parameterDefinition);
     }
-    
+
     public void addUsesExecutionEnvironment(final Link usesExecutionEnvironment)
     {
         this.usesExecutionEnvironment.add(usesExecutionEnvironment);
     }
-    
+
     public void addFutureAction(final Link futureAction)
     {
         this.futureAction.add(futureAction);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -239,7 +239,7 @@ public class AutomationPlan
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -254,7 +254,7 @@ public class AutomationPlan
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -270,7 +270,7 @@ public class AutomationPlan
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -285,7 +285,7 @@ public class AutomationPlan
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -300,7 +300,7 @@ public class AutomationPlan
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -315,7 +315,7 @@ public class AutomationPlan
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -330,7 +330,7 @@ public class AutomationPlan
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:subject
     // End of user code
     @OslcName("subject")
@@ -346,7 +346,7 @@ public class AutomationPlan
         // End of user code
         return subject;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -361,7 +361,7 @@ public class AutomationPlan
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -377,7 +377,7 @@ public class AutomationPlan
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -393,7 +393,7 @@ public class AutomationPlan
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:parameterDefinition
     // End of user code
     @OslcName("parameterDefinition")
@@ -408,7 +408,7 @@ public class AutomationPlan
         // End of user code
         return parameterDefinition;
     }
-    
+
     // Start of user code getterAnnotation:usesExecutionEnvironment
     // End of user code
     @OslcName("usesExecutionEnvironment")
@@ -424,7 +424,7 @@ public class AutomationPlan
         // End of user code
         return usesExecutionEnvironment;
     }
-    
+
     // Start of user code getterAnnotation:futureAction
     // End of user code
     @OslcName("futureAction")
@@ -440,8 +440,8 @@ public class AutomationPlan
         // End of user code
         return futureAction;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -453,11 +453,11 @@ public class AutomationPlan
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -465,11 +465,11 @@ public class AutomationPlan
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -481,11 +481,11 @@ public class AutomationPlan
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -493,11 +493,11 @@ public class AutomationPlan
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -505,11 +505,11 @@ public class AutomationPlan
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -517,11 +517,11 @@ public class AutomationPlan
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<Link> type )
@@ -533,11 +533,11 @@ public class AutomationPlan
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:subject
     // End of user code
     public void setSubject(final Set<String> subject )
@@ -549,11 +549,11 @@ public class AutomationPlan
         {
             this.subject.addAll(subject);
         }
-    
+
         // Start of user code setterFinalize:subject
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -561,11 +561,11 @@ public class AutomationPlan
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -577,11 +577,11 @@ public class AutomationPlan
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -593,11 +593,11 @@ public class AutomationPlan
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:parameterDefinition
     // End of user code
     public void setParameterDefinition(final Set<Link> parameterDefinition )
@@ -609,11 +609,11 @@ public class AutomationPlan
         {
             this.parameterDefinition.addAll(parameterDefinition);
         }
-    
+
         // Start of user code setterFinalize:parameterDefinition
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:usesExecutionEnvironment
     // End of user code
     public void setUsesExecutionEnvironment(final Set<Link> usesExecutionEnvironment )
@@ -625,11 +625,11 @@ public class AutomationPlan
         {
             this.usesExecutionEnvironment.addAll(usesExecutionEnvironment);
         }
-    
+
         // Start of user code setterFinalize:usesExecutionEnvironment
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:futureAction
     // End of user code
     public void setFutureAction(final Set<Link> futureAction )
@@ -641,10 +641,10 @@ public class AutomationPlan
         {
             this.futureAction.addAll(futureAction);
         }
-    
+
         // Start of user code setterFinalize:futureAction
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationRequest.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationRequest.java
@@ -85,13 +85,13 @@ public class AutomationRequest
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -103,29 +103,29 @@ public class AutomationRequest
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:state
     // End of user code
-    private Set<Link> state = new HashSet<Link>();
+    private Set<Link> state = new HashSet<>();
     // Start of user code attributeAnnotation:desiredState
     // End of user code
     private Link desiredState;
     // Start of user code attributeAnnotation:inputParameter
     // End of user code
-    private Set<Link> inputParameter = new HashSet<Link>();
+    private Set<Link> inputParameter = new HashSet<>();
     // Start of user code attributeAnnotation:executesAutomationPlan
     // End of user code
     private Link executesAutomationPlan;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -133,38 +133,38 @@ public class AutomationRequest
     public AutomationRequest()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public AutomationRequest(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_autoDomainConstants.AUTOMATIONREQUEST_PATH,
         AutomationRequest.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local AutomationRequest Resource} - update AutomationRequest.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -173,49 +173,49 @@ public class AutomationRequest
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addState(final Link state)
     {
         this.state.add(state);
     }
-    
+
     public void addInputParameter(final Link inputParameter)
     {
         this.inputParameter.add(inputParameter);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -231,7 +231,7 @@ public class AutomationRequest
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -246,7 +246,7 @@ public class AutomationRequest
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -262,7 +262,7 @@ public class AutomationRequest
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -277,7 +277,7 @@ public class AutomationRequest
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -292,7 +292,7 @@ public class AutomationRequest
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -307,7 +307,7 @@ public class AutomationRequest
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -322,7 +322,7 @@ public class AutomationRequest
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -337,7 +337,7 @@ public class AutomationRequest
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -353,7 +353,7 @@ public class AutomationRequest
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -369,7 +369,7 @@ public class AutomationRequest
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:state
     // End of user code
     @OslcName("state")
@@ -384,7 +384,7 @@ public class AutomationRequest
         // End of user code
         return state;
     }
-    
+
     // Start of user code getterAnnotation:desiredState
     // End of user code
     @OslcName("desiredState")
@@ -399,7 +399,7 @@ public class AutomationRequest
         // End of user code
         return desiredState;
     }
-    
+
     // Start of user code getterAnnotation:inputParameter
     // End of user code
     @OslcName("inputParameter")
@@ -415,7 +415,7 @@ public class AutomationRequest
         // End of user code
         return inputParameter;
     }
-    
+
     // Start of user code getterAnnotation:executesAutomationPlan
     // End of user code
     @OslcName("executesAutomationPlan")
@@ -432,8 +432,8 @@ public class AutomationRequest
         // End of user code
         return executesAutomationPlan;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -445,11 +445,11 @@ public class AutomationRequest
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -457,11 +457,11 @@ public class AutomationRequest
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -473,11 +473,11 @@ public class AutomationRequest
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -485,11 +485,11 @@ public class AutomationRequest
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -497,11 +497,11 @@ public class AutomationRequest
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -509,11 +509,11 @@ public class AutomationRequest
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<Link> type )
@@ -525,11 +525,11 @@ public class AutomationRequest
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -537,11 +537,11 @@ public class AutomationRequest
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -553,11 +553,11 @@ public class AutomationRequest
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -569,11 +569,11 @@ public class AutomationRequest
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:state
     // End of user code
     public void setState(final Set<Link> state )
@@ -585,11 +585,11 @@ public class AutomationRequest
         {
             this.state.addAll(state);
         }
-    
+
         // Start of user code setterFinalize:state
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:desiredState
     // End of user code
     public void setDesiredState(final Link desiredState )
@@ -597,11 +597,11 @@ public class AutomationRequest
         // Start of user code setterInit:desiredState
         // End of user code
         this.desiredState = desiredState;
-    
+
         // Start of user code setterFinalize:desiredState
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:inputParameter
     // End of user code
     public void setInputParameter(final Set<Link> inputParameter )
@@ -613,11 +613,11 @@ public class AutomationRequest
         {
             this.inputParameter.addAll(inputParameter);
         }
-    
+
         // Start of user code setterFinalize:inputParameter
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:executesAutomationPlan
     // End of user code
     public void setExecutesAutomationPlan(final Link executesAutomationPlan )
@@ -625,10 +625,10 @@ public class AutomationRequest
         // Start of user code setterInit:executesAutomationPlan
         // End of user code
         this.executesAutomationPlan = executesAutomationPlan;
-    
+
         // Start of user code setterFinalize:executesAutomationPlan
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationResult.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationResult.java
@@ -86,13 +86,13 @@ public class AutomationResult
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:identifier
     // End of user code
     private String identifier;
@@ -101,44 +101,44 @@ public class AutomationResult
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:state
     // End of user code
-    private Set<Link> state = new HashSet<Link>();
+    private Set<Link> state = new HashSet<>();
     // Start of user code attributeAnnotation:desiredState
     // End of user code
     private Link desiredState;
     // Start of user code attributeAnnotation:verdict
     // End of user code
-    private Set<Link> verdict = new HashSet<Link>();
+    private Set<Link> verdict = new HashSet<>();
     // Start of user code attributeAnnotation:contribution
     // End of user code
-    private Set<Link> contribution = new HashSet<Link>();
+    private Set<Link> contribution = new HashSet<>();
     // Start of user code attributeAnnotation:inputParameter
     // End of user code
-    private Set<Link> inputParameter = new HashSet<Link>();
+    private Set<Link> inputParameter = new HashSet<>();
     // Start of user code attributeAnnotation:outputParameter
     // End of user code
-    private Set<Link> outputParameter = new HashSet<Link>();
+    private Set<Link> outputParameter = new HashSet<>();
     // Start of user code attributeAnnotation:producedByAutomationRequest
     // End of user code
     private Link producedByAutomationRequest;
     // Start of user code attributeAnnotation:reportsOnAutomationPlan
     // End of user code
     private Link reportsOnAutomationPlan;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -146,38 +146,38 @@ public class AutomationResult
     public AutomationResult()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public AutomationResult(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_autoDomainConstants.AUTOMATIONRESULT_PATH,
         AutomationResult.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local AutomationResult Resource} - update AutomationResult.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -186,69 +186,69 @@ public class AutomationResult
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addState(final Link state)
     {
         this.state.add(state);
     }
-    
+
     public void addVerdict(final Link verdict)
     {
         this.verdict.add(verdict);
     }
-    
+
     public void addContribution(final Link contribution)
     {
         this.contribution.add(contribution);
     }
-    
+
     public void addInputParameter(final Link inputParameter)
     {
         this.inputParameter.add(inputParameter);
     }
-    
+
     public void addOutputParameter(final Link outputParameter)
     {
         this.outputParameter.add(outputParameter);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -264,7 +264,7 @@ public class AutomationResult
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -279,7 +279,7 @@ public class AutomationResult
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -295,7 +295,7 @@ public class AutomationResult
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -310,7 +310,7 @@ public class AutomationResult
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -325,7 +325,7 @@ public class AutomationResult
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -340,7 +340,7 @@ public class AutomationResult
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:subject
     // End of user code
     @OslcName("subject")
@@ -356,7 +356,7 @@ public class AutomationResult
         // End of user code
         return subject;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -371,7 +371,7 @@ public class AutomationResult
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -387,7 +387,7 @@ public class AutomationResult
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -403,7 +403,7 @@ public class AutomationResult
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:state
     // End of user code
     @OslcName("state")
@@ -418,7 +418,7 @@ public class AutomationResult
         // End of user code
         return state;
     }
-    
+
     // Start of user code getterAnnotation:desiredState
     // End of user code
     @OslcName("desiredState")
@@ -433,7 +433,7 @@ public class AutomationResult
         // End of user code
         return desiredState;
     }
-    
+
     // Start of user code getterAnnotation:verdict
     // End of user code
     @OslcName("verdict")
@@ -448,7 +448,7 @@ public class AutomationResult
         // End of user code
         return verdict;
     }
-    
+
     // Start of user code getterAnnotation:contribution
     // End of user code
     @OslcName("contribution")
@@ -463,7 +463,7 @@ public class AutomationResult
         // End of user code
         return contribution;
     }
-    
+
     // Start of user code getterAnnotation:inputParameter
     // End of user code
     @OslcName("inputParameter")
@@ -479,7 +479,7 @@ public class AutomationResult
         // End of user code
         return inputParameter;
     }
-    
+
     // Start of user code getterAnnotation:outputParameter
     // End of user code
     @OslcName("outputParameter")
@@ -495,7 +495,7 @@ public class AutomationResult
         // End of user code
         return outputParameter;
     }
-    
+
     // Start of user code getterAnnotation:producedByAutomationRequest
     // End of user code
     @OslcName("producedByAutomationRequest")
@@ -512,7 +512,7 @@ public class AutomationResult
         // End of user code
         return producedByAutomationRequest;
     }
-    
+
     // Start of user code getterAnnotation:reportsOnAutomationPlan
     // End of user code
     @OslcName("reportsOnAutomationPlan")
@@ -529,8 +529,8 @@ public class AutomationResult
         // End of user code
         return reportsOnAutomationPlan;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -542,11 +542,11 @@ public class AutomationResult
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -554,11 +554,11 @@ public class AutomationResult
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -570,11 +570,11 @@ public class AutomationResult
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -582,11 +582,11 @@ public class AutomationResult
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -594,11 +594,11 @@ public class AutomationResult
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<Link> type )
@@ -610,11 +610,11 @@ public class AutomationResult
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:subject
     // End of user code
     public void setSubject(final Set<String> subject )
@@ -626,11 +626,11 @@ public class AutomationResult
         {
             this.subject.addAll(subject);
         }
-    
+
         // Start of user code setterFinalize:subject
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -638,11 +638,11 @@ public class AutomationResult
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -654,11 +654,11 @@ public class AutomationResult
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -670,11 +670,11 @@ public class AutomationResult
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:state
     // End of user code
     public void setState(final Set<Link> state )
@@ -686,11 +686,11 @@ public class AutomationResult
         {
             this.state.addAll(state);
         }
-    
+
         // Start of user code setterFinalize:state
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:desiredState
     // End of user code
     public void setDesiredState(final Link desiredState )
@@ -698,11 +698,11 @@ public class AutomationResult
         // Start of user code setterInit:desiredState
         // End of user code
         this.desiredState = desiredState;
-    
+
         // Start of user code setterFinalize:desiredState
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:verdict
     // End of user code
     public void setVerdict(final Set<Link> verdict )
@@ -714,11 +714,11 @@ public class AutomationResult
         {
             this.verdict.addAll(verdict);
         }
-    
+
         // Start of user code setterFinalize:verdict
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:contribution
     // End of user code
     public void setContribution(final Set<Link> contribution )
@@ -730,11 +730,11 @@ public class AutomationResult
         {
             this.contribution.addAll(contribution);
         }
-    
+
         // Start of user code setterFinalize:contribution
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:inputParameter
     // End of user code
     public void setInputParameter(final Set<Link> inputParameter )
@@ -746,11 +746,11 @@ public class AutomationResult
         {
             this.inputParameter.addAll(inputParameter);
         }
-    
+
         // Start of user code setterFinalize:inputParameter
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:outputParameter
     // End of user code
     public void setOutputParameter(final Set<Link> outputParameter )
@@ -762,11 +762,11 @@ public class AutomationResult
         {
             this.outputParameter.addAll(outputParameter);
         }
-    
+
         // Start of user code setterFinalize:outputParameter
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:producedByAutomationRequest
     // End of user code
     public void setProducedByAutomationRequest(final Link producedByAutomationRequest )
@@ -774,11 +774,11 @@ public class AutomationResult
         // Start of user code setterInit:producedByAutomationRequest
         // End of user code
         this.producedByAutomationRequest = producedByAutomationRequest;
-    
+
         // Start of user code setterFinalize:producedByAutomationRequest
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:reportsOnAutomationPlan
     // End of user code
     public void setReportsOnAutomationPlan(final Link reportsOnAutomationPlan )
@@ -786,10 +786,10 @@ public class AutomationResult
         // Start of user code setterInit:reportsOnAutomationPlan
         // End of user code
         this.reportsOnAutomationPlan = reportsOnAutomationPlan;
-    
+
         // Start of user code setterFinalize:reportsOnAutomationPlan
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/ParameterInstance.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/ParameterInstance.java
@@ -92,14 +92,14 @@ public class ParameterInstance
     private String description;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
-    
+    private Set<Link> serviceProvider = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -107,38 +107,38 @@ public class ParameterInstance
     public ParameterInstance()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public ParameterInstance(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_autoDomainConstants.PARAMETERINSTANCE_PATH,
         ParameterInstance.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local ParameterInstance Resource} - update ParameterInstance.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -147,29 +147,29 @@ public class ParameterInstance
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:name
     // End of user code
     @OslcName("name")
@@ -184,7 +184,7 @@ public class ParameterInstance
         // End of user code
         return name;
     }
-    
+
     // Start of user code getterAnnotation:value
     // End of user code
     @OslcName("value")
@@ -198,7 +198,7 @@ public class ParameterInstance
         // End of user code
         return value;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -213,7 +213,7 @@ public class ParameterInstance
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -228,7 +228,7 @@ public class ParameterInstance
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -244,7 +244,7 @@ public class ParameterInstance
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -260,8 +260,8 @@ public class ParameterInstance
         // End of user code
         return serviceProvider;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:name
     // End of user code
     public void setName(final String name )
@@ -269,11 +269,11 @@ public class ParameterInstance
         // Start of user code setterInit:name
         // End of user code
         this.name = name;
-    
+
         // Start of user code setterFinalize:name
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:value
     // End of user code
     public void setValue(final String value )
@@ -281,11 +281,11 @@ public class ParameterInstance
         // Start of user code setterInit:value
         // End of user code
         this.value = value;
-    
+
         // Start of user code setterFinalize:value
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -293,11 +293,11 @@ public class ParameterInstance
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<Link> type )
@@ -309,11 +309,11 @@ public class ParameterInstance
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -325,11 +325,11 @@ public class ParameterInstance
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -341,10 +341,10 @@ public class ParameterInstance
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ChangeRequest.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ChangeRequest.java
@@ -105,13 +105,13 @@ public class ChangeRequest
     private String identifier;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
@@ -120,10 +120,10 @@ public class ChangeRequest
     private Date modified;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:discussedBy
     // End of user code
     private Link discussedBy;
@@ -153,38 +153,38 @@ public class ChangeRequest
     private Boolean verified;
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private Set<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:affectsPlanItem
     // End of user code
-    private Set<Link> affectsPlanItem = new HashSet<Link>();
+    private Set<Link> affectsPlanItem = new HashSet<>();
     // Start of user code attributeAnnotation:affectedByDefect
     // End of user code
-    private Set<Link> affectedByDefect = new HashSet<Link>();
+    private Set<Link> affectedByDefect = new HashSet<>();
     // Start of user code attributeAnnotation:tracksRequirement
     // End of user code
-    private Set<Link> tracksRequirement = new HashSet<Link>();
+    private Set<Link> tracksRequirement = new HashSet<>();
     // Start of user code attributeAnnotation:implementsRequirement
     // End of user code
-    private Set<Link> implementsRequirement = new HashSet<Link>();
+    private Set<Link> implementsRequirement = new HashSet<>();
     // Start of user code attributeAnnotation:affectsRequirement
     // End of user code
-    private Set<Link> affectsRequirement = new HashSet<Link>();
+    private Set<Link> affectsRequirement = new HashSet<>();
     // Start of user code attributeAnnotation:tracksChangeSet
     // End of user code
-    private Set<Link> tracksChangeSet = new HashSet<Link>();
+    private Set<Link> tracksChangeSet = new HashSet<>();
     // Start of user code attributeAnnotation:parent
     // End of user code
-    private Set<Link> parent = new HashSet<Link>();
+    private Set<Link> parent = new HashSet<>();
     // Start of user code attributeAnnotation:priority
     // End of user code
-    private Set<Link> priority = new HashSet<Link>();
+    private Set<Link> priority = new HashSet<>();
     // Start of user code attributeAnnotation:state
     // End of user code
     private Link state;
     // Start of user code attributeAnnotation:authorizer
     // End of user code
-    private Set<Link> authorizer = new HashSet<Link>();
-    
+    private Set<Link> authorizer = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -192,38 +192,38 @@ public class ChangeRequest
     public ChangeRequest()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public ChangeRequest(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_cmDomainConstants.CHANGEREQUEST_PATH,
         ChangeRequest.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local ChangeRequest Resource} - update ChangeRequest.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -232,90 +232,90 @@ public class ChangeRequest
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         result = String.format("[%s]: %s (Change Request; id=%s)", this.getShortTitle(), this.getTitle(), this.getIdentifier());
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addRelatedChangeRequest(final Link relatedChangeRequest)
     {
         this.relatedChangeRequest.add(relatedChangeRequest);
     }
-    
+
     public void addAffectsPlanItem(final Link affectsPlanItem)
     {
         this.affectsPlanItem.add(affectsPlanItem);
     }
-    
+
     public void addAffectedByDefect(final Link affectedByDefect)
     {
         this.affectedByDefect.add(affectedByDefect);
     }
-    
+
     public void addTracksRequirement(final Link tracksRequirement)
     {
         this.tracksRequirement.add(tracksRequirement);
     }
-    
+
     public void addImplementsRequirement(final Link implementsRequirement)
     {
         this.implementsRequirement.add(implementsRequirement);
     }
-    
+
     public void addAffectsRequirement(final Link affectsRequirement)
     {
         this.affectsRequirement.add(affectsRequirement);
     }
-    
+
     public void addTracksChangeSet(final Link tracksChangeSet)
     {
         this.tracksChangeSet.add(tracksChangeSet);
     }
-    
+
     public void addParent(final Link parent)
     {
         this.parent.add(parent);
     }
-    
+
     public void addPriority(final Link priority)
     {
         this.priority.add(priority);
     }
-    
+
     public void addAuthorizer(final Link authorizer)
     {
         this.authorizer.add(authorizer);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:shortTitle
     // End of user code
     @OslcName("shortTitle")
@@ -330,7 +330,7 @@ public class ChangeRequest
         // End of user code
         return shortTitle;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -345,7 +345,7 @@ public class ChangeRequest
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -360,7 +360,7 @@ public class ChangeRequest
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -375,7 +375,7 @@ public class ChangeRequest
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:subject
     // End of user code
     @OslcName("subject")
@@ -391,7 +391,7 @@ public class ChangeRequest
         // End of user code
         return subject;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -407,7 +407,7 @@ public class ChangeRequest
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -423,7 +423,7 @@ public class ChangeRequest
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -438,7 +438,7 @@ public class ChangeRequest
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -453,7 +453,7 @@ public class ChangeRequest
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -469,7 +469,7 @@ public class ChangeRequest
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -485,7 +485,7 @@ public class ChangeRequest
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:discussedBy
     // End of user code
     @OslcName("discussedBy")
@@ -501,7 +501,7 @@ public class ChangeRequest
         // End of user code
         return discussedBy;
     }
-    
+
     // Start of user code getterAnnotation:closeDate
     // End of user code
     @OslcName("closeDate")
@@ -516,7 +516,7 @@ public class ChangeRequest
         // End of user code
         return closeDate;
     }
-    
+
     // Start of user code getterAnnotation:status
     // End of user code
     @OslcName("status")
@@ -531,7 +531,7 @@ public class ChangeRequest
         // End of user code
         return status;
     }
-    
+
     // Start of user code getterAnnotation:closed
     // End of user code
     @OslcName("closed")
@@ -546,7 +546,7 @@ public class ChangeRequest
         // End of user code
         return closed;
     }
-    
+
     // Start of user code getterAnnotation:inProgress
     // End of user code
     @OslcName("inProgress")
@@ -561,7 +561,7 @@ public class ChangeRequest
         // End of user code
         return inProgress;
     }
-    
+
     // Start of user code getterAnnotation:fixed
     // End of user code
     @OslcName("fixed")
@@ -576,7 +576,7 @@ public class ChangeRequest
         // End of user code
         return fixed;
     }
-    
+
     // Start of user code getterAnnotation:approved
     // End of user code
     @OslcName("approved")
@@ -591,7 +591,7 @@ public class ChangeRequest
         // End of user code
         return approved;
     }
-    
+
     // Start of user code getterAnnotation:reviewed
     // End of user code
     @OslcName("reviewed")
@@ -606,7 +606,7 @@ public class ChangeRequest
         // End of user code
         return reviewed;
     }
-    
+
     // Start of user code getterAnnotation:verified
     // End of user code
     @OslcName("verified")
@@ -621,7 +621,7 @@ public class ChangeRequest
         // End of user code
         return verified;
     }
-    
+
     // Start of user code getterAnnotation:relatedChangeRequest
     // End of user code
     @OslcName("relatedChangeRequest")
@@ -637,7 +637,7 @@ public class ChangeRequest
         // End of user code
         return relatedChangeRequest;
     }
-    
+
     // Start of user code getterAnnotation:affectsPlanItem
     // End of user code
     @OslcName("affectsPlanItem")
@@ -653,7 +653,7 @@ public class ChangeRequest
         // End of user code
         return affectsPlanItem;
     }
-    
+
     // Start of user code getterAnnotation:affectedByDefect
     // End of user code
     @OslcName("affectedByDefect")
@@ -670,7 +670,7 @@ public class ChangeRequest
         // End of user code
         return affectedByDefect;
     }
-    
+
     // Start of user code getterAnnotation:tracksRequirement
     // End of user code
     @OslcName("tracksRequirement")
@@ -686,7 +686,7 @@ public class ChangeRequest
         // End of user code
         return tracksRequirement;
     }
-    
+
     // Start of user code getterAnnotation:implementsRequirement
     // End of user code
     @OslcName("implementsRequirement")
@@ -703,7 +703,7 @@ public class ChangeRequest
         // End of user code
         return implementsRequirement;
     }
-    
+
     // Start of user code getterAnnotation:affectsRequirement
     // End of user code
     @OslcName("affectsRequirement")
@@ -720,7 +720,7 @@ public class ChangeRequest
         // End of user code
         return affectsRequirement;
     }
-    
+
     // Start of user code getterAnnotation:tracksChangeSet
     // End of user code
     @OslcName("tracksChangeSet")
@@ -737,7 +737,7 @@ public class ChangeRequest
         // End of user code
         return tracksChangeSet;
     }
-    
+
     // Start of user code getterAnnotation:parent
     // End of user code
     @OslcName("parent")
@@ -752,7 +752,7 @@ public class ChangeRequest
         // End of user code
         return parent;
     }
-    
+
     // Start of user code getterAnnotation:priority
     // End of user code
     @OslcName("priority")
@@ -767,7 +767,7 @@ public class ChangeRequest
         // End of user code
         return priority;
     }
-    
+
     // Start of user code getterAnnotation:state
     // End of user code
     @OslcName("state")
@@ -782,7 +782,7 @@ public class ChangeRequest
         // End of user code
         return state;
     }
-    
+
     // Start of user code getterAnnotation:authorizer
     // End of user code
     @OslcName("authorizer")
@@ -797,8 +797,8 @@ public class ChangeRequest
         // End of user code
         return authorizer;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:shortTitle
     // End of user code
     public void setShortTitle(final String shortTitle )
@@ -806,11 +806,11 @@ public class ChangeRequest
         // Start of user code setterInit:shortTitle
         // End of user code
         this.shortTitle = shortTitle;
-    
+
         // Start of user code setterFinalize:shortTitle
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -818,11 +818,11 @@ public class ChangeRequest
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -830,11 +830,11 @@ public class ChangeRequest
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -842,11 +842,11 @@ public class ChangeRequest
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:subject
     // End of user code
     public void setSubject(final Set<String> subject )
@@ -858,11 +858,11 @@ public class ChangeRequest
         {
             this.subject.addAll(subject);
         }
-    
+
         // Start of user code setterFinalize:subject
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -874,11 +874,11 @@ public class ChangeRequest
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -890,11 +890,11 @@ public class ChangeRequest
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -902,11 +902,11 @@ public class ChangeRequest
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -914,11 +914,11 @@ public class ChangeRequest
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -930,11 +930,11 @@ public class ChangeRequest
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -946,11 +946,11 @@ public class ChangeRequest
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:discussedBy
     // End of user code
     public void setDiscussedBy(final Link discussedBy )
@@ -958,11 +958,11 @@ public class ChangeRequest
         // Start of user code setterInit:discussedBy
         // End of user code
         this.discussedBy = discussedBy;
-    
+
         // Start of user code setterFinalize:discussedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:closeDate
     // End of user code
     public void setCloseDate(final Date closeDate )
@@ -970,11 +970,11 @@ public class ChangeRequest
         // Start of user code setterInit:closeDate
         // End of user code
         this.closeDate = closeDate;
-    
+
         // Start of user code setterFinalize:closeDate
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:status
     // End of user code
     public void setStatus(final String status )
@@ -982,11 +982,11 @@ public class ChangeRequest
         // Start of user code setterInit:status
         // End of user code
         this.status = status;
-    
+
         // Start of user code setterFinalize:status
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:closed
     // End of user code
     public void setClosed(final Boolean closed )
@@ -994,11 +994,11 @@ public class ChangeRequest
         // Start of user code setterInit:closed
         // End of user code
         this.closed = closed;
-    
+
         // Start of user code setterFinalize:closed
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:inProgress
     // End of user code
     public void setInProgress(final Boolean inProgress )
@@ -1006,11 +1006,11 @@ public class ChangeRequest
         // Start of user code setterInit:inProgress
         // End of user code
         this.inProgress = inProgress;
-    
+
         // Start of user code setterFinalize:inProgress
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:fixed
     // End of user code
     public void setFixed(final Boolean fixed )
@@ -1018,11 +1018,11 @@ public class ChangeRequest
         // Start of user code setterInit:fixed
         // End of user code
         this.fixed = fixed;
-    
+
         // Start of user code setterFinalize:fixed
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:approved
     // End of user code
     public void setApproved(final Boolean approved )
@@ -1030,11 +1030,11 @@ public class ChangeRequest
         // Start of user code setterInit:approved
         // End of user code
         this.approved = approved;
-    
+
         // Start of user code setterFinalize:approved
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:reviewed
     // End of user code
     public void setReviewed(final Boolean reviewed )
@@ -1042,11 +1042,11 @@ public class ChangeRequest
         // Start of user code setterInit:reviewed
         // End of user code
         this.reviewed = reviewed;
-    
+
         // Start of user code setterFinalize:reviewed
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:verified
     // End of user code
     public void setVerified(final Boolean verified )
@@ -1054,11 +1054,11 @@ public class ChangeRequest
         // Start of user code setterInit:verified
         // End of user code
         this.verified = verified;
-    
+
         // Start of user code setterFinalize:verified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:relatedChangeRequest
     // End of user code
     public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest )
@@ -1070,11 +1070,11 @@ public class ChangeRequest
         {
             this.relatedChangeRequest.addAll(relatedChangeRequest);
         }
-    
+
         // Start of user code setterFinalize:relatedChangeRequest
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:affectsPlanItem
     // End of user code
     public void setAffectsPlanItem(final Set<Link> affectsPlanItem )
@@ -1086,11 +1086,11 @@ public class ChangeRequest
         {
             this.affectsPlanItem.addAll(affectsPlanItem);
         }
-    
+
         // Start of user code setterFinalize:affectsPlanItem
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:affectedByDefect
     // End of user code
     public void setAffectedByDefect(final Set<Link> affectedByDefect )
@@ -1102,11 +1102,11 @@ public class ChangeRequest
         {
             this.affectedByDefect.addAll(affectedByDefect);
         }
-    
+
         // Start of user code setterFinalize:affectedByDefect
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:tracksRequirement
     // End of user code
     public void setTracksRequirement(final Set<Link> tracksRequirement )
@@ -1118,11 +1118,11 @@ public class ChangeRequest
         {
             this.tracksRequirement.addAll(tracksRequirement);
         }
-    
+
         // Start of user code setterFinalize:tracksRequirement
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:implementsRequirement
     // End of user code
     public void setImplementsRequirement(final Set<Link> implementsRequirement )
@@ -1134,11 +1134,11 @@ public class ChangeRequest
         {
             this.implementsRequirement.addAll(implementsRequirement);
         }
-    
+
         // Start of user code setterFinalize:implementsRequirement
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:affectsRequirement
     // End of user code
     public void setAffectsRequirement(final Set<Link> affectsRequirement )
@@ -1150,11 +1150,11 @@ public class ChangeRequest
         {
             this.affectsRequirement.addAll(affectsRequirement);
         }
-    
+
         // Start of user code setterFinalize:affectsRequirement
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:tracksChangeSet
     // End of user code
     public void setTracksChangeSet(final Set<Link> tracksChangeSet )
@@ -1166,11 +1166,11 @@ public class ChangeRequest
         {
             this.tracksChangeSet.addAll(tracksChangeSet);
         }
-    
+
         // Start of user code setterFinalize:tracksChangeSet
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:parent
     // End of user code
     public void setParent(final Set<Link> parent )
@@ -1182,11 +1182,11 @@ public class ChangeRequest
         {
             this.parent.addAll(parent);
         }
-    
+
         // Start of user code setterFinalize:parent
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:priority
     // End of user code
     public void setPriority(final Set<Link> priority )
@@ -1198,11 +1198,11 @@ public class ChangeRequest
         {
             this.priority.addAll(priority);
         }
-    
+
         // Start of user code setterFinalize:priority
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:state
     // End of user code
     public void setState(final Link state )
@@ -1210,11 +1210,11 @@ public class ChangeRequest
         // Start of user code setterInit:state
         // End of user code
         this.state = state;
-    
+
         // Start of user code setterFinalize:state
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:authorizer
     // End of user code
     public void setAuthorizer(final Set<Link> authorizer )
@@ -1226,10 +1226,10 @@ public class ChangeRequest
         {
             this.authorizer.addAll(authorizer);
         }
-    
+
         // Start of user code setterFinalize:authorizer
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/VersionResource.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/VersionResource.java
@@ -84,13 +84,13 @@ public class VersionResource
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -105,7 +105,7 @@ public class VersionResource
     private Date modified;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
@@ -114,22 +114,22 @@ public class VersionResource
     private Date committed;
     // Start of user code attributeAnnotation:committer
     // End of user code
-    private Set<Link> committer = new HashSet<Link>();
+    private Set<Link> committer = new HashSet<>();
     // Start of user code attributeAnnotation:component
     // End of user code
-    private Set<String> component = new HashSet<String>();
+    private Set<String> component = new HashSet<>();
     // Start of user code attributeAnnotation:versionId
     // End of user code
     private String versionId;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:modifiedBy
     // End of user code
     private Link modifiedBy;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:shortId
     // End of user code
     private String shortId;
@@ -138,14 +138,14 @@ public class VersionResource
     private String shortTitle;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:wasDerivedFrom
     // End of user code
-    private Set<Link> wasDerivedFrom = new HashSet<Link>();
+    private Set<Link> wasDerivedFrom = new HashSet<>();
     // Start of user code attributeAnnotation:wasRevisionOf
     // End of user code
-    private Set<Link> wasRevisionOf = new HashSet<Link>();
-    
+    private Set<Link> wasRevisionOf = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -153,38 +153,38 @@ public class VersionResource
     public VersionResource()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public VersionResource(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_configDomainConstants.VERSIONRESOURCE_PATH,
         VersionResource.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local VersionResource Resource} - update VersionResource.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -193,64 +193,64 @@ public class VersionResource
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addCommitter(final Link committer)
     {
         this.committer.add(committer);
     }
-    
+
     public void addComponent(final String component)
     {
         this.component.add(component);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addWasDerivedFrom(final Link wasDerivedFrom)
     {
         this.wasDerivedFrom.add(wasDerivedFrom);
     }
-    
+
     public void addWasRevisionOf(final Link wasRevisionOf)
     {
         this.wasRevisionOf.add(wasRevisionOf);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -266,7 +266,7 @@ public class VersionResource
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -281,7 +281,7 @@ public class VersionResource
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -297,7 +297,7 @@ public class VersionResource
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -312,7 +312,7 @@ public class VersionResource
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -327,7 +327,7 @@ public class VersionResource
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:isVersionOf
     // End of user code
     @OslcName("isVersionOf")
@@ -343,7 +343,7 @@ public class VersionResource
         // End of user code
         return isVersionOf;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -358,7 +358,7 @@ public class VersionResource
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:subject
     // End of user code
     @OslcName("subject")
@@ -374,7 +374,7 @@ public class VersionResource
         // End of user code
         return subject;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -389,7 +389,7 @@ public class VersionResource
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:committed
     // End of user code
     @OslcName("committed")
@@ -404,7 +404,7 @@ public class VersionResource
         // End of user code
         return committed;
     }
-    
+
     // Start of user code getterAnnotation:committer
     // End of user code
     @OslcName("committer")
@@ -419,7 +419,7 @@ public class VersionResource
         // End of user code
         return committer;
     }
-    
+
     // Start of user code getterAnnotation:component
     // End of user code
     @OslcName("component")
@@ -434,7 +434,7 @@ public class VersionResource
         // End of user code
         return component;
     }
-    
+
     // Start of user code getterAnnotation:versionId
     // End of user code
     @OslcName("versionId")
@@ -449,7 +449,7 @@ public class VersionResource
         // End of user code
         return versionId;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -465,7 +465,7 @@ public class VersionResource
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:modifiedBy
     // End of user code
     @OslcName("modifiedBy")
@@ -480,7 +480,7 @@ public class VersionResource
         // End of user code
         return modifiedBy;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -496,7 +496,7 @@ public class VersionResource
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:shortId
     // End of user code
     @OslcName("shortId")
@@ -511,7 +511,7 @@ public class VersionResource
         // End of user code
         return shortId;
     }
-    
+
     // Start of user code getterAnnotation:shortTitle
     // End of user code
     @OslcName("shortTitle")
@@ -526,7 +526,7 @@ public class VersionResource
         // End of user code
         return shortTitle;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -541,7 +541,7 @@ public class VersionResource
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:wasDerivedFrom
     // End of user code
     @OslcName("wasDerivedFrom")
@@ -557,7 +557,7 @@ public class VersionResource
         // End of user code
         return wasDerivedFrom;
     }
-    
+
     // Start of user code getterAnnotation:wasRevisionOf
     // End of user code
     @OslcName("wasRevisionOf")
@@ -573,8 +573,8 @@ public class VersionResource
         // End of user code
         return wasRevisionOf;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -586,11 +586,11 @@ public class VersionResource
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -598,11 +598,11 @@ public class VersionResource
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -614,11 +614,11 @@ public class VersionResource
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -626,11 +626,11 @@ public class VersionResource
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -638,11 +638,11 @@ public class VersionResource
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:isVersionOf
     // End of user code
     public void setIsVersionOf(final Link isVersionOf )
@@ -650,11 +650,11 @@ public class VersionResource
         // Start of user code setterInit:isVersionOf
         // End of user code
         this.isVersionOf = isVersionOf;
-    
+
         // Start of user code setterFinalize:isVersionOf
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -662,11 +662,11 @@ public class VersionResource
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:subject
     // End of user code
     public void setSubject(final Set<String> subject )
@@ -678,11 +678,11 @@ public class VersionResource
         {
             this.subject.addAll(subject);
         }
-    
+
         // Start of user code setterFinalize:subject
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -690,11 +690,11 @@ public class VersionResource
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:committed
     // End of user code
     public void setCommitted(final Date committed )
@@ -702,11 +702,11 @@ public class VersionResource
         // Start of user code setterInit:committed
         // End of user code
         this.committed = committed;
-    
+
         // Start of user code setterFinalize:committed
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:committer
     // End of user code
     public void setCommitter(final Set<Link> committer )
@@ -718,11 +718,11 @@ public class VersionResource
         {
             this.committer.addAll(committer);
         }
-    
+
         // Start of user code setterFinalize:committer
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:component
     // End of user code
     public void setComponent(final Set<String> component )
@@ -734,11 +734,11 @@ public class VersionResource
         {
             this.component.addAll(component);
         }
-    
+
         // Start of user code setterFinalize:component
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:versionId
     // End of user code
     public void setVersionId(final String versionId )
@@ -746,11 +746,11 @@ public class VersionResource
         // Start of user code setterInit:versionId
         // End of user code
         this.versionId = versionId;
-    
+
         // Start of user code setterFinalize:versionId
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -762,11 +762,11 @@ public class VersionResource
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modifiedBy
     // End of user code
     public void setModifiedBy(final Link modifiedBy )
@@ -774,11 +774,11 @@ public class VersionResource
         // Start of user code setterInit:modifiedBy
         // End of user code
         this.modifiedBy = modifiedBy;
-    
+
         // Start of user code setterFinalize:modifiedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -790,11 +790,11 @@ public class VersionResource
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:shortId
     // End of user code
     public void setShortId(final String shortId )
@@ -802,11 +802,11 @@ public class VersionResource
         // Start of user code setterInit:shortId
         // End of user code
         this.shortId = shortId;
-    
+
         // Start of user code setterFinalize:shortId
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:shortTitle
     // End of user code
     public void setShortTitle(final String shortTitle )
@@ -814,11 +814,11 @@ public class VersionResource
         // Start of user code setterInit:shortTitle
         // End of user code
         this.shortTitle = shortTitle;
-    
+
         // Start of user code setterFinalize:shortTitle
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<Link> type )
@@ -830,11 +830,11 @@ public class VersionResource
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:wasDerivedFrom
     // End of user code
     public void setWasDerivedFrom(final Set<Link> wasDerivedFrom )
@@ -846,11 +846,11 @@ public class VersionResource
         {
             this.wasDerivedFrom.addAll(wasDerivedFrom);
         }
-    
+
         // Start of user code setterFinalize:wasDerivedFrom
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:wasRevisionOf
     // End of user code
     public void setWasRevisionOf(final Set<Link> wasRevisionOf )
@@ -862,10 +862,10 @@ public class VersionResource
         {
             this.wasRevisionOf.addAll(wasRevisionOf);
         }
-    
+
         // Start of user code setterFinalize:wasRevisionOf
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestCase.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestCase.java
@@ -90,13 +90,13 @@ public class TestCase
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -108,32 +108,32 @@ public class TestCase
     private Date modified;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private Set<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:testsChangeRequest
     // End of user code
-    private Set<Link> testsChangeRequest = new HashSet<Link>();
+    private Set<Link> testsChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:usesTestScript
     // End of user code
-    private Set<Link> usesTestScript = new HashSet<Link>();
+    private Set<Link> usesTestScript = new HashSet<>();
     // Start of user code attributeAnnotation:validatesRequirement
     // End of user code
-    private Set<Link> validatesRequirement = new HashSet<Link>();
-    
+    private Set<Link> validatesRequirement = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -141,38 +141,38 @@ public class TestCase
     public TestCase()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public TestCase(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_qmDomainConstants.TESTCASE_PATH,
         TestCase.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local TestCase Resource} - update TestCase.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -181,65 +181,65 @@ public class TestCase
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         result = String.format("%s (TestCase; id=%s)", this.getTitle(), this.getIdentifier());
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addRelatedChangeRequest(final Link relatedChangeRequest)
     {
         this.relatedChangeRequest.add(relatedChangeRequest);
     }
-    
+
     public void addTestsChangeRequest(final Link testsChangeRequest)
     {
         this.testsChangeRequest.add(testsChangeRequest);
     }
-    
+
     public void addUsesTestScript(final Link usesTestScript)
     {
         this.usesTestScript.add(usesTestScript);
     }
-    
+
     public void addValidatesRequirement(final Link validatesRequirement)
     {
         this.validatesRequirement.add(validatesRequirement);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -255,7 +255,7 @@ public class TestCase
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -270,7 +270,7 @@ public class TestCase
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -286,7 +286,7 @@ public class TestCase
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -301,7 +301,7 @@ public class TestCase
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -316,7 +316,7 @@ public class TestCase
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -331,7 +331,7 @@ public class TestCase
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -347,7 +347,7 @@ public class TestCase
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -363,7 +363,7 @@ public class TestCase
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:subject
     // End of user code
     @OslcName("subject")
@@ -379,7 +379,7 @@ public class TestCase
         // End of user code
         return subject;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -394,7 +394,7 @@ public class TestCase
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -409,7 +409,7 @@ public class TestCase
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:relatedChangeRequest
     // End of user code
     @OslcName("relatedChangeRequest")
@@ -426,7 +426,7 @@ public class TestCase
         // End of user code
         return relatedChangeRequest;
     }
-    
+
     // Start of user code getterAnnotation:testsChangeRequest
     // End of user code
     @OslcName("testsChangeRequest")
@@ -443,7 +443,7 @@ public class TestCase
         // End of user code
         return testsChangeRequest;
     }
-    
+
     // Start of user code getterAnnotation:usesTestScript
     // End of user code
     @OslcName("usesTestScript")
@@ -459,7 +459,7 @@ public class TestCase
         // End of user code
         return usesTestScript;
     }
-    
+
     // Start of user code getterAnnotation:validatesRequirement
     // End of user code
     @OslcName("validatesRequirement")
@@ -476,8 +476,8 @@ public class TestCase
         // End of user code
         return validatesRequirement;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -489,11 +489,11 @@ public class TestCase
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -501,11 +501,11 @@ public class TestCase
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -517,11 +517,11 @@ public class TestCase
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -529,11 +529,11 @@ public class TestCase
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -541,11 +541,11 @@ public class TestCase
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -553,11 +553,11 @@ public class TestCase
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -569,11 +569,11 @@ public class TestCase
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -585,11 +585,11 @@ public class TestCase
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:subject
     // End of user code
     public void setSubject(final Set<String> subject )
@@ -601,11 +601,11 @@ public class TestCase
         {
             this.subject.addAll(subject);
         }
-    
+
         // Start of user code setterFinalize:subject
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -613,11 +613,11 @@ public class TestCase
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<Link> type )
@@ -629,11 +629,11 @@ public class TestCase
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:relatedChangeRequest
     // End of user code
     public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest )
@@ -645,11 +645,11 @@ public class TestCase
         {
             this.relatedChangeRequest.addAll(relatedChangeRequest);
         }
-    
+
         // Start of user code setterFinalize:relatedChangeRequest
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:testsChangeRequest
     // End of user code
     public void setTestsChangeRequest(final Set<Link> testsChangeRequest )
@@ -661,11 +661,11 @@ public class TestCase
         {
             this.testsChangeRequest.addAll(testsChangeRequest);
         }
-    
+
         // Start of user code setterFinalize:testsChangeRequest
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:usesTestScript
     // End of user code
     public void setUsesTestScript(final Set<Link> usesTestScript )
@@ -677,11 +677,11 @@ public class TestCase
         {
             this.usesTestScript.addAll(usesTestScript);
         }
-    
+
         // Start of user code setterFinalize:usesTestScript
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:validatesRequirement
     // End of user code
     public void setValidatesRequirement(final Set<Link> validatesRequirement )
@@ -693,10 +693,10 @@ public class TestCase
         {
             this.validatesRequirement.addAll(validatesRequirement);
         }
-    
+
         // Start of user code setterFinalize:validatesRequirement
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestExecutionRecord.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestExecutionRecord.java
@@ -89,13 +89,13 @@ public class TestExecutionRecord
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:identifier
     // End of user code
     private String identifier;
@@ -104,22 +104,22 @@ public class TestExecutionRecord
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:blockedByChangeRequest
     // End of user code
-    private Set<Link> blockedByChangeRequest = new HashSet<Link>();
+    private Set<Link> blockedByChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private Set<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:reportsOnTestPlan
     // End of user code
     private Link reportsOnTestPlan;
@@ -129,7 +129,7 @@ public class TestExecutionRecord
     // Start of user code attributeAnnotation:runsTestCase
     // End of user code
     private Link runsTestCase;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -137,38 +137,38 @@ public class TestExecutionRecord
     public TestExecutionRecord()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public TestExecutionRecord(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_qmDomainConstants.TESTEXECUTIONRECORD_PATH,
         TestExecutionRecord.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local TestExecutionRecord Resource} - update TestExecutionRecord.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -177,49 +177,49 @@ public class TestExecutionRecord
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addBlockedByChangeRequest(final Link blockedByChangeRequest)
     {
         this.blockedByChangeRequest.add(blockedByChangeRequest);
     }
-    
+
     public void addRelatedChangeRequest(final Link relatedChangeRequest)
     {
         this.relatedChangeRequest.add(relatedChangeRequest);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -235,7 +235,7 @@ public class TestExecutionRecord
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -250,7 +250,7 @@ public class TestExecutionRecord
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -266,7 +266,7 @@ public class TestExecutionRecord
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -281,7 +281,7 @@ public class TestExecutionRecord
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -296,7 +296,7 @@ public class TestExecutionRecord
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -311,7 +311,7 @@ public class TestExecutionRecord
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -327,7 +327,7 @@ public class TestExecutionRecord
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -343,7 +343,7 @@ public class TestExecutionRecord
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -358,7 +358,7 @@ public class TestExecutionRecord
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:blockedByChangeRequest
     // End of user code
     @OslcName("blockedByChangeRequest")
@@ -375,7 +375,7 @@ public class TestExecutionRecord
         // End of user code
         return blockedByChangeRequest;
     }
-    
+
     // Start of user code getterAnnotation:relatedChangeRequest
     // End of user code
     @OslcName("relatedChangeRequest")
@@ -392,7 +392,7 @@ public class TestExecutionRecord
         // End of user code
         return relatedChangeRequest;
     }
-    
+
     // Start of user code getterAnnotation:reportsOnTestPlan
     // End of user code
     @OslcName("reportsOnTestPlan")
@@ -408,7 +408,7 @@ public class TestExecutionRecord
         // End of user code
         return reportsOnTestPlan;
     }
-    
+
     // Start of user code getterAnnotation:runsOnTestEnvironment
     // End of user code
     @OslcName("runsOnTestEnvironment")
@@ -424,7 +424,7 @@ public class TestExecutionRecord
         // End of user code
         return runsOnTestEnvironment;
     }
-    
+
     // Start of user code getterAnnotation:runsTestCase
     // End of user code
     @OslcName("runsTestCase")
@@ -440,8 +440,8 @@ public class TestExecutionRecord
         // End of user code
         return runsTestCase;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -453,11 +453,11 @@ public class TestExecutionRecord
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -465,11 +465,11 @@ public class TestExecutionRecord
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -481,11 +481,11 @@ public class TestExecutionRecord
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -493,11 +493,11 @@ public class TestExecutionRecord
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -505,11 +505,11 @@ public class TestExecutionRecord
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<Link> type )
@@ -521,11 +521,11 @@ public class TestExecutionRecord
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -537,11 +537,11 @@ public class TestExecutionRecord
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -553,11 +553,11 @@ public class TestExecutionRecord
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -565,11 +565,11 @@ public class TestExecutionRecord
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:blockedByChangeRequest
     // End of user code
     public void setBlockedByChangeRequest(final Set<Link> blockedByChangeRequest )
@@ -581,11 +581,11 @@ public class TestExecutionRecord
         {
             this.blockedByChangeRequest.addAll(blockedByChangeRequest);
         }
-    
+
         // Start of user code setterFinalize:blockedByChangeRequest
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:relatedChangeRequest
     // End of user code
     public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest )
@@ -597,11 +597,11 @@ public class TestExecutionRecord
         {
             this.relatedChangeRequest.addAll(relatedChangeRequest);
         }
-    
+
         // Start of user code setterFinalize:relatedChangeRequest
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:reportsOnTestPlan
     // End of user code
     public void setReportsOnTestPlan(final Link reportsOnTestPlan )
@@ -609,11 +609,11 @@ public class TestExecutionRecord
         // Start of user code setterInit:reportsOnTestPlan
         // End of user code
         this.reportsOnTestPlan = reportsOnTestPlan;
-    
+
         // Start of user code setterFinalize:reportsOnTestPlan
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:runsOnTestEnvironment
     // End of user code
     public void setRunsOnTestEnvironment(final Link runsOnTestEnvironment )
@@ -621,11 +621,11 @@ public class TestExecutionRecord
         // Start of user code setterInit:runsOnTestEnvironment
         // End of user code
         this.runsOnTestEnvironment = runsOnTestEnvironment;
-    
+
         // Start of user code setterFinalize:runsOnTestEnvironment
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:runsTestCase
     // End of user code
     public void setRunsTestCase(final Link runsTestCase )
@@ -633,10 +633,10 @@ public class TestExecutionRecord
         // Start of user code setterInit:runsTestCase
         // End of user code
         this.runsTestCase = runsTestCase;
-    
+
         // Start of user code setterFinalize:runsTestCase
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestPlan.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestPlan.java
@@ -90,13 +90,13 @@ public class TestPlan
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -108,29 +108,29 @@ public class TestPlan
     private Date modified;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:usesTestCase
     // End of user code
-    private Set<Link> usesTestCase = new HashSet<Link>();
+    private Set<Link> usesTestCase = new HashSet<>();
     // Start of user code attributeAnnotation:validatesRequirementCollection
     // End of user code
-    private Set<Link> validatesRequirementCollection = new HashSet<Link>();
+    private Set<Link> validatesRequirementCollection = new HashSet<>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private Set<Link> relatedChangeRequest = new HashSet<Link>();
-    
+    private Set<Link> relatedChangeRequest = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -138,38 +138,38 @@ public class TestPlan
     public TestPlan()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public TestPlan(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_qmDomainConstants.TESTPLAN_PATH,
         TestPlan.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local TestPlan Resource} - update TestPlan.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -178,60 +178,60 @@ public class TestPlan
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         result = String.format("%s (TestPlan; id=%s)", this.getTitle(), this.getIdentifier());
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addUsesTestCase(final Link usesTestCase)
     {
         this.usesTestCase.add(usesTestCase);
     }
-    
+
     public void addValidatesRequirementCollection(final Link validatesRequirementCollection)
     {
         this.validatesRequirementCollection.add(validatesRequirementCollection);
     }
-    
+
     public void addRelatedChangeRequest(final Link relatedChangeRequest)
     {
         this.relatedChangeRequest.add(relatedChangeRequest);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -247,7 +247,7 @@ public class TestPlan
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -262,7 +262,7 @@ public class TestPlan
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -278,7 +278,7 @@ public class TestPlan
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -293,7 +293,7 @@ public class TestPlan
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -308,7 +308,7 @@ public class TestPlan
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -323,7 +323,7 @@ public class TestPlan
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:subject
     // End of user code
     @OslcName("subject")
@@ -339,7 +339,7 @@ public class TestPlan
         // End of user code
         return subject;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -354,7 +354,7 @@ public class TestPlan
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -369,7 +369,7 @@ public class TestPlan
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -385,7 +385,7 @@ public class TestPlan
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -401,7 +401,7 @@ public class TestPlan
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:usesTestCase
     // End of user code
     @OslcName("usesTestCase")
@@ -417,7 +417,7 @@ public class TestPlan
         // End of user code
         return usesTestCase;
     }
-    
+
     // Start of user code getterAnnotation:validatesRequirementCollection
     // End of user code
     @OslcName("validatesRequirementCollection")
@@ -434,7 +434,7 @@ public class TestPlan
         // End of user code
         return validatesRequirementCollection;
     }
-    
+
     // Start of user code getterAnnotation:relatedChangeRequest
     // End of user code
     @OslcName("relatedChangeRequest")
@@ -451,8 +451,8 @@ public class TestPlan
         // End of user code
         return relatedChangeRequest;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -464,11 +464,11 @@ public class TestPlan
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -476,11 +476,11 @@ public class TestPlan
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -492,11 +492,11 @@ public class TestPlan
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -504,11 +504,11 @@ public class TestPlan
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -516,11 +516,11 @@ public class TestPlan
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -528,11 +528,11 @@ public class TestPlan
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:subject
     // End of user code
     public void setSubject(final Set<String> subject )
@@ -544,11 +544,11 @@ public class TestPlan
         {
             this.subject.addAll(subject);
         }
-    
+
         // Start of user code setterFinalize:subject
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -556,11 +556,11 @@ public class TestPlan
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<Link> type )
@@ -572,11 +572,11 @@ public class TestPlan
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -588,11 +588,11 @@ public class TestPlan
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -604,11 +604,11 @@ public class TestPlan
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:usesTestCase
     // End of user code
     public void setUsesTestCase(final Set<Link> usesTestCase )
@@ -620,11 +620,11 @@ public class TestPlan
         {
             this.usesTestCase.addAll(usesTestCase);
         }
-    
+
         // Start of user code setterFinalize:usesTestCase
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:validatesRequirementCollection
     // End of user code
     public void setValidatesRequirementCollection(final Set<Link> validatesRequirementCollection )
@@ -636,11 +636,11 @@ public class TestPlan
         {
             this.validatesRequirementCollection.addAll(validatesRequirementCollection);
         }
-    
+
         // Start of user code setterFinalize:validatesRequirementCollection
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:relatedChangeRequest
     // End of user code
     public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest )
@@ -652,10 +652,10 @@ public class TestPlan
         {
             this.relatedChangeRequest.addAll(relatedChangeRequest);
         }
-    
+
         // Start of user code setterFinalize:relatedChangeRequest
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestResult.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestResult.java
@@ -98,22 +98,22 @@ public class TestResult
     private Date modified;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:status
     // End of user code
     private String status;
     // Start of user code attributeAnnotation:affectedByChangeRequest
     // End of user code
-    private Set<Link> affectedByChangeRequest = new HashSet<Link>();
+    private Set<Link> affectedByChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:executesTestScript
     // End of user code
     private Link executesTestScript;
@@ -126,7 +126,7 @@ public class TestResult
     // Start of user code attributeAnnotation:reportsOnTestPlan
     // End of user code
     private Link reportsOnTestPlan;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -134,38 +134,38 @@ public class TestResult
     public TestResult()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public TestResult(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_qmDomainConstants.TESTRESULT_PATH,
         TestResult.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local TestResult Resource} - update TestResult.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -174,34 +174,34 @@ public class TestResult
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addAffectedByChangeRequest(final Link affectedByChangeRequest)
     {
         this.affectedByChangeRequest.add(affectedByChangeRequest);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -216,7 +216,7 @@ public class TestResult
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -231,7 +231,7 @@ public class TestResult
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -246,7 +246,7 @@ public class TestResult
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -262,7 +262,7 @@ public class TestResult
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -277,7 +277,7 @@ public class TestResult
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -292,7 +292,7 @@ public class TestResult
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -308,7 +308,7 @@ public class TestResult
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:status
     // End of user code
     @OslcName("status")
@@ -323,7 +323,7 @@ public class TestResult
         // End of user code
         return status;
     }
-    
+
     // Start of user code getterAnnotation:affectedByChangeRequest
     // End of user code
     @OslcName("affectedByChangeRequest")
@@ -340,7 +340,7 @@ public class TestResult
         // End of user code
         return affectedByChangeRequest;
     }
-    
+
     // Start of user code getterAnnotation:executesTestScript
     // End of user code
     @OslcName("executesTestScript")
@@ -357,7 +357,7 @@ public class TestResult
         // End of user code
         return executesTestScript;
     }
-    
+
     // Start of user code getterAnnotation:producedByTestExecutionRecord
     // End of user code
     @OslcName("producedByTestExecutionRecord")
@@ -374,7 +374,7 @@ public class TestResult
         // End of user code
         return producedByTestExecutionRecord;
     }
-    
+
     // Start of user code getterAnnotation:reportsOnTestCase
     // End of user code
     @OslcName("reportsOnTestCase")
@@ -390,7 +390,7 @@ public class TestResult
         // End of user code
         return reportsOnTestCase;
     }
-    
+
     // Start of user code getterAnnotation:reportsOnTestPlan
     // End of user code
     @OslcName("reportsOnTestPlan")
@@ -406,8 +406,8 @@ public class TestResult
         // End of user code
         return reportsOnTestPlan;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -415,11 +415,11 @@ public class TestResult
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -427,11 +427,11 @@ public class TestResult
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -439,11 +439,11 @@ public class TestResult
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -455,11 +455,11 @@ public class TestResult
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -467,11 +467,11 @@ public class TestResult
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<Link> type )
@@ -483,11 +483,11 @@ public class TestResult
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -499,11 +499,11 @@ public class TestResult
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:status
     // End of user code
     public void setStatus(final String status )
@@ -511,11 +511,11 @@ public class TestResult
         // Start of user code setterInit:status
         // End of user code
         this.status = status;
-    
+
         // Start of user code setterFinalize:status
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:affectedByChangeRequest
     // End of user code
     public void setAffectedByChangeRequest(final Set<Link> affectedByChangeRequest )
@@ -527,11 +527,11 @@ public class TestResult
         {
             this.affectedByChangeRequest.addAll(affectedByChangeRequest);
         }
-    
+
         // Start of user code setterFinalize:affectedByChangeRequest
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:executesTestScript
     // End of user code
     public void setExecutesTestScript(final Link executesTestScript )
@@ -539,11 +539,11 @@ public class TestResult
         // Start of user code setterInit:executesTestScript
         // End of user code
         this.executesTestScript = executesTestScript;
-    
+
         // Start of user code setterFinalize:executesTestScript
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:producedByTestExecutionRecord
     // End of user code
     public void setProducedByTestExecutionRecord(final Link producedByTestExecutionRecord )
@@ -551,11 +551,11 @@ public class TestResult
         // Start of user code setterInit:producedByTestExecutionRecord
         // End of user code
         this.producedByTestExecutionRecord = producedByTestExecutionRecord;
-    
+
         // Start of user code setterFinalize:producedByTestExecutionRecord
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:reportsOnTestCase
     // End of user code
     public void setReportsOnTestCase(final Link reportsOnTestCase )
@@ -563,11 +563,11 @@ public class TestResult
         // Start of user code setterInit:reportsOnTestCase
         // End of user code
         this.reportsOnTestCase = reportsOnTestCase;
-    
+
         // Start of user code setterFinalize:reportsOnTestCase
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:reportsOnTestPlan
     // End of user code
     public void setReportsOnTestPlan(final Link reportsOnTestPlan )
@@ -575,10 +575,10 @@ public class TestResult
         // Start of user code setterInit:reportsOnTestPlan
         // End of user code
         this.reportsOnTestPlan = reportsOnTestPlan;
-    
+
         // Start of user code setterFinalize:reportsOnTestPlan
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestScript.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestScript.java
@@ -89,13 +89,13 @@ public class TestScript
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -107,26 +107,26 @@ public class TestScript
     private Date modified;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:executionInstructions
     // End of user code
-    private Set<Link> executionInstructions = new HashSet<Link>();
+    private Set<Link> executionInstructions = new HashSet<>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private Set<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:validatesRequirement
     // End of user code
-    private Set<Link> validatesRequirement = new HashSet<Link>();
-    
+    private Set<Link> validatesRequirement = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -134,38 +134,38 @@ public class TestScript
     public TestScript()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public TestScript(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_qmDomainConstants.TESTSCRIPT_PATH,
         TestScript.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local TestScript Resource} - update TestScript.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -174,54 +174,54 @@ public class TestScript
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addExecutionInstructions(final Link executionInstructions)
     {
         this.executionInstructions.add(executionInstructions);
     }
-    
+
     public void addRelatedChangeRequest(final Link relatedChangeRequest)
     {
         this.relatedChangeRequest.add(relatedChangeRequest);
     }
-    
+
     public void addValidatesRequirement(final Link validatesRequirement)
     {
         this.validatesRequirement.add(validatesRequirement);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -237,7 +237,7 @@ public class TestScript
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -252,7 +252,7 @@ public class TestScript
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -268,7 +268,7 @@ public class TestScript
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -283,7 +283,7 @@ public class TestScript
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -298,7 +298,7 @@ public class TestScript
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -313,7 +313,7 @@ public class TestScript
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -329,7 +329,7 @@ public class TestScript
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -345,7 +345,7 @@ public class TestScript
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -360,7 +360,7 @@ public class TestScript
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:type
     // End of user code
     @OslcName("type")
@@ -375,7 +375,7 @@ public class TestScript
         // End of user code
         return type;
     }
-    
+
     // Start of user code getterAnnotation:executionInstructions
     // End of user code
     @OslcName("executionInstructions")
@@ -391,7 +391,7 @@ public class TestScript
         // End of user code
         return executionInstructions;
     }
-    
+
     // Start of user code getterAnnotation:relatedChangeRequest
     // End of user code
     @OslcName("relatedChangeRequest")
@@ -408,7 +408,7 @@ public class TestScript
         // End of user code
         return relatedChangeRequest;
     }
-    
+
     // Start of user code getterAnnotation:validatesRequirement
     // End of user code
     @OslcName("validatesRequirement")
@@ -425,8 +425,8 @@ public class TestScript
         // End of user code
         return validatesRequirement;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -438,11 +438,11 @@ public class TestScript
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -450,11 +450,11 @@ public class TestScript
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -466,11 +466,11 @@ public class TestScript
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -478,11 +478,11 @@ public class TestScript
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -490,11 +490,11 @@ public class TestScript
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -502,11 +502,11 @@ public class TestScript
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -518,11 +518,11 @@ public class TestScript
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -534,11 +534,11 @@ public class TestScript
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -546,11 +546,11 @@ public class TestScript
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:type
     // End of user code
     public void setType(final Set<Link> type )
@@ -562,11 +562,11 @@ public class TestScript
         {
             this.type.addAll(type);
         }
-    
+
         // Start of user code setterFinalize:type
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:executionInstructions
     // End of user code
     public void setExecutionInstructions(final Set<Link> executionInstructions )
@@ -578,11 +578,11 @@ public class TestScript
         {
             this.executionInstructions.addAll(executionInstructions);
         }
-    
+
         // Start of user code setterFinalize:executionInstructions
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:relatedChangeRequest
     // End of user code
     public void setRelatedChangeRequest(final Set<Link> relatedChangeRequest )
@@ -594,11 +594,11 @@ public class TestScript
         {
             this.relatedChangeRequest.addAll(relatedChangeRequest);
         }
-    
+
         // Start of user code setterFinalize:relatedChangeRequest
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:validatesRequirement
     // End of user code
     public void setValidatesRequirement(final Set<Link> validatesRequirement )
@@ -610,10 +610,10 @@ public class TestScript
         {
             this.validatesRequirement.addAll(validatesRequirement);
         }
-    
+
         // Start of user code setterFinalize:validatesRequirement
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Requirement.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Requirement.java
@@ -95,13 +95,13 @@ public class Requirement
     private String shortTitle;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
@@ -110,53 +110,53 @@ public class Requirement
     private Date modified;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:elaboratedBy
     // End of user code
-    private Set<Link> elaboratedBy = new HashSet<Link>();
+    private Set<Link> elaboratedBy = new HashSet<>();
     // Start of user code attributeAnnotation:elaborates
     // End of user code
-    private Set<Link> elaborates = new HashSet<Link>();
+    private Set<Link> elaborates = new HashSet<>();
     // Start of user code attributeAnnotation:specifiedBy
     // End of user code
-    private Set<Link> specifiedBy = new HashSet<Link>();
+    private Set<Link> specifiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:specifies
     // End of user code
-    private Set<Link> specifies = new HashSet<Link>();
+    private Set<Link> specifies = new HashSet<>();
     // Start of user code attributeAnnotation:affectedBy
     // End of user code
-    private Set<Link> affectedBy = new HashSet<Link>();
+    private Set<Link> affectedBy = new HashSet<>();
     // Start of user code attributeAnnotation:trackedBy
     // End of user code
-    private Set<Link> trackedBy = new HashSet<Link>();
+    private Set<Link> trackedBy = new HashSet<>();
     // Start of user code attributeAnnotation:implementedBy
     // End of user code
-    private Set<Link> implementedBy = new HashSet<Link>();
+    private Set<Link> implementedBy = new HashSet<>();
     // Start of user code attributeAnnotation:validatedBy
     // End of user code
-    private Set<Link> validatedBy = new HashSet<Link>();
+    private Set<Link> validatedBy = new HashSet<>();
     // Start of user code attributeAnnotation:satisfiedBy
     // End of user code
-    private Set<Link> satisfiedBy = new HashSet<Link>();
+    private Set<Link> satisfiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:satisfies
     // End of user code
-    private Set<Link> satisfies = new HashSet<Link>();
+    private Set<Link> satisfies = new HashSet<>();
     // Start of user code attributeAnnotation:decomposedBy
     // End of user code
-    private Set<Link> decomposedBy = new HashSet<Link>();
+    private Set<Link> decomposedBy = new HashSet<>();
     // Start of user code attributeAnnotation:decomposes
     // End of user code
-    private Set<Link> decomposes = new HashSet<Link>();
+    private Set<Link> decomposes = new HashSet<>();
     // Start of user code attributeAnnotation:constrainedBy
     // End of user code
-    private Set<Link> constrainedBy = new HashSet<Link>();
+    private Set<Link> constrainedBy = new HashSet<>();
     // Start of user code attributeAnnotation:constrains
     // End of user code
-    private Set<Link> constrains = new HashSet<Link>();
-    
+    private Set<Link> constrains = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -164,38 +164,38 @@ public class Requirement
     public Requirement()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public Requirement(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_rmDomainConstants.REQUIREMENT_PATH,
         Requirement.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local Requirement Resource} - update Requirement.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -204,111 +204,111 @@ public class Requirement
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         result = String.format("%s: %s (Requirement; id=%s)", this.getShortTitle(), this.getTitle(), this.getIdentifier());
 
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addElaboratedBy(final Link elaboratedBy)
     {
         this.elaboratedBy.add(elaboratedBy);
     }
-    
+
     public void addElaborates(final Link elaborates)
     {
         this.elaborates.add(elaborates);
     }
-    
+
     public void addSpecifiedBy(final Link specifiedBy)
     {
         this.specifiedBy.add(specifiedBy);
     }
-    
+
     public void addSpecifies(final Link specifies)
     {
         this.specifies.add(specifies);
     }
-    
+
     public void addAffectedBy(final Link affectedBy)
     {
         this.affectedBy.add(affectedBy);
     }
-    
+
     public void addTrackedBy(final Link trackedBy)
     {
         this.trackedBy.add(trackedBy);
     }
-    
+
     public void addImplementedBy(final Link implementedBy)
     {
         this.implementedBy.add(implementedBy);
     }
-    
+
     public void addValidatedBy(final Link validatedBy)
     {
         this.validatedBy.add(validatedBy);
     }
-    
+
     public void addSatisfiedBy(final Link satisfiedBy)
     {
         this.satisfiedBy.add(satisfiedBy);
     }
-    
+
     public void addSatisfies(final Link satisfies)
     {
         this.satisfies.add(satisfies);
     }
-    
+
     public void addDecomposedBy(final Link decomposedBy)
     {
         this.decomposedBy.add(decomposedBy);
     }
-    
+
     public void addDecomposes(final Link decomposes)
     {
         this.decomposes.add(decomposes);
     }
-    
+
     public void addConstrainedBy(final Link constrainedBy)
     {
         this.constrainedBy.add(constrainedBy);
     }
-    
+
     public void addConstrains(final Link constrains)
     {
         this.constrains.add(constrains);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -323,7 +323,7 @@ public class Requirement
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -338,7 +338,7 @@ public class Requirement
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -353,7 +353,7 @@ public class Requirement
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:shortTitle
     // End of user code
     @OslcName("shortTitle")
@@ -368,7 +368,7 @@ public class Requirement
         // End of user code
         return shortTitle;
     }
-    
+
     // Start of user code getterAnnotation:subject
     // End of user code
     @OslcName("subject")
@@ -384,7 +384,7 @@ public class Requirement
         // End of user code
         return subject;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -400,7 +400,7 @@ public class Requirement
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -416,7 +416,7 @@ public class Requirement
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -431,7 +431,7 @@ public class Requirement
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -446,7 +446,7 @@ public class Requirement
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -462,7 +462,7 @@ public class Requirement
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -478,7 +478,7 @@ public class Requirement
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:elaboratedBy
     // End of user code
     @OslcName("elaboratedBy")
@@ -494,7 +494,7 @@ public class Requirement
         // End of user code
         return elaboratedBy;
     }
-    
+
     // Start of user code getterAnnotation:elaborates
     // End of user code
     @OslcName("elaborates")
@@ -510,7 +510,7 @@ public class Requirement
         // End of user code
         return elaborates;
     }
-    
+
     // Start of user code getterAnnotation:specifiedBy
     // End of user code
     @OslcName("specifiedBy")
@@ -526,7 +526,7 @@ public class Requirement
         // End of user code
         return specifiedBy;
     }
-    
+
     // Start of user code getterAnnotation:specifies
     // End of user code
     @OslcName("specifies")
@@ -542,7 +542,7 @@ public class Requirement
         // End of user code
         return specifies;
     }
-    
+
     // Start of user code getterAnnotation:affectedBy
     // End of user code
     @OslcName("affectedBy")
@@ -558,7 +558,7 @@ public class Requirement
         // End of user code
         return affectedBy;
     }
-    
+
     // Start of user code getterAnnotation:trackedBy
     // End of user code
     @OslcName("trackedBy")
@@ -574,7 +574,7 @@ public class Requirement
         // End of user code
         return trackedBy;
     }
-    
+
     // Start of user code getterAnnotation:implementedBy
     // End of user code
     @OslcName("implementedBy")
@@ -590,7 +590,7 @@ public class Requirement
         // End of user code
         return implementedBy;
     }
-    
+
     // Start of user code getterAnnotation:validatedBy
     // End of user code
     @OslcName("validatedBy")
@@ -606,7 +606,7 @@ public class Requirement
         // End of user code
         return validatedBy;
     }
-    
+
     // Start of user code getterAnnotation:satisfiedBy
     // End of user code
     @OslcName("satisfiedBy")
@@ -622,7 +622,7 @@ public class Requirement
         // End of user code
         return satisfiedBy;
     }
-    
+
     // Start of user code getterAnnotation:satisfies
     // End of user code
     @OslcName("satisfies")
@@ -638,7 +638,7 @@ public class Requirement
         // End of user code
         return satisfies;
     }
-    
+
     // Start of user code getterAnnotation:decomposedBy
     // End of user code
     @OslcName("decomposedBy")
@@ -654,7 +654,7 @@ public class Requirement
         // End of user code
         return decomposedBy;
     }
-    
+
     // Start of user code getterAnnotation:decomposes
     // End of user code
     @OslcName("decomposes")
@@ -670,7 +670,7 @@ public class Requirement
         // End of user code
         return decomposes;
     }
-    
+
     // Start of user code getterAnnotation:constrainedBy
     // End of user code
     @OslcName("constrainedBy")
@@ -686,7 +686,7 @@ public class Requirement
         // End of user code
         return constrainedBy;
     }
-    
+
     // Start of user code getterAnnotation:constrains
     // End of user code
     @OslcName("constrains")
@@ -702,8 +702,8 @@ public class Requirement
         // End of user code
         return constrains;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -711,11 +711,11 @@ public class Requirement
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -723,11 +723,11 @@ public class Requirement
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -735,11 +735,11 @@ public class Requirement
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:shortTitle
     // End of user code
     public void setShortTitle(final String shortTitle )
@@ -747,11 +747,11 @@ public class Requirement
         // Start of user code setterInit:shortTitle
         // End of user code
         this.shortTitle = shortTitle;
-    
+
         // Start of user code setterFinalize:shortTitle
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:subject
     // End of user code
     public void setSubject(final Set<String> subject )
@@ -763,11 +763,11 @@ public class Requirement
         {
             this.subject.addAll(subject);
         }
-    
+
         // Start of user code setterFinalize:subject
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -779,11 +779,11 @@ public class Requirement
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -795,11 +795,11 @@ public class Requirement
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -807,11 +807,11 @@ public class Requirement
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -819,11 +819,11 @@ public class Requirement
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -835,11 +835,11 @@ public class Requirement
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -851,11 +851,11 @@ public class Requirement
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:elaboratedBy
     // End of user code
     public void setElaboratedBy(final Set<Link> elaboratedBy )
@@ -867,11 +867,11 @@ public class Requirement
         {
             this.elaboratedBy.addAll(elaboratedBy);
         }
-    
+
         // Start of user code setterFinalize:elaboratedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:elaborates
     // End of user code
     public void setElaborates(final Set<Link> elaborates )
@@ -883,11 +883,11 @@ public class Requirement
         {
             this.elaborates.addAll(elaborates);
         }
-    
+
         // Start of user code setterFinalize:elaborates
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:specifiedBy
     // End of user code
     public void setSpecifiedBy(final Set<Link> specifiedBy )
@@ -899,11 +899,11 @@ public class Requirement
         {
             this.specifiedBy.addAll(specifiedBy);
         }
-    
+
         // Start of user code setterFinalize:specifiedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:specifies
     // End of user code
     public void setSpecifies(final Set<Link> specifies )
@@ -915,11 +915,11 @@ public class Requirement
         {
             this.specifies.addAll(specifies);
         }
-    
+
         // Start of user code setterFinalize:specifies
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:affectedBy
     // End of user code
     public void setAffectedBy(final Set<Link> affectedBy )
@@ -931,11 +931,11 @@ public class Requirement
         {
             this.affectedBy.addAll(affectedBy);
         }
-    
+
         // Start of user code setterFinalize:affectedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:trackedBy
     // End of user code
     public void setTrackedBy(final Set<Link> trackedBy )
@@ -947,11 +947,11 @@ public class Requirement
         {
             this.trackedBy.addAll(trackedBy);
         }
-    
+
         // Start of user code setterFinalize:trackedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:implementedBy
     // End of user code
     public void setImplementedBy(final Set<Link> implementedBy )
@@ -963,11 +963,11 @@ public class Requirement
         {
             this.implementedBy.addAll(implementedBy);
         }
-    
+
         // Start of user code setterFinalize:implementedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:validatedBy
     // End of user code
     public void setValidatedBy(final Set<Link> validatedBy )
@@ -979,11 +979,11 @@ public class Requirement
         {
             this.validatedBy.addAll(validatedBy);
         }
-    
+
         // Start of user code setterFinalize:validatedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:satisfiedBy
     // End of user code
     public void setSatisfiedBy(final Set<Link> satisfiedBy )
@@ -995,11 +995,11 @@ public class Requirement
         {
             this.satisfiedBy.addAll(satisfiedBy);
         }
-    
+
         // Start of user code setterFinalize:satisfiedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:satisfies
     // End of user code
     public void setSatisfies(final Set<Link> satisfies )
@@ -1011,11 +1011,11 @@ public class Requirement
         {
             this.satisfies.addAll(satisfies);
         }
-    
+
         // Start of user code setterFinalize:satisfies
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:decomposedBy
     // End of user code
     public void setDecomposedBy(final Set<Link> decomposedBy )
@@ -1027,11 +1027,11 @@ public class Requirement
         {
             this.decomposedBy.addAll(decomposedBy);
         }
-    
+
         // Start of user code setterFinalize:decomposedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:decomposes
     // End of user code
     public void setDecomposes(final Set<Link> decomposes )
@@ -1043,11 +1043,11 @@ public class Requirement
         {
             this.decomposes.addAll(decomposes);
         }
-    
+
         // Start of user code setterFinalize:decomposes
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:constrainedBy
     // End of user code
     public void setConstrainedBy(final Set<Link> constrainedBy )
@@ -1059,11 +1059,11 @@ public class Requirement
         {
             this.constrainedBy.addAll(constrainedBy);
         }
-    
+
         // Start of user code setterFinalize:constrainedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:constrains
     // End of user code
     public void setConstrains(final Set<Link> constrains )
@@ -1075,10 +1075,10 @@ public class Requirement
         {
             this.constrains.addAll(constrains);
         }
-    
+
         // Start of user code setterFinalize:constrains
         // End of user code
     }
-    
-    
+
+
 }

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/RequirementCollection.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/RequirementCollection.java
@@ -95,13 +95,13 @@ public class RequirementCollection
     private String shortTitle;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
@@ -110,56 +110,56 @@ public class RequirementCollection
     private Date modified;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:elaboratedBy
     // End of user code
-    private Set<Link> elaboratedBy = new HashSet<Link>();
+    private Set<Link> elaboratedBy = new HashSet<>();
     // Start of user code attributeAnnotation:elaborates
     // End of user code
-    private Set<Link> elaborates = new HashSet<Link>();
+    private Set<Link> elaborates = new HashSet<>();
     // Start of user code attributeAnnotation:specifiedBy
     // End of user code
-    private Set<Link> specifiedBy = new HashSet<Link>();
+    private Set<Link> specifiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:specifies
     // End of user code
-    private Set<Link> specifies = new HashSet<Link>();
+    private Set<Link> specifies = new HashSet<>();
     // Start of user code attributeAnnotation:affectedBy
     // End of user code
-    private Set<Link> affectedBy = new HashSet<Link>();
+    private Set<Link> affectedBy = new HashSet<>();
     // Start of user code attributeAnnotation:trackedBy
     // End of user code
-    private Set<Link> trackedBy = new HashSet<Link>();
+    private Set<Link> trackedBy = new HashSet<>();
     // Start of user code attributeAnnotation:implementedBy
     // End of user code
-    private Set<Link> implementedBy = new HashSet<Link>();
+    private Set<Link> implementedBy = new HashSet<>();
     // Start of user code attributeAnnotation:validatedBy
     // End of user code
-    private Set<Link> validatedBy = new HashSet<Link>();
+    private Set<Link> validatedBy = new HashSet<>();
     // Start of user code attributeAnnotation:satisfiedBy
     // End of user code
-    private Set<Link> satisfiedBy = new HashSet<Link>();
+    private Set<Link> satisfiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:satisfies
     // End of user code
-    private Set<Link> satisfies = new HashSet<Link>();
+    private Set<Link> satisfies = new HashSet<>();
     // Start of user code attributeAnnotation:decomposedBy
     // End of user code
-    private Set<Link> decomposedBy = new HashSet<Link>();
+    private Set<Link> decomposedBy = new HashSet<>();
     // Start of user code attributeAnnotation:decomposes
     // End of user code
-    private Set<Link> decomposes = new HashSet<Link>();
+    private Set<Link> decomposes = new HashSet<>();
     // Start of user code attributeAnnotation:constrainedBy
     // End of user code
-    private Set<Link> constrainedBy = new HashSet<Link>();
+    private Set<Link> constrainedBy = new HashSet<>();
     // Start of user code attributeAnnotation:constrains
     // End of user code
-    private Set<Link> constrains = new HashSet<Link>();
+    private Set<Link> constrains = new HashSet<>();
     // Start of user code attributeAnnotation:uses
     // End of user code
-    private Set<Link> uses = new HashSet<Link>();
-    
+    private Set<Link> uses = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -167,38 +167,38 @@ public class RequirementCollection
     public RequirementCollection()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public RequirementCollection(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_rmDomainConstants.REQUIREMENTCOLLECTION_PATH,
         RequirementCollection.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local RequirementCollection Resource} - update RequirementCollection.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -207,114 +207,114 @@ public class RequirementCollection
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addElaboratedBy(final Link elaboratedBy)
     {
         this.elaboratedBy.add(elaboratedBy);
     }
-    
+
     public void addElaborates(final Link elaborates)
     {
         this.elaborates.add(elaborates);
     }
-    
+
     public void addSpecifiedBy(final Link specifiedBy)
     {
         this.specifiedBy.add(specifiedBy);
     }
-    
+
     public void addSpecifies(final Link specifies)
     {
         this.specifies.add(specifies);
     }
-    
+
     public void addAffectedBy(final Link affectedBy)
     {
         this.affectedBy.add(affectedBy);
     }
-    
+
     public void addTrackedBy(final Link trackedBy)
     {
         this.trackedBy.add(trackedBy);
     }
-    
+
     public void addImplementedBy(final Link implementedBy)
     {
         this.implementedBy.add(implementedBy);
     }
-    
+
     public void addValidatedBy(final Link validatedBy)
     {
         this.validatedBy.add(validatedBy);
     }
-    
+
     public void addSatisfiedBy(final Link satisfiedBy)
     {
         this.satisfiedBy.add(satisfiedBy);
     }
-    
+
     public void addSatisfies(final Link satisfies)
     {
         this.satisfies.add(satisfies);
     }
-    
+
     public void addDecomposedBy(final Link decomposedBy)
     {
         this.decomposedBy.add(decomposedBy);
     }
-    
+
     public void addDecomposes(final Link decomposes)
     {
         this.decomposes.add(decomposes);
     }
-    
+
     public void addConstrainedBy(final Link constrainedBy)
     {
         this.constrainedBy.add(constrainedBy);
     }
-    
+
     public void addConstrains(final Link constrains)
     {
         this.constrains.add(constrains);
     }
-    
+
     public void addUses(final Link uses)
     {
         this.uses.add(uses);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -329,7 +329,7 @@ public class RequirementCollection
         // End of user code
         return title;
     }
-    
+
     // Start of user code getterAnnotation:description
     // End of user code
     @OslcName("description")
@@ -344,7 +344,7 @@ public class RequirementCollection
         // End of user code
         return description;
     }
-    
+
     // Start of user code getterAnnotation:identifier
     // End of user code
     @OslcName("identifier")
@@ -359,7 +359,7 @@ public class RequirementCollection
         // End of user code
         return identifier;
     }
-    
+
     // Start of user code getterAnnotation:shortTitle
     // End of user code
     @OslcName("shortTitle")
@@ -374,7 +374,7 @@ public class RequirementCollection
         // End of user code
         return shortTitle;
     }
-    
+
     // Start of user code getterAnnotation:subject
     // End of user code
     @OslcName("subject")
@@ -390,7 +390,7 @@ public class RequirementCollection
         // End of user code
         return subject;
     }
-    
+
     // Start of user code getterAnnotation:creator
     // End of user code
     @OslcName("creator")
@@ -406,7 +406,7 @@ public class RequirementCollection
         // End of user code
         return creator;
     }
-    
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")
@@ -422,7 +422,7 @@ public class RequirementCollection
         // End of user code
         return contributor;
     }
-    
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")
@@ -437,7 +437,7 @@ public class RequirementCollection
         // End of user code
         return created;
     }
-    
+
     // Start of user code getterAnnotation:modified
     // End of user code
     @OslcName("modified")
@@ -452,7 +452,7 @@ public class RequirementCollection
         // End of user code
         return modified;
     }
-    
+
     // Start of user code getterAnnotation:serviceProvider
     // End of user code
     @OslcName("serviceProvider")
@@ -468,7 +468,7 @@ public class RequirementCollection
         // End of user code
         return serviceProvider;
     }
-    
+
     // Start of user code getterAnnotation:instanceShape
     // End of user code
     @OslcName("instanceShape")
@@ -484,7 +484,7 @@ public class RequirementCollection
         // End of user code
         return instanceShape;
     }
-    
+
     // Start of user code getterAnnotation:elaboratedBy
     // End of user code
     @OslcName("elaboratedBy")
@@ -500,7 +500,7 @@ public class RequirementCollection
         // End of user code
         return elaboratedBy;
     }
-    
+
     // Start of user code getterAnnotation:elaborates
     // End of user code
     @OslcName("elaborates")
@@ -516,7 +516,7 @@ public class RequirementCollection
         // End of user code
         return elaborates;
     }
-    
+
     // Start of user code getterAnnotation:specifiedBy
     // End of user code
     @OslcName("specifiedBy")
@@ -532,7 +532,7 @@ public class RequirementCollection
         // End of user code
         return specifiedBy;
     }
-    
+
     // Start of user code getterAnnotation:specifies
     // End of user code
     @OslcName("specifies")
@@ -548,7 +548,7 @@ public class RequirementCollection
         // End of user code
         return specifies;
     }
-    
+
     // Start of user code getterAnnotation:affectedBy
     // End of user code
     @OslcName("affectedBy")
@@ -564,7 +564,7 @@ public class RequirementCollection
         // End of user code
         return affectedBy;
     }
-    
+
     // Start of user code getterAnnotation:trackedBy
     // End of user code
     @OslcName("trackedBy")
@@ -580,7 +580,7 @@ public class RequirementCollection
         // End of user code
         return trackedBy;
     }
-    
+
     // Start of user code getterAnnotation:implementedBy
     // End of user code
     @OslcName("implementedBy")
@@ -596,7 +596,7 @@ public class RequirementCollection
         // End of user code
         return implementedBy;
     }
-    
+
     // Start of user code getterAnnotation:validatedBy
     // End of user code
     @OslcName("validatedBy")
@@ -612,7 +612,7 @@ public class RequirementCollection
         // End of user code
         return validatedBy;
     }
-    
+
     // Start of user code getterAnnotation:satisfiedBy
     // End of user code
     @OslcName("satisfiedBy")
@@ -628,7 +628,7 @@ public class RequirementCollection
         // End of user code
         return satisfiedBy;
     }
-    
+
     // Start of user code getterAnnotation:satisfies
     // End of user code
     @OslcName("satisfies")
@@ -644,7 +644,7 @@ public class RequirementCollection
         // End of user code
         return satisfies;
     }
-    
+
     // Start of user code getterAnnotation:decomposedBy
     // End of user code
     @OslcName("decomposedBy")
@@ -660,7 +660,7 @@ public class RequirementCollection
         // End of user code
         return decomposedBy;
     }
-    
+
     // Start of user code getterAnnotation:decomposes
     // End of user code
     @OslcName("decomposes")
@@ -676,7 +676,7 @@ public class RequirementCollection
         // End of user code
         return decomposes;
     }
-    
+
     // Start of user code getterAnnotation:constrainedBy
     // End of user code
     @OslcName("constrainedBy")
@@ -692,7 +692,7 @@ public class RequirementCollection
         // End of user code
         return constrainedBy;
     }
-    
+
     // Start of user code getterAnnotation:constrains
     // End of user code
     @OslcName("constrains")
@@ -708,7 +708,7 @@ public class RequirementCollection
         // End of user code
         return constrains;
     }
-    
+
     // Start of user code getterAnnotation:uses
     // End of user code
     @OslcName("uses")
@@ -725,8 +725,8 @@ public class RequirementCollection
         // End of user code
         return uses;
     }
-    
-    
+
+
     // Start of user code setterAnnotation:title
     // End of user code
     public void setTitle(final String title )
@@ -734,11 +734,11 @@ public class RequirementCollection
         // Start of user code setterInit:title
         // End of user code
         this.title = title;
-    
+
         // Start of user code setterFinalize:title
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:description
     // End of user code
     public void setDescription(final String description )
@@ -746,11 +746,11 @@ public class RequirementCollection
         // Start of user code setterInit:description
         // End of user code
         this.description = description;
-    
+
         // Start of user code setterFinalize:description
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:identifier
     // End of user code
     public void setIdentifier(final String identifier )
@@ -758,11 +758,11 @@ public class RequirementCollection
         // Start of user code setterInit:identifier
         // End of user code
         this.identifier = identifier;
-    
+
         // Start of user code setterFinalize:identifier
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:shortTitle
     // End of user code
     public void setShortTitle(final String shortTitle )
@@ -770,11 +770,11 @@ public class RequirementCollection
         // Start of user code setterInit:shortTitle
         // End of user code
         this.shortTitle = shortTitle;
-    
+
         // Start of user code setterFinalize:shortTitle
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:subject
     // End of user code
     public void setSubject(final Set<String> subject )
@@ -786,11 +786,11 @@ public class RequirementCollection
         {
             this.subject.addAll(subject);
         }
-    
+
         // Start of user code setterFinalize:subject
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:creator
     // End of user code
     public void setCreator(final Set<Link> creator )
@@ -802,11 +802,11 @@ public class RequirementCollection
         {
             this.creator.addAll(creator);
         }
-    
+
         // Start of user code setterFinalize:creator
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:contributor
     // End of user code
     public void setContributor(final Set<Link> contributor )
@@ -818,11 +818,11 @@ public class RequirementCollection
         {
             this.contributor.addAll(contributor);
         }
-    
+
         // Start of user code setterFinalize:contributor
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:created
     // End of user code
     public void setCreated(final Date created )
@@ -830,11 +830,11 @@ public class RequirementCollection
         // Start of user code setterInit:created
         // End of user code
         this.created = created;
-    
+
         // Start of user code setterFinalize:created
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:modified
     // End of user code
     public void setModified(final Date modified )
@@ -842,11 +842,11 @@ public class RequirementCollection
         // Start of user code setterInit:modified
         // End of user code
         this.modified = modified;
-    
+
         // Start of user code setterFinalize:modified
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:serviceProvider
     // End of user code
     public void setServiceProvider(final Set<Link> serviceProvider )
@@ -858,11 +858,11 @@ public class RequirementCollection
         {
             this.serviceProvider.addAll(serviceProvider);
         }
-    
+
         // Start of user code setterFinalize:serviceProvider
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:instanceShape
     // End of user code
     public void setInstanceShape(final Set<Link> instanceShape )
@@ -874,11 +874,11 @@ public class RequirementCollection
         {
             this.instanceShape.addAll(instanceShape);
         }
-    
+
         // Start of user code setterFinalize:instanceShape
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:elaboratedBy
     // End of user code
     public void setElaboratedBy(final Set<Link> elaboratedBy )
@@ -890,11 +890,11 @@ public class RequirementCollection
         {
             this.elaboratedBy.addAll(elaboratedBy);
         }
-    
+
         // Start of user code setterFinalize:elaboratedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:elaborates
     // End of user code
     public void setElaborates(final Set<Link> elaborates )
@@ -906,11 +906,11 @@ public class RequirementCollection
         {
             this.elaborates.addAll(elaborates);
         }
-    
+
         // Start of user code setterFinalize:elaborates
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:specifiedBy
     // End of user code
     public void setSpecifiedBy(final Set<Link> specifiedBy )
@@ -922,11 +922,11 @@ public class RequirementCollection
         {
             this.specifiedBy.addAll(specifiedBy);
         }
-    
+
         // Start of user code setterFinalize:specifiedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:specifies
     // End of user code
     public void setSpecifies(final Set<Link> specifies )
@@ -938,11 +938,11 @@ public class RequirementCollection
         {
             this.specifies.addAll(specifies);
         }
-    
+
         // Start of user code setterFinalize:specifies
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:affectedBy
     // End of user code
     public void setAffectedBy(final Set<Link> affectedBy )
@@ -954,11 +954,11 @@ public class RequirementCollection
         {
             this.affectedBy.addAll(affectedBy);
         }
-    
+
         // Start of user code setterFinalize:affectedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:trackedBy
     // End of user code
     public void setTrackedBy(final Set<Link> trackedBy )
@@ -970,11 +970,11 @@ public class RequirementCollection
         {
             this.trackedBy.addAll(trackedBy);
         }
-    
+
         // Start of user code setterFinalize:trackedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:implementedBy
     // End of user code
     public void setImplementedBy(final Set<Link> implementedBy )
@@ -986,11 +986,11 @@ public class RequirementCollection
         {
             this.implementedBy.addAll(implementedBy);
         }
-    
+
         // Start of user code setterFinalize:implementedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:validatedBy
     // End of user code
     public void setValidatedBy(final Set<Link> validatedBy )
@@ -1002,11 +1002,11 @@ public class RequirementCollection
         {
             this.validatedBy.addAll(validatedBy);
         }
-    
+
         // Start of user code setterFinalize:validatedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:satisfiedBy
     // End of user code
     public void setSatisfiedBy(final Set<Link> satisfiedBy )
@@ -1018,11 +1018,11 @@ public class RequirementCollection
         {
             this.satisfiedBy.addAll(satisfiedBy);
         }
-    
+
         // Start of user code setterFinalize:satisfiedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:satisfies
     // End of user code
     public void setSatisfies(final Set<Link> satisfies )
@@ -1034,11 +1034,11 @@ public class RequirementCollection
         {
             this.satisfies.addAll(satisfies);
         }
-    
+
         // Start of user code setterFinalize:satisfies
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:decomposedBy
     // End of user code
     public void setDecomposedBy(final Set<Link> decomposedBy )
@@ -1050,11 +1050,11 @@ public class RequirementCollection
         {
             this.decomposedBy.addAll(decomposedBy);
         }
-    
+
         // Start of user code setterFinalize:decomposedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:decomposes
     // End of user code
     public void setDecomposes(final Set<Link> decomposes )
@@ -1066,11 +1066,11 @@ public class RequirementCollection
         {
             this.decomposes.addAll(decomposes);
         }
-    
+
         // Start of user code setterFinalize:decomposes
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:constrainedBy
     // End of user code
     public void setConstrainedBy(final Set<Link> constrainedBy )
@@ -1082,11 +1082,11 @@ public class RequirementCollection
         {
             this.constrainedBy.addAll(constrainedBy);
         }
-    
+
         // Start of user code setterFinalize:constrainedBy
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:constrains
     // End of user code
     public void setConstrains(final Set<Link> constrains )
@@ -1098,11 +1098,11 @@ public class RequirementCollection
         {
             this.constrains.addAll(constrains);
         }
-    
+
         // Start of user code setterFinalize:constrains
         // End of user code
     }
-    
+
     // Start of user code setterAnnotation:uses
     // End of user code
     public void setUses(final Set<Link> uses )
@@ -1114,10 +1114,10 @@ public class RequirementCollection
         {
             this.uses.addAll(uses);
         }
-    
+
         // Start of user code setterFinalize:uses
         // End of user code
     }
-    
-    
+
+
 }

--- a/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/consumer/AbstractConsumerStore.java
+++ b/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/consumer/AbstractConsumerStore.java
@@ -25,21 +25,21 @@ import net.oauth.OAuthMessage;
 
 /**
  * Manages the list of OAuth consumers.
- * 
+ *
  * @author Samuel Padgett
  */
 public abstract class AbstractConsumerStore implements ConsumerStore {
 	private Map<String, LyoOAuthConsumer> consumerMap = Collections
-			.synchronizedMap(new HashMap<String, LyoOAuthConsumer>());
-	
+			.synchronizedMap(new HashMap<>());
+
 	public AbstractConsumerStore() {}
-	
+
 	public void addAll(Collection<LyoOAuthConsumer> consumers) {
 		for (LyoOAuthConsumer consumer : consumers) {
 			consumerMap.put(consumer.consumerKey, consumer);
 		}
 	}
-	
+
 	public Collection<LyoOAuthConsumer> getAllConsumers() {
 		return consumerMap.values();
 	}
@@ -53,13 +53,13 @@ public abstract class AbstractConsumerStore implements ConsumerStore {
 	public LyoOAuthConsumer getConsumer(String consumerKey) {
 		return consumerMap.get(consumerKey);
 	}
-	
+
 	public abstract void closeConsumerStore();
-	
+
 	protected LyoOAuthConsumer add(LyoOAuthConsumer consumer) {
 		return consumerMap.put(consumer.consumerKey, consumer);
 	}
-	
+
 	protected LyoOAuthConsumer remove(String consumerKey) {
 		return consumerMap.remove(consumerKey);
 	}

--- a/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/SimpleTokenStrategy.java
+++ b/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/token/SimpleTokenStrategy.java
@@ -32,17 +32,17 @@ import net.oauth.OAuthProblemException;
  * tokens and stores them in memory. Tokens are only good for the life of the
  * process. Least recently used tokens are invalidated when cached limits are
  * reached.
- * 
+ *
  * @author Samuel Padgett
  */
 public class SimpleTokenStrategy implements TokenStrategy {
 	private final static int REQUEST_TOKEN_MAX_ENTIRES = 500;
 	private final static int ACCESS_TOKEN_MAX_ENTRIES = 5000;
-	
+
 	/**
 	 * Holds information associated with a request token such as the callback
 	 * URL and OAuth verification code.
-	 * 
+	 *
 	 * @author Samuel Padgett
 	 */
 	protected class RequestTokenData {
@@ -50,7 +50,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 		private boolean authorized;
 		private String callback;
 		private String verificationCode;
-		
+
 		public RequestTokenData(String consumerKey) {
 			this.consumerKey = consumerKey;
 			this.authorized = false;
@@ -62,40 +62,40 @@ public class SimpleTokenStrategy implements TokenStrategy {
 			this.authorized = false;
 			this.callback = callback;
 		}
-		
+
 		public String getConsumerKey() {
 			return consumerKey;
 		}
-		
+
 		public void setConsumerKey(String consumerKey) {
 			this.consumerKey = consumerKey;
 		}
-		
+
 		public boolean isAuthorized() {
 			return authorized;
 		}
-		
+
 		public void setAuthorized(boolean authorized) {
 			this.authorized = authorized;
 		}
-		
+
 		public String getCallback() {
 			return callback;
 		}
-		
+
 		public void setCallback(String callback) {
 			this.callback = callback;
 		}
-		
+
 		public String getVerificationCode() {
 			return verificationCode;
 		}
-		
+
 		public void setVerificationCode(String verificationCode) {
 			this.verificationCode = verificationCode;
 		}
 	}
-	
+
 	// key is request token string, value is RequestTokenData
 	private Map<String, RequestTokenData> requestTokens;
 
@@ -107,7 +107,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 
 	/**
 	 * Constructs a SimpleTokenStrategy using the defaults for cache limits on request and access tokens.
-	 * 
+	 *
 	 * @see SimpleTokenStrategy#SimpleTokenStrategy(int, int)
 	 */
 	public SimpleTokenStrategy() {
@@ -118,17 +118,17 @@ public class SimpleTokenStrategy implements TokenStrategy {
 	 * Constructs a SimpleTokenStrategy with cache limits on the number of
 	 * request and access tokens. Least recently used tokens are invalidated
 	 * when cache limits are reached.
-	 * 
+	 *
 	 * @param requestTokenMaxCount
 	 *            the maximum number of request tokens to track
 	 * @param accessTokenMaxCount
 	 *            the maximum number of access tokens to track
 	 */
 	public SimpleTokenStrategy(int requestTokenMaxCount, int accessTokenMaxCount) {
-		requestTokens = new LRUCache<String, RequestTokenData>(requestTokenMaxCount);
-		accessTokens = new LRUCache<String, String>(accessTokenMaxCount);
-		tokenSecrets = new LRUCache<String, String>(requestTokenMaxCount
-				+ accessTokenMaxCount);
+		requestTokens = new LRUCache<>(requestTokenMaxCount);
+		accessTokens = new LRUCache<>(accessTokenMaxCount);
+		tokenSecrets = new LRUCache<>(requestTokenMaxCount
+            + accessTokenMaxCount);
 	}
 
 	@Override
@@ -177,7 +177,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 			String requestToken) throws OAuthProblemException {
 		String verificationCode = generateTokenString();
 		getRequestTokenData(requestToken).setVerificationCode(verificationCode);
-		
+
 		return verificationCode;
 	}
 
@@ -258,10 +258,10 @@ public class SimpleTokenStrategy implements TokenStrategy {
 			return tokenSecret;
 		}
 	}
-	
+
 	/**
 	 * Creates a unique, random string to use for tokens.
-	 * 
+	 *
 	 * @return the random string
 	 */
 	protected String generateTokenString() {
@@ -270,7 +270,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 
 	/**
 	 * Gets the request token data from this OAuth request.
-	 * 
+	 *
 	 * @param oAuthRequest
 	 *            the OAuth request
 	 * @return the request token data
@@ -286,7 +286,7 @@ public class SimpleTokenStrategy implements TokenStrategy {
 
 	/**
 	 * Gets the request token data for this request token.
-	 * 
+	 *
 	 * @param requestToken
 	 *            the request token string
 	 * @return the request token data

--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/Preview.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/Preview.java
@@ -31,7 +31,7 @@ public class Preview {
      *
      */
     @JsonProperty("properties")
-    private List<Property> properties = new ArrayList<Property>();
+    private List<Property> properties = new ArrayList<>();
 
     /**
      *

--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PreviewFactory.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PreviewFactory.java
@@ -38,16 +38,16 @@ public class PreviewFactory {
     public static Preview getPreview(final AbstractResource aResource, List<String> getterMethodNames,
                                      boolean showPropertyHeadingsAsLinks) throws IllegalAccessException,
         IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
-        ArrayList<Property> previewItems = new ArrayList<Property>();
+        ArrayList<Property> previewItems = new ArrayList<>();
         Method getterMethod;
         for (String getterMethodName : getterMethodNames) {
             getterMethod = aResource.getClass().getMethod(getterMethodName);
             boolean multiple = getterMethod.getAnnotation(OslcOccurs.class).value().equals(Occurs.ZeroOrMany) ||
                 getterMethod.getAnnotation(OslcOccurs.class).value().equals(Occurs.OneOrMany);
-            final boolean isResourceValueType = (null != getterMethod.getAnnotation(OslcValueType.class)) 
+            final boolean isResourceValueType = (null != getterMethod.getAnnotation(OslcValueType.class))
                     && (getterMethod.getAnnotation(OslcValueType.class).value().equals(ValueType.Resource));
-            final boolean isNotInlinedRepresentation = (null == getterMethod.getAnnotation(OslcRepresentation.class)) 
-                    || ((null != getterMethod.getAnnotation(OslcRepresentation.class)) 
+            final boolean isNotInlinedRepresentation = (null == getterMethod.getAnnotation(OslcRepresentation.class))
+                    || ((null != getterMethod.getAnnotation(OslcRepresentation.class))
                             && (!getterMethod.getAnnotation(OslcRepresentation.class).value().equals(Representation.Inline)));
             boolean showPropertyValueAsLink = isResourceValueType && isNotInlinedRepresentation;
             PropertyDefintion key;

--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PropertyDefintion.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PropertyDefintion.java
@@ -128,7 +128,7 @@ public class PropertyDefintion {
         TEXT("Text"),
         LINK("Link");
         private final String value;
-        private final static Map<String, PropertyDefintion.RepresentationType> CONSTANTS = new HashMap<String, PropertyDefintion.RepresentationType>();
+        private final static Map<String, PropertyDefintion.RepresentationType> CONSTANTS = new HashMap<>();
 
         static {
             for (PropertyDefintion.RepresentationType c: values()) {

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/StorePool.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/StorePool.java
@@ -32,7 +32,7 @@ public class StorePool {
 
     public StorePool (int poolSize, URI defaultNamedGraphUri, URI sparqlQueryEndpoint, URI sparqlUpdateEndpoint, String userName, String password) {
         this.defaultNamedGraphUri = defaultNamedGraphUri;
-        this.storePool = new ArrayBlockingQueue<Store>(poolSize);
+        this.storePool = new ArrayBlockingQueue<>(poolSize);
         for (int i = 0; i < poolSize; i++) {
             Store s = null;
             if( userName != null && password != null ){
@@ -57,7 +57,7 @@ public class StorePool {
             return null;
         }
     }
-     
+
     public void releaseStore(Store store) {
         try {
             storePool.put(store);

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
@@ -526,7 +526,7 @@ public class SparqlStoreImpl implements Store {
         SelectBuilder distinctResourcesQuery = new SelectBuilder();
 
         //Setup prefixes
-        Map<String, String> prefixesMap = new HashMap<String, String>();
+        Map<String, String> prefixesMap = new HashMap<>();
         try {
             if (!StringUtils.isEmpty(prefixes)) {
                 prefixesMap = QueryUtils.parsePrefixes(prefixes);

--- a/store/store-core/src/test/java/org/eclipse/lyo/store/resources/Requirement.java
+++ b/store/store-core/src/test/java/org/eclipse/lyo/store/resources/Requirement.java
@@ -31,7 +31,7 @@ public class Requirement
     private String description;
     private String identifier;
     private Date created;
-    private HashSet<Link> decomposes = new HashSet<Link>();
+    private HashSet<Link> decomposes = new HashSet<>();
     private String stringProperty;
     private Integer intProperty;
 
@@ -40,13 +40,13 @@ public class Requirement
     {
         super();
     }
-    
+
     public Requirement(final URI about)
            throws URISyntaxException
     {
         super(about);
     }
-    
+
     @OslcName("title")
     @OslcPropertyDefinition(DUBLIN_CORE_NAMSPACE + "title")
     @OslcDescription("Title of the resource represented as rich text in XHTML content. SHOULD include only content that is valid inside an XHTML <span> element.")
@@ -57,7 +57,7 @@ public class Requirement
     {
         return title;
     }
-    
+
     @OslcName("description")
     @OslcPropertyDefinition(DUBLIN_CORE_NAMSPACE + "description")
     @OslcDescription("Descriptive text about resource represented as rich text in XHTML content. SHOULD include only content that is valid and suitable inside an XHTML <div> element.")
@@ -90,7 +90,7 @@ public class Requirement
     {
         return created;
     }
-    
+
     @OslcName("decomposes")
     @OslcPropertyDefinition(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_NAMSPACE + "decomposes")
     @OslcDescription("The object is decomposed by the subject.")
@@ -101,7 +101,7 @@ public class Requirement
     {
         return decomposes;
     }
-    
+
     @OslcName("stringProperty")
     @OslcPropertyDefinition(Nsp1DomainConstants.TESTDOMAIN_NAMSPACE + "stringProperty")
     @OslcOccurs(Occurs.ExactlyOne)
@@ -111,7 +111,7 @@ public class Requirement
     {
         return stringProperty;
     }
-    
+
     @OslcName("intProperty")
     @OslcPropertyDefinition(Nsp1DomainConstants.TESTDOMAIN_NAMSPACE + "intProperty")
     @OslcOccurs(Occurs.ExactlyOne)
@@ -125,25 +125,25 @@ public class Requirement
     public void setTitle(final String title )
     {
         this.title = title;
-   
+
     }
-    
+
     public void setDescription(final String description )
     {
         this.description = description;
     }
-    
+
     public void setIdentifier(final String identifier )
     {
         this.identifier = identifier;
     }
 
-    
+
     public void setCreated(final Date created )
     {
         this.created = created;
     }
-    
+
     public void setDecomposes(final HashSet<Link> decomposes )
     {
         this.decomposes.clear();
@@ -152,15 +152,15 @@ public class Requirement
             this.decomposes.addAll(decomposes);
         }
     }
-    
+
     public void setStringProperty(final String stringProperty )
     {
         this.stringProperty = stringProperty;
     }
-    
+
     public void setIntProperty(final Integer intProperty )
     {
         this.intProperty = intProperty;
     }
-    
+
 }

--- a/trs/server/src/main/java/org/eclipse/lyo/oslc4j/trs/server/PagedTrsFactory.java
+++ b/trs/server/src/main/java/org/eclipse/lyo/oslc4j/trs/server/PagedTrsFactory.java
@@ -14,25 +14,25 @@ public class PagedTrsFactory {
             final String baseRelativePath, final String changeLogRelativePath, final Collection<URI> baseResourceUris) {
 		InmemPagedTrs pagedTrs = new InmemPagedTrs(basePageLimit, changelogPageLimit, uriBase, baseRelativePath, changeLogRelativePath, baseResourceUris);
         return pagedTrs;
-		
+
 	}
 
 	public InmemPagedTrs getInmemPagedTrs (final int basePageLimit, final int changelogPageLimit, final Collection<URI> baseResourceUris) {
 		return getInmemPagedTrs(basePageLimit, changelogPageLimit,
-            UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path(TrackedResourceSetService.RESOURCE_PATH).build(), 
+            UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path(TrackedResourceSetService.RESOURCE_PATH).build(),
             TrackedResourceSetService.BASE_PATH, TrackedResourceSetService.CHANGELOG_PATH, baseResourceUris);
 	}
 
 	public InmemPagedTrs getInmemPagedTrs (final int basePageLimit, final int changelogPageLimit) {
 		return getInmemPagedTrs(basePageLimit, changelogPageLimit,
-            UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path(TrackedResourceSetService.RESOURCE_PATH).build(), 
-            TrackedResourceSetService.BASE_PATH, TrackedResourceSetService.CHANGELOG_PATH, new ArrayList<URI>());
+            UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path(TrackedResourceSetService.RESOURCE_PATH).build(),
+            TrackedResourceSetService.BASE_PATH, TrackedResourceSetService.CHANGELOG_PATH, new ArrayList<>());
 	}
 
 	public InmemPagedTrs getInmemPagedTrs () {
 		return getInmemPagedTrs(50, 50,
-            UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path(TrackedResourceSetService.RESOURCE_PATH).build(), 
-            TrackedResourceSetService.BASE_PATH, TrackedResourceSetService.CHANGELOG_PATH, new ArrayList<URI>());
+            UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path(TrackedResourceSetService.RESOURCE_PATH).build(),
+            TrackedResourceSetService.BASE_PATH, TrackedResourceSetService.CHANGELOG_PATH, new ArrayList<>());
 	}
 
 }

--- a/trs/server/src/main/java/org/eclipse/lyo/oslc4j/trs/server/TRSUtil.java
+++ b/trs/server/src/main/java/org/eclipse/lyo/oslc4j/trs/server/TRSUtil.java
@@ -77,7 +77,7 @@ public class TRSUtil {
      */
     public static List<Resource> getResourcesWithTypeFromModel(Model model,
             String fullQualifiedRDFTypeName) {
-        List<Resource> resources = new ArrayList<Resource>();
+        List<Resource> resources = new ArrayList<>();
         ResIterator listSubjects = null;
         listSubjects = model.listSubjectsWithProperty(
                 RDF.type,
@@ -103,7 +103,7 @@ public class TRSUtil {
             throws IllegalAccessException, IllegalArgumentException, InstantiationException,
             InvocationTargetException, SecurityException, NoSuchMethodException,
             DatatypeConfigurationException, OslcCoreApplicationException, URISyntaxException {
-        List<ChangeEvent> changeEvents = new ArrayList<ChangeEvent>();
+        List<ChangeEvent> changeEvents = new ArrayList<>();
         List<Resource> modificationResources = getResourcesWithTypeFromModel(changeLogJenaModel,
                                                                              TRSConstants
                                                                                      .TRS_TYPE_MODIFICATION);

--- a/validation/src/test/java/org/eclipse/lyo/validation/AResource.java
+++ b/validation/src/test/java/org/eclipse/lyo/validation/AResource.java
@@ -78,7 +78,7 @@ public class AResource extends AbstractResource {
     private BigInteger integerProperty2;
     private BigInteger anotherIntegerProperty;
     private String aStringProperty;
-    private HashSet<Date> aSetOfDates = new HashSet<Date>();
+    private HashSet<Date> aSetOfDates = new HashSet<>();
     private Link aReferenceProperty = new Link();
     private BigInteger integerProperty3;
     private String anotherStringProperty;

--- a/validation/src/test/java/org/eclipse/lyo/validation/AnOslcResource.java
+++ b/validation/src/test/java/org/eclipse/lyo/validation/AnOslcResource.java
@@ -62,7 +62,7 @@ public class AnOslcResource extends AbstractResource {
     private BigInteger integerProperty2;
     private BigInteger anotherIntegerProperty;
     private String aStringProperty;
-    private HashSet<Date> aSetOfDates = new HashSet<Date>();
+    private HashSet<Date> aSetOfDates = new HashSet<>();
     private Link aReferenceProperty = new Link();
     private BigInteger integerProperty3;
 


### PR DESCRIPTION
## Description

Cleanup 

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API
