### PR TITLE
fix: avoid exception in mostConcreteResourceType()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 
 ### Fixed
 
-- A regression is fixed where `org.eclipse.lyo.oslc4j.provider.jena.OslcRdfXmlProvider` could try to unmarshal an Array or a Collection, which would interfere with the application of the suitable providers when the RDF input is correct. 
+- A regression is fixed where `org.eclipse.lyo.oslc4j.provider.jena.OslcRdfXmlProvider` could try to unmarshal an Array or a Collection, which would interfere with the application of the suitable providers when the RDF input is correct.
+- [PR 260](https://github.com/eclipse/lyo/pull/260) fixed the [bug](https://github.com/eclipse/lyo/pull/259) in `ResourcePackages.getMostConcreteClassOf` that could trigger the error "Multiple classes, not in the same inheritance tree, are annotated to map the same RDF:type".
 
 ## [5.0.0]
 

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackages.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackages.java
@@ -110,10 +110,18 @@ public class ResourcePackages {
         do {
             Class<?> pivot = candidates.get(index);
             Iterator<Class<?>> iterator = candidates.iterator();
+            int currentIndex = -1;
             while(iterator.hasNext()) {
                 Class<?> current = iterator.next();
+                currentIndex++;
                 if (!current.equals(pivot) && current.isAssignableFrom(pivot)) {
                     iterator.remove();
+                    if (currentIndex < index) {
+                        //if we are removing an item located before the pivot (index position),
+                        //then decrement the index, since the size of the array is also reduced, making sure the pivot index is correct 
+                        //in relation to the new size.
+                        index--;
+                    }
                 }
             }
             size = candidates.size();

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackages.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackages.java
@@ -101,11 +101,25 @@ public class ResourcePackages {
      * belonging to different inheritance trees.
      */
     private static Class<?> getMostConcreteClassOf(List<Class<?>> candidates) {
-        int size;
+        int size = candidates.size();
         int index = 0;
         do {
             Class<?> pivot = candidates.get(index);
-            candidates.removeIf(current -> !current.equals(pivot) && current.isAssignableFrom(pivot));
+            Iterator<Class<?>> iterator = candidates.iterator();
+            int currentIndex = -1;
+            while(iterator.hasNext()) {
+                Class<?> current = iterator.next();
+                currentIndex++;
+                if (!current.equals(pivot) && current.isAssignableFrom(pivot)) {
+                    iterator.remove();
+                    if (currentIndex < index) {
+                        //if we are removing an item located before the pivot (index position),
+                        //then decrement the index, since the size of the array is also reduced, making sure the pivot index is correct
+                        //in relation to the new size.
+                        index--;
+                    }
+                }
+            }
             size = candidates.size();
         } while(++index < size);
         if (candidates.size() > 1) {

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackagesTests.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackagesTests.java
@@ -8,6 +8,7 @@ import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.RDF;
 import org.eclipse.lyo.oslc4j.provider.jena.resources.Cat;
 import org.eclipse.lyo.oslc4j.provider.jena.resources.Pet;
+import org.eclipse.lyo.oslc4j.provider.jena.resources.WildDog;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -83,6 +84,28 @@ public class ResourcePackagesTests {
         Optional<Class<?>> mappedClass = ResourcePackages.getClassOf(resource);
         Assert.assertEquals(true, mappedClass.isPresent());
         Assert.assertEquals(Cat.class, mappedClass.get());
+    }
+
+    @Test
+    public void testGetClassOf_mostConcreteResourceType_decreasingSpecialisation() {
+        ResourcePackages.mapPackage(Pet.class.getPackage());
+        resource.addProperty(RDF.type, ResourceFactory.createResource("http://locahost:7001/vocabulary/WildDog"));
+        resource.addProperty(RDF.type, ResourceFactory.createResource("http://locahost:7001/vocabulary/Dog"));
+        resource.addProperty(RDF.type, ResourceFactory.createResource("http://locahost:7001/vocabulary/Animal"));
+        Optional<Class<?>> mappedClass = ResourcePackages.getClassOf(resource);
+        Assert.assertEquals(true, mappedClass.isPresent());
+        Assert.assertEquals(WildDog.class, mappedClass.get());
+    }
+
+    @Test
+    public void testGetClassOf_mostConcreteResourceType_increasingSpecialisation() {
+        ResourcePackages.mapPackage(Pet.class.getPackage());
+        resource.addProperty(RDF.type, ResourceFactory.createResource("http://locahost:7001/vocabulary/Animal"));
+        resource.addProperty(RDF.type, ResourceFactory.createResource("http://locahost:7001/vocabulary/Dog"));
+        resource.addProperty(RDF.type, ResourceFactory.createResource("http://locahost:7001/vocabulary/WildDog"));
+        Optional<Class<?>> mappedClass = ResourcePackages.getClassOf(resource);
+        Assert.assertEquals(true, mappedClass.isPresent());
+        Assert.assertEquals(WildDog.class, mappedClass.get());
     }
 
 }

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackagesTests.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackagesTests.java
@@ -45,7 +45,7 @@ public class ResourcePackagesTests {
         }
 
         Assert.assertEquals(1, ResourcePackages.SCANNED_PACKAGES.size());
-        Assert.assertEquals(6, ResourcePackages.TYPES_MAPPINGS.keySet().size());
+        Assert.assertEquals(7, ResourcePackages.TYPES_MAPPINGS.keySet().size());
     }
 
     @Test

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/resources/WildDog.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/resources/WildDog.java
@@ -1,0 +1,19 @@
+package org.eclipse.lyo.oslc4j.provider.jena.resources;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+
+/**
+ * A dog pet
+ * @author rherrera
+ */
+@OslcNamespace("http://locahost:7001/vocabulary/")
+@OslcResourceShape(title = "AbstractTypesTest")
+public class WildDog extends Dog {
+
+    @Override
+    public void eat() {
+        System.out.println("Eating like a wild dog");
+    }
+    
+}


### PR DESCRIPTION
## Description

The method getMostConcreteClassOf() in org.eclipse.lyo.oslc4j.provider.jena.ordfm.ResourcePackages incorrectly triggers an exception when trying to select the most concrete class, if the classes are listed in a certain order.

This test illustrates when it fails; namely when the candidate classes are listed in increasing specialisation.

See https://github.com/eclipse/lyo/issues/259 for details

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [ ] This PR does NOT break the API

## Issues

Closes #259
