### PR TITLE
Replace Jackson dependencies with a BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <v.jena>4.5.0-SNAPSHOT</v.jena>
     <v.slf4j>1.7.36</v.slf4j>
-    <v.jackson>2.13.1</v.jackson>
+    <v.jackson>2.13.2.20220328</v.jackson>
 
     <v.httpclient>4.5.13</v.httpclient>
     <v.guava>30.1.1-jre</v.guava>
@@ -307,15 +307,12 @@
       </dependency>
 
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${v.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${v.jackson}</version>
-       </dependency>
 
        <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
## Description

Address CVE-2020-36518

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #264