### PR TITLE
Add JDK 11, Jena, and Guava Javadoc links (+switch to source v11)

### DIFF
--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/OslcOAuthClient.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/OslcOAuthClient.java
@@ -47,11 +47,6 @@ public class OslcOAuthClient implements IOslcClient {
 
     /**
      * Initialize an OAuthClient with the required OAuth URLs
-     * @param requestTokenURL
-     * @param authorizationTokenURL
-     * @param accessTokenURL
-     * @param consumerKey
-     * @param consumerSecret
      */
     public OslcOAuthClient(
             OAuthAccessor accessor,

--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/query/OslcQueryResult.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/query/OslcQueryResult.java
@@ -159,7 +159,6 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 
 	/**
 	 * @return the next page of results
-	 * @throws NoSuchElementException if there is no next page
 	 */
 	public OslcQueryResult next() {
 		return new OslcQueryResult(this);

--- a/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/QueryUtils.java
+++ b/core/oslc-query/src/main/java/org/eclipse/lyo/core/query/QueryUtils.java
@@ -1,5 +1,6 @@
+package org.eclipse.lyo.core.query;
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,7 +12,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-package org.eclipse.lyo.core.query;
 
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
@@ -34,7 +34,7 @@ import org.eclipse.lyo.oslc4j.core.SingletonWildcardProperties;
 
 /**
  * Utility methods for parsing various OSLC HTTP query
- * parameter clauses; e.g. oslc.where
+ * parameter clauses; e.g. {@code oslc.where}
  */
 public class QueryUtils
 {
@@ -74,9 +74,9 @@ public class QueryUtils
 
 			CommonTree rawTree = parser.oslc_prefixes().getTree();
 
-			checkErrors(parser.getErrors());;
+			checkErrors(parser.getErrors());
 
-			PrefixMap prefixMap =
+            PrefixMap prefixMap =
 				new PrefixMap(rawTree.getChildCount());
 
 			for (int index = 0; index < rawTree.getChildCount(); index++) {
@@ -127,9 +127,9 @@ public class QueryUtils
 			OslcWhereParser.oslc_where_return resultTree =
 				parser.oslc_where();
 
-			checkErrors(parser.getErrors());;
+			checkErrors(parser.getErrors());
 
-			CommonTree rawTree = (CommonTree)resultTree.getTree();
+            CommonTree rawTree = resultTree.getTree();
 			Tree child = rawTree.getChild(0);
 
 			if (child.getType() == Token.INVALID_TOKEN_TYPE) {
@@ -172,9 +172,9 @@ public class QueryUtils
 			OslcSelectParser.oslc_select_return resultTree =
 				parser.oslc_select();
 
-			checkErrors(parser.getErrors());;
+			checkErrors(parser.getErrors());
 
-			CommonTree rawTree = (CommonTree)resultTree.getTree();
+            CommonTree rawTree = resultTree.getTree();
 
 			if (rawTree.getType() == Token.INVALID_TOKEN_TYPE) {
 				throw ((CommonErrorNode)rawTree).trappedException;
@@ -184,7 +184,7 @@ public class QueryUtils
 				Proxy.newProxyInstance(SelectClause.class.getClassLoader(),
 						new Class<?>[] { SelectClause.class, Properties.class },
 						new PropertiesInvocationHandler(
-								(CommonTree)resultTree.getTree(),
+                            resultTree.getTree(),
 								prefixMap));
 
 		} catch (RecognitionException e) {
@@ -217,9 +217,9 @@ public class QueryUtils
 			OslcSelectParser.oslc_select_return resultTree =
 				parser.oslc_select();
 
-			checkErrors(parser.getErrors());;
+			checkErrors(parser.getErrors());
 
-			CommonTree rawTree = (CommonTree)resultTree.getTree();
+            CommonTree rawTree = resultTree.getTree();
 
 			if (rawTree.getType() == Token.INVALID_TOKEN_TYPE) {
 				throw ((CommonErrorNode)rawTree).trappedException;
@@ -229,7 +229,7 @@ public class QueryUtils
 				Proxy.newProxyInstance(PropertiesClause.class.getClassLoader(),
 						new Class<?>[] { PropertiesClause.class, Properties.class },
 						new PropertiesInvocationHandler(
-								(CommonTree)resultTree.getTree(),
+                            resultTree.getTree(),
 								prefixMap));
 
 		} catch (RecognitionException e) {
@@ -262,9 +262,9 @@ public class QueryUtils
 			OslcOrderByParser.oslc_order_by_return resultTree =
 				parser.oslc_order_by();
 
-			checkErrors(parser.getErrors());;
+			checkErrors(parser.getErrors());
 
-			CommonTree rawTree = (CommonTree)resultTree.getTree();
+            CommonTree rawTree = resultTree.getTree();
 			Tree child = rawTree.getChild(0);
 
 			if (child.getType() == Token.INVALID_TOKEN_TYPE) {
@@ -283,7 +283,7 @@ public class QueryUtils
 
 	/**
 	 * Create a map representation of the {@link Properties} returned
-	 * from parsing oslc.properties or olsc.select URL query
+	 * from parsing {@code oslc.properties} or {@code oslc.select} URL query
 	 * parameters suitable for generating a property result from an
 	 * HTTP GET request.<p>
 	 *
@@ -312,7 +312,7 @@ public class QueryUtils
 
 		for (Property property : children) {
 
-			PName pname = null;
+			PName pname;
 			String propertyName = null;
 
 			if (! property.isWildcard()) {
@@ -403,12 +403,12 @@ public class QueryUtils
 	}
 
 	/**
-	 * Parse a oslc.searchTerms expression
+	 * Parse an {@code oslc.searchTerms} expression
 	 *
 	 * <p><b>Note</b>: {@link Object#toString()} of result has been overridden to
 	 * return input expression.
 	 *
-	 * @param searchTermsExpression contents of an oslc.searchTerms HTTP query
+	 * @param searchTermsExpression contents of an {@code oslc.searchTerms} HTTP query
 	 * parameter
 	 *
 	 * @return the parsed search terms clause
@@ -427,9 +427,9 @@ public class QueryUtils
 			OslcSearchTermsParser.oslc_search_terms_return resultTree =
 				parser.oslc_search_terms();
 
-			checkErrors(parser.getErrors());;
+			checkErrors(parser.getErrors());
 
-			CommonTree rawTree = (CommonTree)resultTree.getTree();
+            CommonTree rawTree = resultTree.getTree();
 			Tree child = rawTree.getChild(0);
 
 			if (child.getType() == Token.INVALID_TOKEN_TYPE) {
@@ -469,7 +469,7 @@ public class QueryUtils
 		public String
 		toString()
 		{
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			boolean first = true;
 
 			for (String string : this) {
@@ -492,7 +492,7 @@ public class QueryUtils
 	}
 
 	/**
-	 * Implementation of a Map<String, String> prefixMap
+	 * Implementation of a {@code Map<String, String> prefixMap}
 	 */
 	private static class PrefixMap extends HashMap<String, String>
 	{
@@ -505,7 +505,7 @@ public class QueryUtils
 		public String
 		toString()
 		{
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			Iterator<String> keys = this.keySet().iterator();
 			boolean first = true;
 
@@ -602,8 +602,8 @@ public class QueryUtils
 	}
 
 	/**
-	 * Merge into {@link #lhs} properties those of {@link #rhs} property
-	 * map, merging any common, nested property maps
+	 * Merge into {@code lhs} properties those of {@code rhs} property
+	 * map, merging any common, nested property maps.
 	 *
 	 * @param lhs target of property map merge
 	 * @param rhs source of property map merge
@@ -614,37 +614,35 @@ public class QueryUtils
 		Map<String, Object> rhs
 	)
 	{
-		Iterator<String> propertyNames = rhs.keySet().iterator();
 
-		while (propertyNames.hasNext()) {
+        for (String propertyName : rhs.keySet()) {
 
-			String propertyName = propertyNames.next();
-			@SuppressWarnings("unchecked")
-			Map<String, Object> lhsNestedProperties =
-				(Map<String, Object>)lhs.get(propertyName);
-			@SuppressWarnings("unchecked")
-			Map<String, Object> rhsNestedProperties =
-				(Map<String, Object>)rhs.get(propertyName);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> lhsNestedProperties =
+                (Map<String, Object>) lhs.get(propertyName);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> rhsNestedProperties =
+                (Map<String, Object>) rhs.get(propertyName);
 
-			if (lhsNestedProperties == rhsNestedProperties) {
-				continue;
-			}
+            if (lhsNestedProperties == rhsNestedProperties) {
+                continue;
+            }
 
-			if (lhsNestedProperties == null ||
-				lhsNestedProperties == OSLC4JConstants.OSL4J_PROPERTY_SINGLETON) {
+            if (lhsNestedProperties == null ||
+                lhsNestedProperties == OSLC4JConstants.OSL4J_PROPERTY_SINGLETON) {
 
-				lhs.put(propertyName, rhsNestedProperties);
+                lhs.put(propertyName, rhsNestedProperties);
 
-				continue;
-			}
+                continue;
+            }
 
-			mergePropertyMaps(lhsNestedProperties, rhsNestedProperties);
-		}
+            mergePropertyMaps(lhsNestedProperties, rhsNestedProperties);
+        }
 	}
 
 	/**
 	 * Check list of errors from parsing some expression, generating
-	 * @{link {@link ParseException} if there are any.
+	 * {@link ParseException} if there are any.
 	 *
 	 * @param errors list of errors, hopefully empty
 	 *
@@ -657,7 +655,7 @@ public class QueryUtils
 			return;
 		}
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		boolean first = true;
 
 		for (String error : errors) {

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -365,7 +365,7 @@ public class OSLC4JUtils {
 	}
 
 	/**
-	 * Return if the query result list type will be http://www.w3.org/2000/01/rdf-schema#Container
+	 * Return if the query result list type will be <a href="http://www.w3.org/2000/01/rdf-schema#Container">http://www.w3.org/2000/01/rdf-schema#Container</a>
 	 * or there will be no type. Default is no type.
 	 */
 	public static boolean isQueryResultListAsContainer() {
@@ -537,7 +537,7 @@ public class OSLC4JUtils {
 	 */
 	private static Boolean parseBooleanPropertyOrDefault(final String key,
 			final boolean defaultValue) {
-		Boolean value = null;
+		Boolean value;
 		final String property = System.getProperty(key);
 		if (Strings.isNullOrEmpty(property)) {
 			value = defaultValue;
@@ -683,62 +683,52 @@ public class OSLC4JUtils {
 	 * @param property
 	 *			  Property information
 	 * @return Java object related to the Resource Shape type.
-	 * @throws DatatypeConfigurationException
-	 *			   , IllegalArgumentException, InstantiationException,
-	 *			   InvocationTargetException
-	 *
+     *
 	 */
-	public static RDFDatatype getDataTypeBasedOnResourceShapeType(final HashSet<String>
-			rdfTypesList,
-			final Property property )
-	{
-		if (null != rdfTypesList && !rdfTypesList.isEmpty() && null != property )
-		{
-			try {
-				// get the pre-defined list of ResourceShapes
-				List<ResourceShape> shapes = OSLC4JUtils.getShapes();
+    public static RDFDatatype getDataTypeBasedOnResourceShapeType(final HashSet<String> rdfTypesList,
+                                                                  final Property property) {
+        if (null != rdfTypesList && !rdfTypesList.isEmpty() && null != property) {
+            try {
+                // get the pre-defined list of ResourceShapes
+                List<ResourceShape> shapes = OSLC4JUtils.getShapes();
 
-				if (null != shapes && !shapes.isEmpty()) {
+                if (null != shapes && !shapes.isEmpty()) {
+                    // try to find the attribute type in the list of
+                    // resource shapes
+                    String propertyName = property.getURI();
 
-					// try to find the attribute type in the list of
-					// resource shapes
-					String propertyName = property.getURI();
+                    TypeMapper typeMapper = TypeMapper.getInstance();
 
-					TypeMapper typeMapper = TypeMapper.getInstance();
+                    for (ResourceShape shape : shapes) {
+                        // ensure that the current resource shape matches the resource rdf:type
+                        if (doesResourceShapeMatchRdfTypes(shape, rdfTypesList)) {
+                            org.eclipse.lyo.oslc4j.core.model.Property[] props = shape.getProperties();
 
-					for (ResourceShape shape : shapes) {
+                            for (org.eclipse.lyo.oslc4j.core.model.Property prop : props) {
+                                URI propDefinition = prop.getPropertyDefinition();
 
-						// ensure that the current resource shape matches the resource rdf:type
-						if (doesResourceShapeMatchRdfTypes(shape, rdfTypesList)) {
+                                if (propertyName.equals(propDefinition.toString())) {
+                                    URI propValueType = prop.getValueType();
 
-							org.eclipse.lyo.oslc4j.core.model.Property[] props = shape
-									.getProperties();
+                                    if (null == propValueType) {
+                                        continue;
+                                    }
+                                    return typeMapper.getTypeByName(propValueType.toString());
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                // if there is any error, return null
+                // TODO Andrew@2017-07-18: Throw an exception instead of throwing null
+                log.warn("Could not find Data Type <{}> based on shape", property, e);
+                return null;
+            }
+        }
+        return null;
+    }
 
-							for (org.eclipse.lyo.oslc4j.core.model.Property prop : props) {
-								URI propDefinition = prop.getPropertyDefinition();
-
-								if (propertyName.equals(propDefinition.toString())) {
-									URI propValueType = prop.getValueType();
-
-									if (null == propValueType) {
-										continue;
-									}
-									return typeMapper.getTypeByName(propValueType.toString());
-								}
-							}
-						}
-					}
-				}
-			} catch (Exception e) {
-				// if there is any error, return null
-				// TODO Andrew@2017-07-18: Throw an exception instead of throwing null
-				log.warn("Could not find Data Type <{}> based on shape", property, e);
-				return null;
-			}
-		}
-		return null;
-	}
-	
 	 /**
      * @see OSLC4JConstants#LYO_STORE_PAGING_UNSAFE
      * @return the boolean value of org.eclipse.lyo.oslc4j.unsafePaging

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Link.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Link.java
@@ -22,8 +22,7 @@ import java.util.Objects;
 /**
  * Special OSLC link type. Differs from {@link URI} since it can hold a label,
  * expressed in RDF using reification.
- * @see <a href="http://open-services.net/bin/view/Main/OslcCoreSpecAppendixLinks">OSLC Core
- * Specification 2.0, Appendix C: Guidance on Links & Relationships</a>
+ * @see <a href="http://open-services.net/bin/view/Main/OslcCoreSpecAppendixLinks">OSLC Core Specification 2.0, Appendix C: Guidance on Links &amp; Relationships</a>
  */
 public class Link extends AbstractReifiedResource<URI> {
     private String label;

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaModelHelper.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaModelHelper.java
@@ -333,8 +333,8 @@ public final class JenaModelHelper
     }
 
     /**
-     * @see #unmarshal(Resource, Class)
-     * @see #unmarshalSingle(Model, Class)
+     * @deprecated Use {@link #unmarshal(Resource, Class)} or {@link #unmarshalSingle(Model, Class)}
+     *          instead.
      */
     @Deprecated
     public static Object fromJenaResource(final Resource resource, Class<?> beanClass)
@@ -387,7 +387,7 @@ public final class JenaModelHelper
     }
 
     /**
-     * @see #unmarshal(Model, Class)
+     * @deprecated Use {@link #unmarshal(Model, Class)} instead.
      */
     @Deprecated
     public static Object[] fromJenaModel(final Model model, final Class<?> beanClass)

--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.10.1</version>
           <configuration>
-            <compilerArgument>-Xlint:deprecation,unchecked</compilerArgument>
+            <compilerArgument>-Xlint:fallthrough,unchecked,removal,deprecation,dep-ann,varargs,overloads,serial,try,finally</compilerArgument>
           </configuration>
         </plugin>
         <plugin>
@@ -430,8 +430,13 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.3.2</version>
           <configuration>
-            <source>8</source>
             <doclint>none</doclint>
+            <links>
+              <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
+              <link>https://jena.apache.org/documentation/javadoc/jena/</link>
+              <link>https://jena.apache.org/documentation/javadoc/arq/</link>
+              <link>https://guava.dev/releases/${v.guava}/api/docs/</link>
+            </links>
           </configuration>
           <executions>
             <execution>
@@ -575,6 +580,10 @@
         <configuration>
           <generateBackupPoms>false</generateBackupPoms>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,8 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.3.2</version>
           <configuration>
-            <doclint>none</doclint>
+<!--            <doclint>none</doclint>-->
+            <doclint>all,-accessibility,-html,-missing</doclint>
             <links>
               <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
               <link>https://jena.apache.org/documentation/javadoc/jena/</link>

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
             <doclint>all,-accessibility,-html,-missing</doclint>
             <links>
               <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
+              <link>https://docs.oracle.com/javaee/7/api/</link>
               <link>https://jena.apache.org/documentation/javadoc/jena/</link>
               <link>https://jena.apache.org/documentation/javadoc/arq/</link>
               <link>https://guava.dev/releases/${v.guava}/api/docs/</link>

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/Store.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/Store.java
@@ -103,7 +103,7 @@ public interface Store {
     boolean resourceExists(URI namedGraphUri, URI resourceUri);
 
     /**
-     * Retrieve a Jena model for triples under the given subject from the corresponding named graph.
+     * Retrieve a Jena {@link Model} for triples under the given subject from the corresponding named graph.
      */
     Model getJenaModelForSubject(URI namedGraphUri, URI subject)
             throws NoSuchElementException;
@@ -172,63 +172,71 @@ public interface Store {
             int limit, int offset) throws StoreAccessException, ModelUnmarshallingException;
 
     /**
-     * Alternative to {@link Store#getResources(URI, Class, String, String, String, int, int)} with additional paramters for inlined resources.
-     *
-     * These paramters extend the default query from 
-     * 
+     * Alternative to {@link Store#getResources(URI, Class, String, String, String, int, int)} with additional parameters for inlined resources.
+     * These parameters extend the default query from:
+     * <pre>
      * DESCRIBE ?s
-     * WHERE { 
+     * WHERE {
      *   ...
      *   SELECT distinct ?s
      *     WHERE {
      *       ?s ?p ?o .
-     *       ?s rdf:type  <http://...> .
+     *       ?s rdf:type  &lt;http://...&gt; .
      *       ...
      *     }
      * }
-     * 
-     * to
-     * 
+     * </pre>
+     * to:
+     * <pre>
      * DESCRIBE ?s ?a ?b
-     * WHERE { 
+     * WHERE {
      * ...
      *   SELECT distinct ?s ?a ?b
      *   WHERE {
      *     ?s  ?p        ?o .
-     *     ?s rdf:type  <http://...> .
-     *     ?s <http://...#prp1>  ?a .
-     *     ?a <http://prp2> ?b
+     *     ?s rdf:type  &lt;http://...&gt; .
+     *     ?s &lt;http://...#prp1&gt;  ?a .
+     *     ?a &lt;http://prp2&gt; ?b
      *   }
      * }
-     *  
-     *  hence allowing ?a and ?b to be described, as well as ?a 
-     *  
-     *  Corresponding paramters to acheive this:
+     * </pre>
+     *
+     *  hence allowing {@code ?a} and {@code ?b} to be described, as well as {@code ?s}.
+     *
+     *  Corresponding parameters to achieve this:
+     *
+     *  <pre>
      *  List<String> additionalDistinctVars = new ArrayList<String>();
      *  additionalDistinctVars.add("a");
      *  additionalDistinctVars.add("b");
-     *  
+     *
      *  SelectBuilder additionalQueryFilter = new SelectBuilder();
      *  additionalQueryFilter
      *  .addWhere( "?s", new ResourceImpl("http://...#" + "prp1"), "?a")
      *  .addWhere( "?a", new ResourceImpl(http://...# + "prp2"), "?b");
-
+     *  </pre>
      * @param additionalDistinctVars
      * @param additionalQueryFilter
      */
     <T extends IResource> List<T> getResources(URI namedGraphUri, Class<T> clazz,
             String prefixes, String where, String searchTerms,
-            int limit, int offset, 
+            int limit, int offset,
             List<String> additionalDistinctVars, SelectBuilder additionalQueryFilter) throws StoreAccessException, ModelUnmarshallingException;
 
     /**
-     * Retrieve a Jena model that satisfies the given where parameter as defined in the OSLC Query language (https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/specs/oslc-query.html)
-     * If the namedGraph is null, the query is applied on all namedGraph in the triplestore.
-     * The method currently only provides support for terms of type Comparisons, where the operator is 'EQUALS', and the operand is either a String or a URI.
+     * Retrieve a Jena model that satisfies the given where parameter as defined in the OSLC Query
+     * language
+     * (<a href="https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/specs/oslc-query.html">https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/specs/oslc-query.html</a>)
+     * If the {@code namedGraph} is null, the query is applied on all {@code namedGraph} in the triplestore.
+     * The method currently only provides support for terms of type Comparisons, where the operator
+     * is {@code 'EQUALS'}, and the operand is either a {@link String} or a {@link URI}.
      *
      * @param namedGraph    namedGraphUri URI of a named graph under which resources were stored
-     * @param prefixes      defines the prefixes for prefixed names that appear in the oslc.where query parameter.
-     * @param where         filters the member list, keeping only those member resources that satisfy the boolean test on the member resource properties. (See oslc.where  at https://tools.oasis-open.org/version-control/browse/wsvn/oslc-core/trunk/specs/oslc-query.html)
+     * @param prefixes      defines the prefixes for prefixed names that appear in the oslc.where
+     *                      query parameter.
+     * @param where         filters the member list, keeping only those member resources that satisfy
+     *                     the boolean test on the member resource properties. (See {@code oslc.where}  at
+     *                      <a href="https://tools.oasis-open.org/version-control/browse/wsvn/oslc-core/trunk/specs/oslc-query.html">https://tools.oasis-open.org/version-control/browse/wsvn/oslc-core/trunk/specs/oslc-query.html</a>)
      * @param limit         paging limit
      * @param offset        paging offset
      *
@@ -238,30 +246,39 @@ public interface Store {
     Model getResources(URI namedGraph, String prefixes, String where, int limit, int offset);
 
     /**
-     * Retrieve a Jena model that satisfies the given where parameter as defined in the OSLC Query language (https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/specs/oslc-query.html)
-     * If the namedGraph is null, the query is applied on all namedGraph in the triplestore.
-     * The method currently only provides support for terms of type Comparisons, where the operator is 'EQUALS', and the operand is either a String or a URI.
+     * Retrieve a Jena model that satisfies the given where parameter as defined in the OSLC Query
+     * language (<a href="https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/specs/oslc-query.html">https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/specs/oslc-query.html</a>)
+     * If the {@code namedGraph} is null, the query is applied on all {@code namedGraph} in the triplestore.
+     * The method currently only provides support for terms of type Comparisons, where the operator
+     * is {@code 'EQUALS'}, and the operand is either a {@link String} or a {@link URI}.
      *
      * @param namedGraph    namedGraphUri URI of a named graph under which resources were stored
-     * @param prefixes      defines the prefixes for prefixed names that appear in the oslc.where query parameter.
-     * @param where         filters the member list, keeping only those member resources that satisfy the boolean test on the member resource properties. (See oslc.where  at https://tools.oasis-open.org/version-control/browse/wsvn/oslc-core/trunk/specs/oslc-query.html)
-     * @param searchTerms   score each member resource using a full text search on it text-valued properties. (See oslc.searchTerms  at https://tools.oasis-open.org/version-control/browse/wsvn/oslc-core/trunk/specs/oslc-query.html)
+     * @param prefixes      defines the prefixes for prefixed names that appear in the {@code oslc.where}
+     *                      query parameter.
+     * @param where         filters the member list, keeping only those member resources that satisfy
+     *                     the boolean test on the member resource properties. (See {@code oslc.where}
+     *                     at <a href="https://tools.oasis-open.org/version-control/browse/wsvn/oslc-core/trunk/specs/oslc-query.html">https://tools.oasis-open.org/version-control/browse/wsvn/oslc-core/trunk/specs/oslc-query.html</a>)
+     * @param searchTerms   score each member resource using a full text search on it text-valued
+     *                      properties. (See {@code oslc.searchTerms} at
+     *                      <a href="https://tools.oasis-open.org/version-control/browse/wsvn/oslc-core/trunk/specs/oslc-query.html">https://tools.oasis-open.org/version-control/browse/wsvn/oslc-core/trunk/specs/oslc-query.html</a>)
      * @param limit         paging limit
      * @param offset        paging offset
      *
-     * @return list of resources, size is less or equal to 'limit'
+     * @return a Jena {@link Model} with the less than or equal to {@code limit} resources.
      *
      */
     Model getResources(URI namedGraph, String prefixes, String where, String searchTerms, int limit, int offset);
 
-    
+
     /**
-     * Alternative to {@link Store#getResources(URI, String, String, String, int, int)} with additional paramters for inlined resources.
+     * Alternative to {@link Store#getResources(URI, String, String, String, int, int)} with
+     * additional parameters for inlined resources.
      *
-     * See {@link Store#getResources(URI, Class, String, String, String, int, int, List<String>, SelectBuilder)} for an explanation of these additional paramters.
+     * See {@link Store#getResources(URI, Class, String, String, String, int, int, List, SelectBuilder)}
+     * for an explanation of these additional parameters.
 
      */
-    Model getResources(URI namedGraph, String prefixes, String where, String searchTerms, int limit, int offset, 
+    Model getResources(URI namedGraph, String prefixes, String where, String searchTerms, int limit, int offset,
             List<String> additionalDistinctVars, SelectBuilder additionalQueryFilter);
 
     /**

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/JenaQueryExecutor.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/query/JenaQueryExecutor.java
@@ -1,9 +1,7 @@
 package org.eclipse.lyo.store.internals.query;
 
-import java.io.InputStream;
-
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -42,7 +40,6 @@ public interface JenaQueryExecutor {
     /**
      * Prepares a SPARQL Update processor (write-only).
      *
-     * @param query SPARQL query string
      * @return prepared processor
      */
     UpdateProcessor prepareSparqlUpdate(final UpdateRequest updateRequest);
@@ -50,7 +47,6 @@ public interface JenaQueryExecutor {
     /**
      * Prepares a SPARQL Update processor (write-only).
      *
-     * @param query SPARQL query string
      * @return prepared processor
      */
     UpdateProcessor prepareSparqlUpdate(final Update update);

--- a/store/store-core/src/main/javadoc/overview.html
+++ b/store/store-core/src/main/javadoc/overview.html
@@ -31,7 +31,7 @@
         model the domain and automatically generate OSLC4J-compliant Java code</a>.
 </p>
 
-<p>The main part of this project is the {@link Store} interface. You can instantiate concrete implementations of this
-    interface using the {@link StoreFactory} class.</p>
+<p>The main part of this project is the {@link org.eclipse.lyo.store.Store} interface. You can instantiate concrete implementations of this
+    interface using the {@link org.eclipse.lyo.store.StoreFactory} class.</p>
 </body>
 </html>


### PR DESCRIPTION
## Description

This is the big Javadoc update we meant to do a long time ago. Here are the highlights:

- We switched the javadoc checks from JDK 8 level to JDK 11 level and enabled the linter (only for some critical errors).
- All `@link` references to JAX-RS or Jena code fully resolve to the projects' Javadocs. All Java links point to JDK 11 docs, not JDK 8 docs, despite us still only using Java 8 language features in a case backporting is needed for future releases.
- Deprecations are explained in Javadocs with `@deprecated` tags instead of `@see`. Thanks to @estepper for bringing it to our attention.
- All broken code references in the docs have been resolved.

Here is how the linking to JAX-RS and Jena classes works:

![Screen Shot 2022-04-16 at 17 36 25](https://user-images.githubusercontent.com/64734/163681494-7828e7bd-33cb-4642-a12f-8c9b756219ed.jpg)

![Screen Shot 2022-04-16 at 17 37 10](https://user-images.githubusercontent.com/64734/163681501-4458199a-b7ff-4aae-8fa3-a852a9a79425.jpg)

From now on, having bad references, unescaped angle brackets, or non-existent params or throw declarations will break the build. Here are some guidelines for the Javadoc writing in the future:

- Use `{@code code.here()}` for single-line code.
- Use `<pre></pre>` for multi-line code blocks. ALWAYS escape `<>` with `&lt;&gt;`.
- Paragraphs shall be followed by a single `<p>` tag (or separated by) in order to get newlines.
- NEVER use `<code></code>`.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #232, closes #253.