### PR TITLE
Use --no-module-directories flag on javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -430,6 +430,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.3.2</version>
           <configuration>
+            <additionalJOption>--no-module-directories</additionalJOption>
 <!--            <doclint>none</doclint>-->
             <doclint>all,-accessibility,-html,-missing</doclint>
             <links>


### PR DESCRIPTION
## Description

See https://stackoverflow.com/questions/52326318/maven-javadoc-search-redirects-to-undefined-url/66891038#66891038

As an alternative, **we can switch to JDK 17 but keep target and release to be 11**. Even more, we can build everything with JDK 11 to be on the safe side but build Javadocs with JDK 17, deploying them from a separate Jenkins build config.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #0; Closes #00

_(use exactly this syntax to link to issues, one issue per statement only!)_
