### PR TITLE
fix!: Switch oslc:maxSize from int to BigInteger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The release was yanked due to a problem with the publication of release artifact
 - 🧨 Jena is upgraded to 4.5.0 **(addresses [CVE-2022-28890](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28890))**
   - Jena renamed `RDFReader/RDFWriter` to `RDFReaderI/RDFWriterI`
 - 🧨 TRS now uses BigInteger instead of 32-bit ints for `trs:order` properties, in line with the spec. 
+- 🧨 `Property` class in Lyo Core now uses BigInteger instead of 32-bit ints for `oslc:maxSize` properties, in line with the spec.
 - LyoStore: Ordering resources by their subject IDs when doing a query to store. This ordering can be disabled with a call to `OSLC4JUtils.setLyoStorePagingUnsafe(true)`
 - LyoStore: `OSLC4JUtils.hasLyoStorePagingPreciseLimit()` will return true by default. Call `OSLC4JUtils.setLyoStorePagingPreciseLimit(false)` to restore the old behavior.
 - `oslc4j-json4j-provider` uses `wink-json4j` version 1.4 instead of 1.2.1-incubating.

--- a/core/lyo-core-model/src/main/java/org/eclipse/lyo/oslc4j/core/model/Property.java
+++ b/core/lyo-core-model/src/main/java/org/eclipse/lyo/oslc4j/core/model/Property.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.lyo.oslc4j.core.model;
 
+import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -46,7 +47,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 	private URI allowedValuesRef;
 	private String description;
 	private Boolean hidden;
-	private Integer maxSize;
+	private BigInteger maxSize;
 	private Boolean memberProperty;
 	private String name;
 	private Occurs occurs;
@@ -121,7 +122,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "maxSize")
 	@OslcReadOnly
 	@OslcTitle("Maximum Size")
-	public Integer getMaxSize() {
+	public BigInteger getMaxSize() {
 		return maxSize;
 	}
 
@@ -289,7 +290,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		this.hidden = hidden;
 	}
 
-	public void setMaxSize(final Integer maxSize) {
+	public void setMaxSize(final BigInteger maxSize) {
 		this.maxSize = maxSize;
 	}
 

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
@@ -302,7 +302,7 @@ public class ResourceShapeFactory {
 
 		final OslcMaxSize maxSizeAnnotation = InheritedMethodAnnotationHelper.getAnnotation(method, OslcMaxSize.class);
 		if (maxSizeAnnotation != null) {
-			property.setMaxSize(maxSizeAnnotation.value());
+			property.setMaxSize(BigInteger.valueOf(maxSizeAnnotation.value()));
 		}
 
 		final OslcValueShape valueShapeAnnotation = InheritedMethodAnnotationHelper.getAnnotation(method, OslcValueShape.class);


### PR DESCRIPTION
## Description

Switch oslc:maxSize from int to BigInteger as per spec.

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [ ] This PR does NOT break the API

## Issues

Closes #0; Closes #00

_(use exactly this syntax to link to issues, one issue per statement only!)_
