### PR TITLE
Add JDK 19 to the build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,13 +38,13 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.jdk }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-${{ matrix.jdk }}_${{ matrix.distribution }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,8 +32,8 @@ jobs:
           - jdk: '17' # LTS
             experimental: true
             distribution: zulu
-##          - jdk: '18-ea'
-#            experimental: true
+          - jdk: '19'
+            experimental: true
     continue-on-error: ${{ matrix.experimental }}
 
     steps:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,9 +30,10 @@ jobs:
 #            experimental: true
 #            distribution: zulu
           - jdk: '17' # LTS
-            experimental: true
             distribution: zulu
+            experimental: true
           - jdk: '19'
+            distribution: zulu
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
 


### PR DESCRIPTION
## Description

Rationale: JDK switched from a 3-year LTS cadence (every 6 releases) to a 2-year cadence (next LTS is JDK 21) and many OSS projects declared that they will support 2 last LTS releases, which may require us to drop JDK 11 next fall, esp. if Jena 6 drops JDK 11 (they are promising to do just that). Thus, I would like to ensure we build fine on the latest JDK and JDK LTS.
## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [ ] This PR does NOT break the API

This is just a CI change. 

