### PR TITLE
Add the @ApiStatus.Experimental annotation to the new JMH class

### DIFF
--- a/core/oslc4j-core/pom.xml
+++ b/core/oslc4j-core/pom.xml
@@ -75,7 +75,10 @@
         <artifactId>classgraph</artifactId>
         <version>4.8.143</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/Unstable.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/Unstable.java
@@ -1,7 +1,0 @@
-package org.eclipse.lyo.oslc4j.core.annotation;
-
-import java.lang.annotation.Documented;
-
-@Documented
-public @interface Unstable {
-}

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/Unstable.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/Unstable.java
@@ -1,0 +1,7 @@
+package org.eclipse.lyo.oslc4j.core.annotation;
+
+import java.lang.annotation.Documented;
+
+@Documented
+public @interface Unstable {
+}

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/jena/JenaModelHelper.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/jena/JenaModelHelper.java
@@ -74,6 +74,7 @@ import java.util.*;
 import java.util.function.Function;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
+@Unstable
 public final class JenaModelHelper
 {
     private static final String PROPERTY_TOTAL_COUNT = "totalCount";

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/jena/JenaModelHelper.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/jena/JenaModelHelper.java
@@ -48,6 +48,7 @@ import org.eclipse.lyo.oslc4j.core.annotation.*;
 import org.eclipse.lyo.oslc4j.core.exception.*;
 import org.eclipse.lyo.oslc4j.core.model.*;
 import org.eclipse.lyo.oslc4j.core.jena.ordfm.ResourcePackages;
+import org.jetbrains.annotations.ApiStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -74,7 +75,7 @@ import java.util.*;
 import java.util.function.Function;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
-@Unstable
+@ApiStatus.Experimental
 public final class JenaModelHelper
 {
     private static final String PROPERTY_TOTAL_COUNT = "totalCount";

--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,12 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.12.0</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>23.0.0</version>
+        <scope>provided</scope>
+      </dependency>
 
       <!--Test-->
       <dependency>


### PR DESCRIPTION
Rationale: we want to make it not static, users can stick to the deprecated code until 6.0, but we should be able to make breaking changes to these new classes in 5.2 etc.
