### PR TITLE
reverting back the values of the domain names to avoid breaking old code

### DIFF
--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/DctermsDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/DctermsDomainConstants.java
@@ -28,11 +28,11 @@ public interface DctermsDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link DctermsDomainConstants#DUBLIN_CORE_NAMSPACE} or {@link DctermsDomainConstants#DUBLIN_CORE_DOMAIN_Name} instead
+     * @deprecated use {@link DctermsDomainConstants#DUBLIN_CORE_NAMSPACE} or {@link DctermsDomainConstants#DUBLIN_CORE_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String DUBLIN_CORE_DOMAIN = "http://purl.org/dc/terms/";
-    public static String DUBLIN_CORE_DOMAIN_Name = "Dublin Core";
+    public static String DUBLIN_CORE_DOMAIN_NAME = "Dublin Core";
     public static String DUBLIN_CORE_NAMSPACE = "http://purl.org/dc/terms/"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String DUBLIN_CORE_NAMSPACE_PREFIX = "dcterms"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/DctermsDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/DctermsDomainConstants.java
@@ -27,7 +27,12 @@ public interface DctermsDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String DUBLIN_CORE_DOMAIN = "Dublin Core";
+    /**
+     * @deprecated use {@link DctermsDomainConstants#DUBLIN_CORE_NAMSPACE} or {@link DctermsDomainConstants#DUBLIN_CORE_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String DUBLIN_CORE_DOMAIN = "http://purl.org/dc/terms/";
+    public static String DUBLIN_CORE_DOMAIN_Name = "Dublin Core";
     public static String DUBLIN_CORE_NAMSPACE = "http://purl.org/dc/terms/"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String DUBLIN_CORE_NAMSPACE_PREFIX = "dcterms"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/FoafDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/FoafDomainConstants.java
@@ -28,11 +28,11 @@ public interface FoafDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link FoafDomainConstants#FOAF_NAMSPACE} or {@link FoafDomainConstants#FOAF_DOMAIN_Name} instead
+     * @deprecated use {@link FoafDomainConstants#FOAF_NAMSPACE} or {@link FoafDomainConstants#FOAF_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String FOAF_DOMAIN = "http://xmlns.com/foaf/0.1/#";
-    public static String FOAF_DOMAIN_Name = "FOAF";
+    public static String FOAF_DOMAIN_NAME = "FOAF";
     public static String FOAF_NAMSPACE = "http://xmlns.com/foaf/0.1/#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String FOAF_NAMSPACE_PREFIX = "foaf"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/FoafDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/FoafDomainConstants.java
@@ -27,7 +27,12 @@ public interface FoafDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String FOAF_DOMAIN = "FOAF";
+    /**
+     * @deprecated use {@link FoafDomainConstants#FOAF_NAMSPACE} or {@link FoafDomainConstants#FOAF_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String FOAF_DOMAIN = "http://xmlns.com/foaf/0.1/#";
+    public static String FOAF_DOMAIN_Name = "FOAF";
     public static String FOAF_NAMSPACE = "http://xmlns.com/foaf/0.1/#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String FOAF_NAMSPACE_PREFIX = "foaf"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/Nsp10DomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/Nsp10DomainConstants.java
@@ -28,11 +28,11 @@ public interface Nsp10DomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link Nsp10DomainConstants#MATLAB_DOMAIN_NAMSPACE} or {@link Nsp10DomainConstants#MATLAB_DOMAIN_DOMAIN_Name} instead
+     * @deprecated use {@link Nsp10DomainConstants#MATLAB_DOMAIN_NAMSPACE} or {@link Nsp10DomainConstants#MATLAB_DOMAIN_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String MATLAB_DOMAIN_DOMAIN = "http://your.organisation.domain/nsp10#";
-    public static String MATLAB_DOMAIN_DOMAIN_Name = "Matlab Domain";
+    public static String MATLAB_DOMAIN_DOMAIN_NAME = "Matlab Domain";
     public static String MATLAB_DOMAIN_NAMSPACE = "http://your.organisation.domain/nsp10#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String MATLAB_DOMAIN_NAMSPACE_PREFIX = "nsp10"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/Nsp10DomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/Nsp10DomainConstants.java
@@ -27,7 +27,12 @@ public interface Nsp10DomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String MATLAB_DOMAIN_DOMAIN = "Matlab Domain";
+    /**
+     * @deprecated use {@link Nsp10DomainConstants#MATLAB_DOMAIN_NAMSPACE} or {@link Nsp10DomainConstants#MATLAB_DOMAIN_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String MATLAB_DOMAIN_DOMAIN = "http://your.organisation.domain/nsp10#";
+    public static String MATLAB_DOMAIN_DOMAIN_Name = "Matlab Domain";
     public static String MATLAB_DOMAIN_NAMSPACE = "http://your.organisation.domain/nsp10#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String MATLAB_DOMAIN_NAMSPACE_PREFIX = "nsp10"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfDomainConstants.java
@@ -27,7 +27,12 @@ public interface RdfDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String RDF_DOMAIN = "RDF";
+    /**
+     * @deprecated use {@link RdfDomainConstants#RDF_NAMSPACE} or {@link RdfDomainConstants#RDF_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String RDF_DOMAIN = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+    public static String RDF_DOMAIN_Name = "RDF";
     public static String RDF_NAMSPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String RDF_NAMSPACE_PREFIX = "rdf"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfDomainConstants.java
@@ -28,11 +28,11 @@ public interface RdfDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link RdfDomainConstants#RDF_NAMSPACE} or {@link RdfDomainConstants#RDF_DOMAIN_Name} instead
+     * @deprecated use {@link RdfDomainConstants#RDF_NAMSPACE} or {@link RdfDomainConstants#RDF_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String RDF_DOMAIN = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
-    public static String RDF_DOMAIN_Name = "RDF";
+    public static String RDF_DOMAIN_NAME = "RDF";
     public static String RDF_NAMSPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String RDF_NAMSPACE_PREFIX = "rdf"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfsDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfsDomainConstants.java
@@ -27,7 +27,12 @@ public interface RdfsDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String RDFS_DOMAIN = "RDFS";
+    /**
+     * @deprecated use {@link RdfsDomainConstants#RDFS_NAMSPACE} or {@link RdfsDomainConstants#RDFS_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String RDFS_DOMAIN = "http://www.w3.org/2000/01/rdf-schema#";
+    public static String RDFS_DOMAIN_Name = "RDFS";
     public static String RDFS_NAMSPACE = "http://www.w3.org/2000/01/rdf-schema#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String RDFS_NAMSPACE_PREFIX = "rdfs"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfsDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/RdfsDomainConstants.java
@@ -28,11 +28,11 @@ public interface RdfsDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link RdfsDomainConstants#RDFS_NAMSPACE} or {@link RdfsDomainConstants#RDFS_DOMAIN_Name} instead
+     * @deprecated use {@link RdfsDomainConstants#RDFS_NAMSPACE} or {@link RdfsDomainConstants#RDFS_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String RDFS_DOMAIN = "http://www.w3.org/2000/01/rdf-schema#";
-    public static String RDFS_DOMAIN_Name = "RDFS";
+    public static String RDFS_DOMAIN_NAME = "RDFS";
     public static String RDFS_NAMSPACE = "http://www.w3.org/2000/01/rdf-schema#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String RDFS_NAMSPACE_PREFIX = "rdfs"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Oslc_amDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Oslc_amDomainConstants.java
@@ -28,11 +28,11 @@ public interface Oslc_amDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link Oslc_amDomainConstants#ARCHITECTURE_MANAGEMENT_NAMSPACE} or {@link Oslc_amDomainConstants#ARCHITECTURE_MANAGEMENT_DOMAIN_Name} instead
+     * @deprecated use {@link Oslc_amDomainConstants#ARCHITECTURE_MANAGEMENT_NAMSPACE} or {@link Oslc_amDomainConstants#ARCHITECTURE_MANAGEMENT_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String ARCHITECTURE_MANAGEMENT_DOMAIN = "http://open-services.net/ns/am#";
-    public static String ARCHITECTURE_MANAGEMENT_DOMAIN_Name = "Architecture Management";
+    public static String ARCHITECTURE_MANAGEMENT_DOMAIN_NAME = "Architecture Management";
     public static String ARCHITECTURE_MANAGEMENT_NAMSPACE = "http://open-services.net/ns/am#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String ARCHITECTURE_MANAGEMENT_NAMSPACE_PREFIX = "oslc_am"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Oslc_amDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Oslc_amDomainConstants.java
@@ -27,7 +27,12 @@ public interface Oslc_amDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String ARCHITECTURE_MANAGEMENT_DOMAIN = "Architecture Management";
+    /**
+     * @deprecated use {@link Oslc_amDomainConstants#ARCHITECTURE_MANAGEMENT_NAMSPACE} or {@link Oslc_amDomainConstants#ARCHITECTURE_MANAGEMENT_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String ARCHITECTURE_MANAGEMENT_DOMAIN = "http://open-services.net/ns/am#";
+    public static String ARCHITECTURE_MANAGEMENT_DOMAIN_Name = "Architecture Management";
     public static String ARCHITECTURE_MANAGEMENT_NAMSPACE = "http://open-services.net/ns/am#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String ARCHITECTURE_MANAGEMENT_NAMSPACE_PREFIX = "oslc_am"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/Oslc_autoDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/Oslc_autoDomainConstants.java
@@ -27,7 +27,12 @@ public interface Oslc_autoDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String AUTOMATION_DOMAIN = "Automation";
+    /**
+     * @deprecated use {@link Oslc_autoDomainConstants#AUTOMATION_NAMSPACE} or {@link Oslc_autoDomainConstants#AUTOMATION_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String AUTOMATION_DOMAIN = "http://open-services.net/ns/auto#";
+    public static String AUTOMATION_DOMAIN_Name = "Automation";
     public static String AUTOMATION_NAMSPACE = "http://open-services.net/ns/auto#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String AUTOMATION_NAMSPACE_PREFIX = "oslc_auto"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/Oslc_autoDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/Oslc_autoDomainConstants.java
@@ -28,11 +28,11 @@ public interface Oslc_autoDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link Oslc_autoDomainConstants#AUTOMATION_NAMSPACE} or {@link Oslc_autoDomainConstants#AUTOMATION_DOMAIN_Name} instead
+     * @deprecated use {@link Oslc_autoDomainConstants#AUTOMATION_NAMSPACE} or {@link Oslc_autoDomainConstants#AUTOMATION_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String AUTOMATION_DOMAIN = "http://open-services.net/ns/auto#";
-    public static String AUTOMATION_DOMAIN_Name = "Automation";
+    public static String AUTOMATION_DOMAIN_NAME = "Automation";
     public static String AUTOMATION_NAMSPACE = "http://open-services.net/ns/auto#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String AUTOMATION_NAMSPACE_PREFIX = "oslc_auto"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Oslc_cmDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Oslc_cmDomainConstants.java
@@ -28,11 +28,11 @@ public interface Oslc_cmDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link Oslc_cmDomainConstants#CHANGE_MANAGEMENT_SHAPES_NAMSPACE} or {@link Oslc_cmDomainConstants#CHANGE_MANAGEMENT_SHAPES_DOMAIN_Name} instead
+     * @deprecated use {@link Oslc_cmDomainConstants#CHANGE_MANAGEMENT_SHAPES_NAMSPACE} or {@link Oslc_cmDomainConstants#CHANGE_MANAGEMENT_SHAPES_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String CHANGE_MANAGEMENT_SHAPES_DOMAIN = "http://open-services.net/ns/cm#";
-    public static String CHANGE_MANAGEMENT_SHAPES_DOMAIN_Name = "Change Management shapes";
+    public static String CHANGE_MANAGEMENT_SHAPES_DOMAIN_NAME = "Change Management shapes";
     public static String CHANGE_MANAGEMENT_SHAPES_NAMSPACE = "http://open-services.net/ns/cm#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String CHANGE_MANAGEMENT_SHAPES_NAMSPACE_PREFIX = "oslc_cm"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Oslc_cmDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/Oslc_cmDomainConstants.java
@@ -27,7 +27,12 @@ public interface Oslc_cmDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String CHANGE_MANAGEMENT_SHAPES_DOMAIN = "Change Management shapes";
+    /**
+     * @deprecated use {@link Oslc_cmDomainConstants#CHANGE_MANAGEMENT_SHAPES_NAMSPACE} or {@link Oslc_cmDomainConstants#CHANGE_MANAGEMENT_SHAPES_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String CHANGE_MANAGEMENT_SHAPES_DOMAIN = "http://open-services.net/ns/cm#";
+    public static String CHANGE_MANAGEMENT_SHAPES_DOMAIN_Name = "Change Management shapes";
     public static String CHANGE_MANAGEMENT_SHAPES_NAMSPACE = "http://open-services.net/ns/cm#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String CHANGE_MANAGEMENT_SHAPES_NAMSPACE_PREFIX = "oslc_cm"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Oslc_configDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Oslc_configDomainConstants.java
@@ -31,11 +31,11 @@ public interface Oslc_configDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link Oslc_configDomainConstants#CONFIGURATION_MANAGEMENT_NAMSPACE} or {@link Oslc_configDomainConstants#CONFIGURATION_MANAGEMENT_DOMAIN_Name} instead
+     * @deprecated use {@link Oslc_configDomainConstants#CONFIGURATION_MANAGEMENT_NAMSPACE} or {@link Oslc_configDomainConstants#CONFIGURATION_MANAGEMENT_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String CONFIGURATION_MANAGEMENT_DOMAIN = "http://open-services.net/ns/config#";
-    public static String CONFIGURATION_MANAGEMENT_DOMAIN_Name = "Configuration Management";
+    public static String CONFIGURATION_MANAGEMENT_DOMAIN_NAME = "Configuration Management";
     public static String CONFIGURATION_MANAGEMENT_NAMSPACE = "http://open-services.net/ns/config#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String CONFIGURATION_MANAGEMENT_NAMSPACE_PREFIX = "oslc_config"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Oslc_configDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Oslc_configDomainConstants.java
@@ -30,7 +30,12 @@ public interface Oslc_configDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String CONFIGURATION_MANAGEMENT_DOMAIN = "Configuration Management";
+    /**
+     * @deprecated use {@link Oslc_configDomainConstants#CONFIGURATION_MANAGEMENT_NAMSPACE} or {@link Oslc_configDomainConstants#CONFIGURATION_MANAGEMENT_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String CONFIGURATION_MANAGEMENT_DOMAIN = "http://open-services.net/ns/config#";
+    public static String CONFIGURATION_MANAGEMENT_DOMAIN_Name = "Configuration Management";
     public static String CONFIGURATION_MANAGEMENT_NAMSPACE = "http://open-services.net/ns/config#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String CONFIGURATION_MANAGEMENT_NAMSPACE_PREFIX = "oslc_config"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/jazz_am/Jazz_amDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/jazz_am/Jazz_amDomainConstants.java
@@ -27,7 +27,12 @@ public interface Jazz_amDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String JAZZ_ARCHITECTURE_MANAGEMENT_DOMAIN = "Jazz Architecture Management ";
+    /**
+     * @deprecated use {@link Jazz_amDomainConstants#JAZZ_ARCHITECTURE_MANAGEMENT_NAMSPACE} or {@link Jazz_amDomainConstants#JAZZ_ARCHITECTURE_MANAGEMENT_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String JAZZ_ARCHITECTURE_MANAGEMENT_DOMAIN = "http://jazz.net/ns/dm/linktypes#";
+    public static String JAZZ_ARCHITECTURE_MANAGEMENT_DOMAIN_Name = "Jazz Architecture Management ";
     public static String JAZZ_ARCHITECTURE_MANAGEMENT_NAMSPACE = "http://jazz.net/ns/dm/linktypes#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String JAZZ_ARCHITECTURE_MANAGEMENT_NAMSPACE_PREFIX = "jazz_am"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/jazz_am/Jazz_amDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/jazz_am/Jazz_amDomainConstants.java
@@ -28,11 +28,11 @@ public interface Jazz_amDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link Jazz_amDomainConstants#JAZZ_ARCHITECTURE_MANAGEMENT_NAMSPACE} or {@link Jazz_amDomainConstants#JAZZ_ARCHITECTURE_MANAGEMENT_DOMAIN_Name} instead
+     * @deprecated use {@link Jazz_amDomainConstants#JAZZ_ARCHITECTURE_MANAGEMENT_NAMSPACE} or {@link Jazz_amDomainConstants#JAZZ_ARCHITECTURE_MANAGEMENT_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String JAZZ_ARCHITECTURE_MANAGEMENT_DOMAIN = "http://jazz.net/ns/dm/linktypes#";
-    public static String JAZZ_ARCHITECTURE_MANAGEMENT_DOMAIN_Name = "Jazz Architecture Management ";
+    public static String JAZZ_ARCHITECTURE_MANAGEMENT_DOMAIN_NAME = "Jazz Architecture Management ";
     public static String JAZZ_ARCHITECTURE_MANAGEMENT_NAMSPACE = "http://jazz.net/ns/dm/linktypes#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String JAZZ_ARCHITECTURE_MANAGEMENT_NAMSPACE_PREFIX = "jazz_am"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/Oslc_qmDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/Oslc_qmDomainConstants.java
@@ -27,7 +27,12 @@ public interface Oslc_qmDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String QUALITY_MANAGEMENT_DOMAIN = "Quality Management";
+    /**
+     * @deprecated use {@link Oslc_qmDomainConstants#QUALITY_MANAGEMENT_NAMSPACE} or {@link Oslc_qmDomainConstants#QUALITY_MANAGEMENT_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String QUALITY_MANAGEMENT_DOMAIN = "http://open-services.net/ns/qm#";
+    public static String QUALITY_MANAGEMENT_DOMAIN_Name = "Quality Management";
     public static String QUALITY_MANAGEMENT_NAMSPACE = "http://open-services.net/ns/qm#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String QUALITY_MANAGEMENT_NAMSPACE_PREFIX = "oslc_qm"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/Oslc_qmDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/Oslc_qmDomainConstants.java
@@ -28,11 +28,11 @@ public interface Oslc_qmDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link Oslc_qmDomainConstants#QUALITY_MANAGEMENT_NAMSPACE} or {@link Oslc_qmDomainConstants#QUALITY_MANAGEMENT_DOMAIN_Name} instead
+     * @deprecated use {@link Oslc_qmDomainConstants#QUALITY_MANAGEMENT_NAMSPACE} or {@link Oslc_qmDomainConstants#QUALITY_MANAGEMENT_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String QUALITY_MANAGEMENT_DOMAIN = "http://open-services.net/ns/qm#";
-    public static String QUALITY_MANAGEMENT_DOMAIN_Name = "Quality Management";
+    public static String QUALITY_MANAGEMENT_DOMAIN_NAME = "Quality Management";
     public static String QUALITY_MANAGEMENT_NAMSPACE = "http://open-services.net/ns/qm#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String QUALITY_MANAGEMENT_NAMSPACE_PREFIX = "oslc_qm"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Oslc_rmDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Oslc_rmDomainConstants.java
@@ -27,7 +27,12 @@ public interface Oslc_rmDomainConstants
     // Start of user code user constants
     // End of user code
 
-    public static String REQUIREMENTS_MANAGEMENT_SHAPES_DOMAIN = "Requirements Management shapes";
+    /**
+     * @deprecated use {@link Oslc_rmDomainConstants#REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE} or {@link Oslc_rmDomainConstants#REQUIREMENTS_MANAGEMENT_SHAPES_DOMAIN_Name} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String REQUIREMENTS_MANAGEMENT_SHAPES_DOMAIN = "http://open-services.net/ns/rm#";
+    public static String REQUIREMENTS_MANAGEMENT_SHAPES_DOMAIN_Name = "Requirements Management shapes";
     public static String REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE = "http://open-services.net/ns/rm#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE_PREFIX = "oslc_rm"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Oslc_rmDomainConstants.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Oslc_rmDomainConstants.java
@@ -28,11 +28,11 @@ public interface Oslc_rmDomainConstants
     // End of user code
 
     /**
-     * @deprecated use {@link Oslc_rmDomainConstants#REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE} or {@link Oslc_rmDomainConstants#REQUIREMENTS_MANAGEMENT_SHAPES_DOMAIN_Name} instead
+     * @deprecated use {@link Oslc_rmDomainConstants#REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE} or {@link Oslc_rmDomainConstants#REQUIREMENTS_MANAGEMENT_SHAPES_DOMAIN_NAME} instead
      */
     @Deprecated(since = "5.0.1")
     public static String REQUIREMENTS_MANAGEMENT_SHAPES_DOMAIN = "http://open-services.net/ns/rm#";
-    public static String REQUIREMENTS_MANAGEMENT_SHAPES_DOMAIN_Name = "Requirements Management shapes";
+    public static String REQUIREMENTS_MANAGEMENT_SHAPES_DOMAIN_NAME = "Requirements Management shapes";
     public static String REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE = "http://open-services.net/ns/rm#"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE_PREFIX = "oslc_rm"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 


### PR DESCRIPTION
## Description

reverting back the values of the domain names to avoid breaking old code
## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

