### PR TITLE
Generic TypeVariable handling

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
         # temurin is Eclipse/AdoptOpenJDK/Adoptium
         # 'liberica' is a preferred Spring SDK
 #        distribution: ['temurin', 'zulu']
-        distribution: ['adopt', 'liberica', 'microsoft', 'corretto']
+        distribution: ['temurin', 'zulu', 'adopt', 'liberica', 'microsoft', 'corretto']
         experimental: [false]
         # jena 3.x has some locking problems under JDK 16/17
         include:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,8 @@ jobs:
         jdk: ['11']
         # temurin is Eclipse/AdoptOpenJDK/Adoptium
         # 'liberica' is a preferred Spring SDK
-        distribution: ['temurin', 'zulu']
+#        distribution: ['temurin', 'zulu']
+        distribution: ['adopt', 'liberica', 'microsoft', 'corretto']
         experimental: [false]
         # jena 3.x has some locking problems under JDK 16/17
         include:

--- a/core/oslc-trs/src/main/java/org/eclipse/lyo/core/trs/package-info.java
+++ b/core/oslc-trs/src/main/java/org/eclipse/lyo/core/trs/package-info.java
@@ -11,7 +11,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
-@OslcSchema({
+/** */@OslcSchema({
 		@OslcNamespaceDefinition(prefix = OslcConstants.DCTERMS_NAMESPACE_PREFIX, namespaceURI = OslcConstants.DCTERMS_NAMESPACE),
 		@OslcNamespaceDefinition(prefix = OslcConstants.OSLC_CORE_NAMESPACE_PREFIX, namespaceURI = OslcConstants.OSLC_CORE_NAMESPACE),
 		@OslcNamespaceDefinition(prefix = OslcConstants.RDF_NAMESPACE_PREFIX, namespaceURI = OslcConstants.RDF_NAMESPACE),

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/CoreHelper.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/CoreHelper.java
@@ -1,0 +1,20 @@
+package org.eclipse.lyo.oslc4j.core;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+
+/**
+ * Not for use outside Lyo, signatures may change outside major releases.
+ *
+ * @since 5.0.1
+ */
+public class CoreHelper {
+    public static Class<?> getActualTypeArgument(Type type) {
+        if (type instanceof Class) {
+            return (Class<?>) type;
+        } else if (type instanceof TypeVariable) {
+            return (Class<?>) ((TypeVariable)type).getBounds()[0];
+        }
+        throw new IllegalArgumentException("You must pass either a Class or a (generic) TypeVariable");
+    }
+}

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
@@ -16,6 +16,7 @@ package org.eclipse.lyo.oslc4j.core.model;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -30,6 +31,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.UriBuilder;
+
+import org.eclipse.lyo.oslc4j.core.CoreHelper;
 import org.eclipse.lyo.oslc4j.core.annotation.*;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreDuplicatePropertyDefinitionException;
@@ -40,9 +43,14 @@ import org.eclipse.lyo.oslc4j.core.exception.OslcCoreInvalidRepresentationExcept
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreInvalidValueTypeException;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreMissingAnnotationException;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreMissingSetMethodException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ResourceShapeFactory {
-	protected static final String METHOD_NAME_START_GET = "get";
+
+    private final static Logger log = LoggerFactory.getLogger(ResourceShapeFactory.class);
+
+    protected static final String METHOD_NAME_START_GET = "get";
 	protected static final String METHOD_NAME_START_IS  = "is";
 	protected static final String METHOD_NAME_START_SET = "set";
 
@@ -194,11 +202,13 @@ public class ResourceShapeFactory {
 				if (actualTypeArguments.length == 1)
 				{
 					final Type actualTypeArgument = actualTypeArguments[0];
-					if (actualTypeArgument instanceof Class)
-					{
-						componentType = (Class<?>) actualTypeArgument;
-					}
-				}
+                    if (actualTypeArgument instanceof Class) {
+                        componentType = CoreHelper.getActualTypeArgument(actualTypeArgument);
+                    } else if (actualTypeArgument instanceof TypeVariable) {
+                        log.error("Resource shapes are not designed to be initialized with the help of GenericEntity " +
+                            "(or other ways to capture a TypeVariable)");
+                    }
+                }
 			}
 		}
 

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/package-info.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/package-info.java
@@ -12,7 +12,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  */
 
-@OslcSchema ({ 
+/** */@OslcSchema ({
    @OslcNamespaceDefinition(prefix = OslcConstants.DCTERMS_NAMESPACE_PREFIX,   namespaceURI = OslcConstants.DCTERMS_NAMESPACE),
    @OslcNamespaceDefinition(prefix = OslcConstants.OSLC_CORE_NAMESPACE_PREFIX, namespaceURI = OslcConstants.OSLC_CORE_NAMESPACE),
    @OslcNamespaceDefinition(prefix = OslcConstants.RDF_NAMESPACE_PREFIX,	   namespaceURI = OslcConstants.RDF_NAMESPACE),
@@ -23,4 +23,3 @@ package org.eclipse.lyo.oslc4j.core.model;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespaceDefinition;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcSchema;
-

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlCollectionProvider.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlCollectionProvider.java
@@ -76,38 +76,29 @@ public class OslcRdfXmlCollectionProvider
 							   final Annotation[] annotations,
 							   final MediaType	  mediaType)
 	{
-		if (Collection.class.isAssignableFrom(type))
-		{
-            //dealing with a subclass of a Collection<?>
+		if (Collection.class.isAssignableFrom(type) && genericType instanceof ParameterizedType) {
+            final ParameterizedType parameterizedType = (ParameterizedType) genericType;
+            final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
 
-            if (genericType instanceof ParameterizedType) {
-                // may not be available due to type erasure
-
-                final ParameterizedType parameterizedType = (ParameterizedType) genericType;
-
-                final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
-
-                if (actualTypeArguments.length == 1)
-                {
-                    Type firstTypeArg = actualTypeArguments[0];
-                    if (firstTypeArg instanceof Class) {
-                        if (log.isTraceEnabled()) {
-                            log.trace("isWritable() call on a generic type arg: <{}> (comptime)",
-                               CoreHelper.getActualTypeArgument(firstTypeArg).getSimpleName());
-                        }
-                        return true;
-                    } else if (firstTypeArg instanceof TypeVariable) {
-                        if (log.isTraceEnabled()) {
-                            log.trace("isWritable() call on a generic type arg: <{}> (runtime)",
-                                CoreHelper.getActualTypeArgument(firstTypeArg).getSimpleName());
-                        }
-                        return true;
+            if (actualTypeArguments.length == 1) {
+                Type firstTypeArg = actualTypeArguments[0];
+                if (firstTypeArg instanceof Class) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("isWritable() call on a generic type arg: <{}> (comptime)",
+                           CoreHelper.getActualTypeArgument(firstTypeArg).getSimpleName());
                     }
-                    return false;
+                    return true;
+                } else if (firstTypeArg instanceof TypeVariable) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("isWritable() call on a generic type arg: <{}> (runtime)",
+                            CoreHelper.getActualTypeArgument(firstTypeArg).getSimpleName());
+                    }
+                    return true;
                 }
-                else {
-                    log.error("Collection type must have exactly one generic type");
-                }
+                return false;
+            }
+            else {
+                log.error("Collection type must have exactly one generic type");
             }
 		} else {
             throw new IllegalArgumentException("This provider should only be applied to Collection<?>");

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ProviderHelper.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ProviderHelper.java
@@ -80,4 +80,5 @@ final class ProviderHelper {
 
         return containsOslcParm;
     }
+
 }

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/ShapeTest.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/ShapeTest.java
@@ -38,15 +38,15 @@ public class ShapeTest {
 	public void allowedAndDefaultValuesTest() throws Exception {
 		ResourceShape s = readResourceShape("/allowedValues.ttl");
 		assertNotNull("Shape is null", s);
-		
+
 		Property allowedValuesUriProperty = s.getProperty(new URI("http://example.com/shapes/allowedValuesUriProperty"));
 		assertNotNull("http://example.com/shapes/allowedValuesUriProperty property not in shape", s);
-		
+
 		Collection<?> uriAllowedValues = allowedValuesUriProperty.getAllowedValuesCollection();
 		assertEquals("Wrong number of allowedValues for allowedValuesUriProperty property", 2, uriAllowedValues.size());
 		assertTrue("uri1 not in allowed values", uriAllowedValues.contains(new URI("http://example.com/ns#uri1")));
 		assertTrue("uri2 not in allowed values", uriAllowedValues.contains(new URI("http://example.com/ns#uri2")));
-		
+
 		assertEquals("Default values should be uri1", new URI("http://example.com/ns#uri1"), allowedValuesUriProperty.getDefaultValueObject());
 
 		Property allowedValuesStringProperty = s.getProperty(new URI("http://example.com/shapes/allowedValuesStringProperty"));
@@ -57,7 +57,7 @@ public class ShapeTest {
 		assertTrue("String 1 not in allowed values", stringAllowedValues.contains("String 1"));
 		assertTrue("String 2 not in allowed values", stringAllowedValues.contains("String 2"));
 		assertTrue("String 3 not in allowed values", stringAllowedValues.contains("String 3"));
-		
+
 		assertEquals("Default values should be \"String 1\"", "String 1", allowedValuesStringProperty.getDefaultValueObject());
 
 		Property allowedValuesIntProperty = s.getProperty(new URI("http://example.com/shapes/allowedValuesIntProperty"));
@@ -65,10 +65,10 @@ public class ShapeTest {
 
 		Collection<?> intAllowedValues = allowedValuesIntProperty.getAllowedValuesCollection();
 		assertEquals("Wrong number of allowedValues for allowedValuesIntProperty", 2, intAllowedValues.size());
-		assertTrue("27 not in allowed values", intAllowedValues.contains(new Integer(27)));
-		assertTrue("32 not in allowed values", intAllowedValues.contains(new Integer(32)));
+		assertTrue("27 not in allowed values", intAllowedValues.contains(Integer.valueOf(27)));
+		assertTrue("32 not in allowed values", intAllowedValues.contains(Integer.valueOf(32)));
 
-		assertEquals("Default values should be 27", new Integer(27), allowedValuesIntProperty.getDefaultValueObject());
+		assertEquals("Default values should be 27", Integer.valueOf(27), allowedValuesIntProperty.getDefaultValueObject());
 	}
 
 	@SuppressWarnings("deprecation")
@@ -77,7 +77,7 @@ public class ShapeTest {
 		OslcTurtleProvider provider = new OslcTurtleProvider();
 		InputStream is = ServiceProviderTest.class.getResourceAsStream("/allowedValuesResource.ttl");
 		assertNotNull("Could not read file: /allowedValuesResource.ttl", is);
-		
+
 		// Make sure the content is properly interpreted as Turtle if the media type is "text/turtle;charset=UTF-8"
 		@SuppressWarnings({ "unchecked", "rawtypes" })
 		AllowedValues allowedValues = (AllowedValues) provider.readFrom((Class) AllowedValues.class,
@@ -87,7 +87,7 @@ public class ShapeTest {
 				null,
 				is);
 		assertNotNull("Allowed values is null", allowedValues);
-		
+
 		Collection<?> uriAllowedValues = allowedValues.getValues();
 		assertEquals("Wrong number of allowedValues for allowedValuesUriProperty property", 2, uriAllowedValues.size());
 		assertTrue("uri1 not in allowed values", uriAllowedValues.contains(new URI("http://example.com/ns#uri1")));
@@ -102,10 +102,10 @@ public class ShapeTest {
 	public void testAllowedValuesBackwardsCompatibility() throws Exception {
 		ResourceShape s = readResourceShape("/allowedValues.ttl");
 		assertNotNull("Shape is null", s);
-		
+
 		Property allowedValuesUriProperty = s.getProperty(new URI("http://example.com/shapes/allowedValuesUriProperty"));
 		assertNotNull("http://example.com/shapes/allowedValuesUriProperty property not in shape", allowedValuesUriProperty);
-		
+
 		assertEquals("Old getAllowedValues() method should return 0 results since it only looks for strings", 0, allowedValuesUriProperty.getAllowedValues().length);
 		assertNull("Old getDefaultValue() method should return null if default value is not a string", allowedValuesUriProperty.getDefaultValue());
 
@@ -133,7 +133,7 @@ public class ShapeTest {
 		OslcTurtleProvider provider = new OslcTurtleProvider();
 		InputStream is = ServiceProviderTest.class.getResourceAsStream(turtleFile);
 		assertNotNull("Could not read file: " + turtleFile, is);
-		
+
 		// Make sure the content is properly interpreted as Turtle if the media type is "text/turtle;charset=UTF-8"
 		ResourceShape s = (ResourceShape) provider.readFrom((Class) ResourceShape.class,
 				null,

--- a/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/AbstractOslcRdfJsonProvider.java
+++ b/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/AbstractOslcRdfJsonProvider.java
@@ -38,6 +38,7 @@ import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.exception.MessageExtractor;
 import org.eclipse.lyo.oslc4j.core.model.Error;
+import org.eclipse.lyo.oslc4j.core.model.IResource;
 import org.eclipse.lyo.oslc4j.core.model.ResponseInfo;
 import org.eclipse.lyo.oslc4j.core.model.ResponseInfoArray;
 
@@ -61,42 +62,15 @@ public abstract class AbstractOslcRdfJsonProvider
 		super();
 	}
 
-	protected static boolean isWriteable(final Class<?>		type,
+	protected static boolean isWriteable(final Class<?>		klass,
 										 final Annotation[] annotations,
 										 final MediaType	requiredMediaType,
 										 final MediaType	actualMediaType)
 	{
-		if (type.getAnnotation(OslcResourceShape.class) != null)
-		{
-			// When handling "recursive" writing of an OSLC Error object, we get a zero-length array of annotations
-			if ((annotations != null) &&
-				((annotations.length > 0) ||
-				 (Error.class != type)))
-			{
-				for (final Annotation annotation : annotations)
-				{
-					if (annotation instanceof Produces)
-					{
-						final Produces producesAnnotation = (Produces) annotation;
-
-						for (final String value : producesAnnotation.value())
-						{
-							if (requiredMediaType.isCompatible(MediaType.valueOf(value)))
-							{
-								return true;
-							}
-						}
-					}
-				}
-
-				return false;
-			}
-
-			// We do not have annotations when running from the non-web client.
-			return requiredMediaType.isCompatible(actualMediaType);
-		}
-
-		return false;
+        // we leave media type and annotation checks to Jersey &c.
+        boolean hasOslcResourceShapeAnnot = klass.getAnnotation(OslcResourceShape.class) != null;
+        boolean subclassOfIResource = IResource.class.isAssignableFrom(klass);
+        return hasOslcResourceShapeAnnot || subclassOfIResource;
 	}
 
 	protected void writeTo(final boolean						queryResult,

--- a/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonCollectionProvider.java
+++ b/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonCollectionProvider.java
@@ -46,6 +46,7 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
+import org.eclipse.lyo.oslc4j.core.CoreHelper;
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,24 +86,20 @@ public class OslcRdfJsonCollectionProvider
 							   final Annotation[] annotations,
 							   final MediaType	  mediaType)
 	{
-		if ((Collection.class.isAssignableFrom(type)) &&
-			(genericType instanceof ParameterizedType)) {
+		if (Collection.class.isAssignableFrom(type) && (genericType instanceof ParameterizedType)) {
 			final ParameterizedType parameterizedType = (ParameterizedType) genericType;
-
 			final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
 
 			if (actualTypeArguments.length == 1) {
 				final Type actualTypeArgument = actualTypeArguments[0];
 
-				if (actualTypeArgument instanceof Class) {
-					return isWriteable((Class<?>) actualTypeArgument,
-									   annotations,
-									   OslcMediaType.APPLICATION_JSON_TYPE,
-									   mediaType);
-				} else if (actualTypeArgument instanceof TypeVariable) {
-                    log.error("GenericEntity<?>-based capture of entity generic type is not supported");
-                    return false;
-                }
+				if (actualTypeArgument instanceof Class || actualTypeArgument instanceof TypeVariable) {
+                    return isWriteable(CoreHelper.getActualTypeArgument(actualTypeArgument),
+                        annotations,
+                        OslcMediaType.APPLICATION_JSON_TYPE,
+                        mediaType);
+				}
+                return false;
             }
 		}
 

--- a/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonCollectionProvider.java
+++ b/core/oslc4j-json4j-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonCollectionProvider.java
@@ -19,6 +19,7 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.net.URI;
 import java.util.AbstractCollection;
 import java.util.AbstractList;
@@ -46,6 +47,8 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Use JSON-LD support in Jena provider.
@@ -59,7 +62,9 @@ public class OslcRdfJsonCollectionProvider
 	   implements MessageBodyReader<Collection<Object>>,
 				  MessageBodyWriter<Collection<Object>>
 {
-	public OslcRdfJsonCollectionProvider()
+    private final static Logger log = LoggerFactory.getLogger(OslcRdfJsonCollectionProvider.class);
+
+    public OslcRdfJsonCollectionProvider()
 	{
 		super();
 	}
@@ -81,24 +86,24 @@ public class OslcRdfJsonCollectionProvider
 							   final MediaType	  mediaType)
 	{
 		if ((Collection.class.isAssignableFrom(type)) &&
-			(genericType instanceof ParameterizedType))
-		{
+			(genericType instanceof ParameterizedType)) {
 			final ParameterizedType parameterizedType = (ParameterizedType) genericType;
 
 			final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
 
-			if (actualTypeArguments.length == 1)
-			{
+			if (actualTypeArguments.length == 1) {
 				final Type actualTypeArgument = actualTypeArguments[0];
 
-				if (actualTypeArgument instanceof Class)
-				{
+				if (actualTypeArgument instanceof Class) {
 					return isWriteable((Class<?>) actualTypeArgument,
 									   annotations,
 									   OslcMediaType.APPLICATION_JSON_TYPE,
 									   mediaType);
-				}
-			}
+				} else if (actualTypeArgument instanceof TypeVariable) {
+                    log.error("GenericEntity<?>-based capture of entity generic type is not supported");
+                    return false;
+                }
+            }
 		}
 
 		return false;
@@ -126,26 +131,20 @@ public class OslcRdfJsonCollectionProvider
 	public boolean isReadable(final Class<?>	 type,
 							  final Type		 genericType,
 							  final Annotation[] annotations,
-							  final MediaType	 mediaType)
-	{
+							  final MediaType	 mediaType) {
 		if ((Collection.class.isAssignableFrom(type)) &&
-			(genericType instanceof ParameterizedType))
-		{
+			(genericType instanceof ParameterizedType)) {
 			final ParameterizedType parameterizedType = (ParameterizedType) genericType;
 
 			final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
 
-			if (actualTypeArguments.length == 1)
-			{
+			if (actualTypeArguments.length == 1) {
 				final Type actualTypeArgument = actualTypeArguments[0];
 
-				if (URI.class.equals((Class<?>) actualTypeArgument)
-						&& (OslcMediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType)))
-				{
+				if (URI.class.equals(actualTypeArgument)
+						&& (OslcMediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType))) {
 					return true;
-				}
-				else
-				{
+				} else {
 					return isReadable((Class<?>) actualTypeArgument,
 									  OslcMediaType.APPLICATION_JSON_TYPE,
 									  mediaType);

--- a/core/shacl/src/main/java/org/eclipse/lyo/shacl/package-info.java
+++ b/core/shacl/src/main/java/org/eclipse/lyo/shacl/package-info.java
@@ -16,7 +16,7 @@
  * @since 2.3.0
  */
 
-@OslcSchema({@OslcNamespaceDefinition(prefix = OslcConstants.DCTERMS_NAMESPACE_PREFIX,
+/** */@OslcSchema({@OslcNamespaceDefinition(prefix = OslcConstants.DCTERMS_NAMESPACE_PREFIX,
                                       namespaceURI = OslcConstants.DCTERMS_NAMESPACE),
                     @OslcNamespaceDefinition(
         prefix = OslcConstants.OSLC_CORE_NAMESPACE_PREFIX,

--- a/pom.xml
+++ b/pom.xml
@@ -448,6 +448,10 @@
                 <name>OslcNamespaceDefinition</name>
                 <placement>X</placement>
               </tag>
+              <tag>
+                <name>Deprecated</name>
+                <placement>X</placement>
+              </tag>
             </tags>
             <!--            <doclint>none</doclint>-->
             <doclint>all,-accessibility,-html,-missing</doclint>

--- a/pom.xml
+++ b/pom.xml
@@ -439,8 +439,13 @@
           <version>3.3.2</version>
           <configuration>
             <tags>
+              <!-- See https://stackoverflow.com/questions/55906161/weird-javadoc-error-with-jdk12-for-osgi-version-annotation -->
               <tag>
                 <name>OslcSchema</name>
+                <placement>X</placement>
+              </tag>
+              <tag>
+                <name>OslcNamespaceDefinition</name>
                 <placement>X</placement>
               </tag>
             </tags>

--- a/pom.xml
+++ b/pom.xml
@@ -438,7 +438,13 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.3.2</version>
           <configuration>
-<!--            <doclint>none</doclint>-->
+            <tags>
+              <tag>
+                <name>OslcSchema</name>
+                <placement>X</placement>
+              </tag>
+            </tags>
+            <!--            <doclint>none</doclint>-->
             <doclint>all,-accessibility,-html,-missing</doclint>
             <links>
               <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>


### PR DESCRIPTION
## Description

When we want to return a Response instead of a `Collection<AbstractResource>`, we need to use `ResponseBuilder.entity()` method to pass the entity. The generic signature is not preserved this way. The suggested way to solve this is to wrap the entity with a `GenericEntity`.

Unfortunately, this changes the type of the generic arguments as seen by JAX-RS Providers from `Class` to `TypeVariable`. This PR enables RDF-based providers to handle both kinds. It also adds error log statements for the JSON Provider that the `TypeVariable` support is missing.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

N/A