### PR TITLE
build: set source code level to Java 11, match bytecode target

### DIFF
--- a/client/oslc-client-base/src/main/java/org/eclipse/lyo/client/exception/JazzAuthErrorException.java
+++ b/client/oslc-client-base/src/main/java/org/eclipse/lyo/client/exception/JazzAuthErrorException.java
@@ -30,7 +30,7 @@ public class JazzAuthErrorException extends OslcClientApplicationException {
 	private final String jazzUrl;
 
 	public JazzAuthErrorException(final int status, final String jazzUrl) {
-		super(MESSAGE_KEY, new Object[] {new Integer(status), jazzUrl});
+		super(MESSAGE_KEY, new Object[] {status, jazzUrl});
 		this.status = status;
 		this.jazzUrl = jazzUrl;
 	}

--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/query/OslcQueryResult.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/query/OslcQueryResult.java
@@ -250,33 +250,34 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 
         Selector select = getMemberSelector();
         final StmtIterator iter = rdfModel.listStatements(select);
-        Iterable<T> result = new Iterable<T>() {
-                public Iterator<T>
-                iterator() {
-                    return new Iterator<T>() {
-                            public boolean hasNext() {
-                                return iter.hasNext();
-                            }
+        Iterable<T> result = new Iterable<>() {
+            public Iterator<T>
+            iterator() {
+                return new Iterator<>() {
+                    public boolean hasNext() {
+                        return iter.hasNext();
+                    }
 
-                            @SuppressWarnings("unchecked")
-                            public T next() {
-                                Statement member = iter.next();
+                    @SuppressWarnings("unchecked")
+                    public T next() {
+                        Statement member = iter.next();
 
-                                try {
-                                    return (T)JenaModelHelper.fromJenaResource((Resource)member.getObject(), clazz);
-                                } catch (DatatypeConfigurationException | IllegalAccessException |
-                                         InvocationTargetException | InstantiationException | OslcCoreApplicationException
-                                         | NoSuchMethodException | URISyntaxException e) {
-                                    throw new LyoModelException(e);
-                                }
-                            }
+                        try {
+                            return (T) JenaModelHelper.fromJenaResource((Resource) member.getObject(), clazz);
+                        } catch (DatatypeConfigurationException | IllegalAccessException |
+                                 InvocationTargetException | InstantiationException |
+                                 OslcCoreApplicationException
+                                 | NoSuchMethodException | URISyntaxException e) {
+                            throw new LyoModelException(e);
+                        }
+                    }
 
-                            public void remove() {
-                                iter.remove();
-                            }
-                        };
-                }
-            };
+                    public void remove() {
+                        iter.remove();
+                    }
+                };
+            }
+        };
 
         return result;
     }
@@ -291,33 +292,31 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 
         Selector select = getMemberSelector();
         final StmtIterator iter = rdfModel.listStatements(select);
-        Iterable<Resource> result = new Iterable<Resource>() {
-                public Iterator<Resource>
-                iterator() {
-                    return new Iterator<Resource>() {
-                            public boolean hasNext() {
-                                return iter.hasNext();
-                            }
+        Iterable<Resource> result = new Iterable<>() {
+            public Iterator<Resource>
+            iterator() {
+                return new Iterator<>() {
+                    public boolean hasNext() {
+                        return iter.hasNext();
+                    }
 
-                            @SuppressWarnings("unchecked")
-                            public Resource next() {
-                                Statement member = iter.next();
+                    @SuppressWarnings("unchecked")
+                    public Resource next() {
+                        Statement member = iter.next();
 
-                                try {
-                                    return (Resource)member.getObject();
-                                } catch (IllegalArgumentException e) {
-                                   throw new IllegalStateException(e.getMessage());
-                                } catch (SecurityException e) {
-                                    throw new IllegalStateException(e.getMessage());
-                                }
-                            }
+                        try {
+                            return (Resource) member.getObject();
+                        } catch (IllegalArgumentException | SecurityException e) {
+                            throw new IllegalStateException(e);
+                        }
+                    }
 
-                            public void remove() {
-                                iter.remove();
-                            }
-                        };
-                }
-            };
+                    public void remove() {
+                        iter.remove();
+                    }
+                };
+            }
+        };
 
         return result;
     }

--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/query/OslcQueryResult.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/query/OslcQueryResult.java
@@ -250,32 +250,27 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 
         Selector select = getMemberSelector();
         final StmtIterator iter = rdfModel.listStatements(select);
-        Iterable<T> result = new Iterable<>() {
-            public Iterator<T>
-            iterator() {
-                return new Iterator<>() {
-                    public boolean hasNext() {
-                        return iter.hasNext();
-                    }
+        Iterable<T> result = () -> new Iterator<>() {
+            public boolean hasNext() {
+                return iter.hasNext();
+            }
 
-                    @SuppressWarnings("unchecked")
-                    public T next() {
-                        Statement member = iter.next();
+            @SuppressWarnings("unchecked")
+            public T next() {
+                Statement member = iter.next();
 
-                        try {
-                            return (T) JenaModelHelper.fromJenaResource((Resource) member.getObject(), clazz);
-                        } catch (DatatypeConfigurationException | IllegalAccessException |
-                                 InvocationTargetException | InstantiationException |
-                                 OslcCoreApplicationException
-                                 | NoSuchMethodException | URISyntaxException e) {
-                            throw new LyoModelException(e);
-                        }
-                    }
+                try {
+                    return (T) JenaModelHelper.fromJenaResource((Resource) member.getObject(), clazz);
+                } catch (DatatypeConfigurationException | IllegalAccessException |
+                         InvocationTargetException | InstantiationException |
+                         OslcCoreApplicationException
+                         | NoSuchMethodException | URISyntaxException e) {
+                    throw new LyoModelException(e);
+                }
+            }
 
-                    public void remove() {
-                        iter.remove();
-                    }
-                };
+            public void remove() {
+                iter.remove();
             }
         };
 
@@ -292,29 +287,24 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 
         Selector select = getMemberSelector();
         final StmtIterator iter = rdfModel.listStatements(select);
-        Iterable<Resource> result = new Iterable<>() {
-            public Iterator<Resource>
-            iterator() {
-                return new Iterator<>() {
-                    public boolean hasNext() {
-                        return iter.hasNext();
-                    }
+        Iterable<Resource> result = () -> new Iterator<>() {
+            public boolean hasNext() {
+                return iter.hasNext();
+            }
 
-                    @SuppressWarnings("unchecked")
-                    public Resource next() {
-                        Statement member = iter.next();
+            @SuppressWarnings("unchecked")
+            public Resource next() {
+                Statement member = iter.next();
 
-                        try {
-                            return (Resource) member.getObject();
-                        } catch (IllegalArgumentException | SecurityException e) {
-                            throw new IllegalStateException(e);
-                        }
-                    }
+                try {
+                    return (Resource) member.getObject();
+                } catch (IllegalArgumentException | SecurityException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
 
-                    public void remove() {
-                        iter.remove();
-                    }
-                };
+            public void remove() {
+                iter.remove();
             }
         };
 

--- a/core/oslc4j-core-wink/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/JsonHelper.java
+++ b/core/oslc4j-core-wink/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/JsonHelper.java
@@ -1748,11 +1748,9 @@ public final class JsonHelper
 		{
 			final JSONArray jsonArray = (JSONArray) jsonValue;
 			final ArrayList<Object> collection = new ArrayList<>();
-			final Iterator<?> i = jsonArray.iterator();
-			while (i.hasNext())
-			{
-				collection.add(fromExtendedJSONValue(i.next(), rdfPrefix, jsonNamespaceMappings, beanClass, propertyQName, rdfTypes));
-			}
+            for (Object o : jsonArray) {
+                collection.add(fromExtendedJSONValue(o, rdfPrefix, jsonNamespaceMappings, beanClass, propertyQName, rdfTypes));
+            }
 
 			return collection;
 		}

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/CoreHelper.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/CoreHelper.java
@@ -13,7 +13,7 @@ public class CoreHelper {
         if (type instanceof Class) {
             return (Class<?>) type;
         } else if (type instanceof TypeVariable) {
-            return (Class<?>) ((TypeVariable)type).getBounds()[0];
+            return (Class<?>) ((TypeVariable<?>)type).getBounds()[0];
         }
         throw new IllegalArgumentException("You must pass either a Class or a (generic) TypeVariable");
     }

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreDeregistrationException.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreDeregistrationException.java
@@ -25,7 +25,7 @@ public final class OslcCoreDeregistrationException extends OslcCoreApplicationEx
 	private final int	 statusCode;
 
 	public OslcCoreDeregistrationException(final URI serviceProviderURI, final int statusCode, final String responseMessage) {
-		super(MESSAGE_KEY, new Object[] {serviceProviderURI.toString(), Integer.valueOf(statusCode), responseMessage});
+		super(MESSAGE_KEY, new Object[] {serviceProviderURI.toString(), statusCode, responseMessage});
 
 		this.responseMessage	= responseMessage;
 		this.serviceProviderURI = serviceProviderURI;

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreRegistrationException.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreRegistrationException.java
@@ -25,7 +25,7 @@ public final class OslcCoreRegistrationException extends OslcCoreApplicationExce
 	private final int			  statusCode;
 
 	public OslcCoreRegistrationException(final ServiceProvider serviceProvider, final int statusCode, final String responseMessage) {
-		super(MESSAGE_KEY, new Object[] {serviceProvider.getTitle(), Integer.valueOf(statusCode), responseMessage});
+		super(MESSAGE_KEY, new Object[] {serviceProvider.getTitle(), statusCode, responseMessage});
 
 		this.responseMessage = responseMessage;
 		this.serviceProvider = serviceProvider;

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
@@ -270,22 +270,22 @@ public class ResourceShapeFactory {
 
 		final OslcHidden hiddenAnnotation = InheritedMethodAnnotationHelper.getAnnotation(method, OslcHidden.class);
 		if (hiddenAnnotation != null) {
-			property.setHidden(Boolean.valueOf(hiddenAnnotation.value()));
+			property.setHidden(hiddenAnnotation.value());
 		}
 
 		final OslcMemberProperty memberPropertyAnnotation = InheritedMethodAnnotationHelper.getAnnotation(method, OslcMemberProperty.class);
 		if (memberPropertyAnnotation != null) {
-			property.setMemberProperty(Boolean.valueOf(memberPropertyAnnotation.value()));
+			property.setMemberProperty(memberPropertyAnnotation.value());
 		}
 
 		final OslcReadOnly readOnlyAnnotation = InheritedMethodAnnotationHelper.getAnnotation(method, OslcReadOnly.class);
 		if (readOnlyAnnotation != null) {
-			property.setReadOnly(Boolean.valueOf(readOnlyAnnotation.value()));
+			property.setReadOnly(readOnlyAnnotation.value());
 		}
 
 		final OslcMaxSize maxSizeAnnotation = InheritedMethodAnnotationHelper.getAnnotation(method, OslcMaxSize.class);
 		if (maxSizeAnnotation != null) {
-			property.setMaxSize(Integer.valueOf(maxSizeAnnotation.value()));
+			property.setMaxSize(maxSizeAnnotation.value());
 		}
 
 		final OslcValueShape valueShapeAnnotation = InheritedMethodAnnotationHelper.getAnnotation(method, OslcValueShape.class);

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaModelHelper.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaModelHelper.java
@@ -966,14 +966,7 @@ public final class JenaModelHelper
 
                         if (multiple)
                         {
-                            List<Object> values = propertyDefinitionsToArrayValues.get(uri);
-                            if (values == null)
-                            {
-                                values = new ArrayList<>();
-
-                                propertyDefinitionsToArrayValues.put(uri,
-                                        values);
-                            }
+                            List<Object> values = propertyDefinitionsToArrayValues.computeIfAbsent(uri, k -> new ArrayList<>());
 
                             values.add(parameter);
                         }

--- a/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackages.java
+++ b/core/oslc4j-core/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackages.java
@@ -78,11 +78,7 @@ public class ResourcePackages {
                             Class<?> rdfClass = Class.forName(classInfo.getName(), true,
                                 Thread.currentThread().getContextClassLoader());
                             String rdfType = TypeFactory.getQualifiedName(rdfClass);
-                            List<Class<?>> types = TYPES_MAPPINGS.get(rdfType);
-                            if (types == null) {
-                                types = new ArrayList<>();
-                                TYPES_MAPPINGS.put(rdfType, types);
-                            }
+                            List<Class<?>> types = TYPES_MAPPINGS.computeIfAbsent(rdfType, k -> new ArrayList<>());
                             types.add(rdfClass);
                             counter ++;
                             LOGGER.trace("[+] {} -> {}", rdfType, rdfClass);
@@ -109,13 +105,7 @@ public class ResourcePackages {
         int index = 0;
         do {
             Class<?> pivot = candidates.get(index);
-            Iterator<Class<?>> iterator = candidates.iterator();
-            while(iterator.hasNext()) {
-                Class<?> current = iterator.next();
-                if (!current.equals(pivot) && current.isAssignableFrom(pivot)) {
-                    iterator.remove();
-                }
-            }
+            candidates.removeIf(current -> !current.equals(pivot) && current.isAssignableFrom(pivot));
             size = candidates.size();
         } while(++index < size);
         if (candidates.size() > 1) {

--- a/core/oslc4j-core/src/test/java/org/eclipse/lyo/oslc4j/core/model/LinkTest.java
+++ b/core/oslc4j-core/src/test/java/org/eclipse/lyo/oslc4j/core/model/LinkTest.java
@@ -52,12 +52,12 @@ public class LinkTest {
     @Test
     public void testEqualsWorksInHashSet() throws Exception {
 
-        Set<Link> setA = new HashSet<Link>() {{
+        Set<Link> setA = new HashSet<>() {{
             this.add(new Link(URI.create(URI_A), LABEL_A));
             this.add(new Link(URI.create(URI_B), LABEL_B));
         }};
 
-        Set<Link> setB = new HashSet<Link>() {{
+        Set<Link> setB = new HashSet<>() {{
             this.add(new Link(URI.create(URI_B), LABEL_B));
             this.add(new Link(URI.create(URI_A), LABEL_A));
         }};
@@ -68,12 +68,12 @@ public class LinkTest {
     @Test
     public void testEqualsWorksInHashSetWhenDifferent() throws Exception {
 
-        Set<Link> setA = new HashSet<Link>() {{
+        Set<Link> setA = new HashSet<>() {{
             this.add(new Link(URI.create(URI_A), LABEL_A));
             this.add(new Link(URI.create(URI_B), LABEL_B));
         }};
 
-        Set<Link> setB = new HashSet<Link>() {{
+        Set<Link> setB = new HashSet<>() {{
             this.add(new Link(URI.create(URI_A)));
         }};
 

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ErrorHandler.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ErrorHandler.java
@@ -46,11 +46,11 @@ public final class ErrorHandler
 	public void warning(final Exception exception)
 	{
 		Level level = Level.WARNING;
-		
+
 		//Workaround to avoid flooding the logs with Jena warnings about using
 		//relative URIs with no base URI.  Common for reified statements in OSLC
 		String msg = exception.getMessage();
-		if (msg != null && (msg.indexOf(JENA_RELATIVE_URI_WARNING_ID) >= 0))
+		if (msg != null && (msg.contains(JENA_RELATIVE_URI_WARNING_ID)))
 		{
 			level=Level.FINE;
 		}
@@ -58,7 +58,7 @@ public final class ErrorHandler
 		logger.log(level,
 				"Warning in Jena handling",
 				exception);
-			
+
 	}
 
 	private static void handleException(final Exception exception)

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ProviderHelper.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ProviderHelper.java
@@ -27,8 +27,8 @@ final class ProviderHelper {
 
     static boolean hasOslcQueryCapabilityMethodAnnot(final Annotation[] annotations) {
         if (annotations != null) {
-            for (int i = 0; i < annotations.length; i++) {
-                if (annotations[i] != null && annotations[i] instanceof OslcQueryCapability) {
+            for (Annotation annotation : annotations) {
+                if (annotation != null && annotation instanceof OslcQueryCapability) {
                     return true;
                 }
             }

--- a/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/RdfXmlAbbreviatedWriter.java
+++ b/core/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/RdfXmlAbbreviatedWriter.java
@@ -186,7 +186,7 @@ public class RdfXmlAbbreviatedWriter implements RDFWriterI {
 			else if(propValue instanceof String){
 
 				try {
-					tab = Integer.valueOf(((String) (propValue)));
+					tab = Integer.parseInt(((String) (propValue)));
 				}
 				catch (NumberFormatException n) {
 
@@ -206,7 +206,7 @@ public class RdfXmlAbbreviatedWriter implements RDFWriterI {
 			else if(propValue instanceof String){
 
 				try {
-					indent = Integer.valueOf(((String) (propValue)));
+					indent = Integer.parseInt(((String) (propValue)));
 				}
 				catch (NumberFormatException n) {
 

--- a/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/ShapeTest.java
+++ b/core/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/ShapeTest.java
@@ -65,10 +65,10 @@ public class ShapeTest {
 
 		Collection<?> intAllowedValues = allowedValuesIntProperty.getAllowedValuesCollection();
 		assertEquals("Wrong number of allowedValues for allowedValuesIntProperty", 2, intAllowedValues.size());
-		assertTrue("27 not in allowed values", intAllowedValues.contains(Integer.valueOf(27)));
-		assertTrue("32 not in allowed values", intAllowedValues.contains(Integer.valueOf(32)));
+		assertTrue("27 not in allowed values", intAllowedValues.contains(27));
+		assertTrue("32 not in allowed values", intAllowedValues.contains(32));
 
-		assertEquals("Default values should be 27", Integer.valueOf(27), allowedValuesIntProperty.getDefaultValueObject());
+		assertEquals("Default values should be 27", 27, allowedValuesIntProperty.getDefaultValueObject());
 	}
 
 	@SuppressWarnings("deprecation")

--- a/core/oslc4j-json4j-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcJsonProviderCollectionTest.java
+++ b/core/oslc4j-json4j-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcJsonProviderCollectionTest.java
@@ -101,7 +101,8 @@ public class OslcJsonProviderCollectionTest extends JerseyTest {
 
         assertThat(response.getStatusInfo().getFamily()).isEqualTo(
             Response.Status.Family.SUCCESSFUL);
-        List<TestResource> rdfResponse = response.readEntity(new GenericType<List<TestResource>>() {});
+        List<TestResource> rdfResponse = response.readEntity(new GenericType<>() {
+        });
         String rdfResponseString = response.readEntity(String.class);
         JSONObject responseJSON = new JSONObject(rdfResponseString);
         Object[] objects = JsonHelper.fromJSON(responseJSON, TestResource.class);

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/LinkType.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/LinkType.java
@@ -81,13 +81,13 @@ public class LinkType
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:identifier
     // End of user code
     private String identifier;
@@ -96,17 +96,17 @@ public class LinkType
     private Date modified;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:comment
     // End of user code
     private String comment;
     // Start of user code attributeAnnotation:label
     // End of user code
     private String label;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -114,38 +114,38 @@ public class LinkType
     public LinkType()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public LinkType(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_amDomainConstants.LINKTYPE_PATH,
         LinkType.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local LinkType Resource} - update LinkType.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -154,36 +154,36 @@ public class LinkType
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         result = String.format("%s (LinkType; id=%s)", this.getLabel(), this.getIdentifier());
 
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Resource.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/am/Resource.java
@@ -80,13 +80,13 @@ public class Resource
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -104,35 +104,35 @@ public class Resource
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<String> type = new HashSet<String>();
+    private Set<String> type = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:shortTitle
     // End of user code
     private String shortTitle;
     // Start of user code attributeAnnotation:external
     // End of user code
-    private Set<Link> external = new HashSet<Link>();
+    private Set<Link> external = new HashSet<>();
     // Start of user code attributeAnnotation:trace
     // End of user code
-    private Set<Link> trace = new HashSet<Link>();
+    private Set<Link> trace = new HashSet<>();
     // Start of user code attributeAnnotation:refine
     // End of user code
-    private Set<Link> refine = new HashSet<Link>();
+    private Set<Link> refine = new HashSet<>();
     // Start of user code attributeAnnotation:derives
     // End of user code
-    private Set<Link> derives = new HashSet<Link>();
+    private Set<Link> derives = new HashSet<>();
     // Start of user code attributeAnnotation:elaborates
     // End of user code
-    private Set<Link> elaborates = new HashSet<Link>();
+    private Set<Link> elaborates = new HashSet<>();
     // Start of user code attributeAnnotation:satisfy
     // End of user code
-    private Set<Link> satisfy = new HashSet<Link>();
-    
+    private Set<Link> satisfy = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -140,38 +140,38 @@ public class Resource
     public Resource()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public Resource(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_amDomainConstants.RESOURCE_PATH,
         Resource.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local Resource Resource} - update Resource.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -180,69 +180,69 @@ public class Resource
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addType(final String type)
     {
         this.type.add(type);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addExternal(final Link external)
     {
         this.external.add(external);
     }
-    
+
     public void addTrace(final Link trace)
     {
         this.trace.add(trace);
     }
-    
+
     public void addRefine(final Link refine)
     {
         this.refine.add(refine);
     }
-    
+
     public void addDerives(final Link derives)
     {
         this.derives.add(derives);
     }
-    
+
     public void addElaborates(final Link elaborates)
     {
         this.elaborates.add(elaborates);
     }
-    
+
     public void addSatisfy(final Link satisfy)
     {
         this.satisfy.add(satisfy);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationPlan.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationPlan.java
@@ -82,13 +82,13 @@ public class AutomationPlan
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -100,29 +100,29 @@ public class AutomationPlan
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:parameterDefinition
     // End of user code
-    private Set<Link> parameterDefinition = new HashSet<Link>();
+    private Set<Link> parameterDefinition = new HashSet<>();
     // Start of user code attributeAnnotation:usesExecutionEnvironment
     // End of user code
-    private Set<Link> usesExecutionEnvironment = new HashSet<Link>();
+    private Set<Link> usesExecutionEnvironment = new HashSet<>();
     // Start of user code attributeAnnotation:futureAction
     // End of user code
-    private Set<Link> futureAction = new HashSet<Link>();
-    
+    private Set<Link> futureAction = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -130,38 +130,38 @@ public class AutomationPlan
     public AutomationPlan()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public AutomationPlan(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_autoDomainConstants.AUTOMATIONPLAN_PATH,
         AutomationPlan.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local AutomationPlan Resource} - update AutomationPlan.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -170,59 +170,59 @@ public class AutomationPlan
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addParameterDefinition(final Link parameterDefinition)
     {
         this.parameterDefinition.add(parameterDefinition);
     }
-    
+
     public void addUsesExecutionEnvironment(final Link usesExecutionEnvironment)
     {
         this.usesExecutionEnvironment.add(usesExecutionEnvironment);
     }
-    
+
     public void addFutureAction(final Link futureAction)
     {
         this.futureAction.add(futureAction);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationRequest.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationRequest.java
@@ -84,13 +84,13 @@ public class AutomationRequest
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -102,29 +102,29 @@ public class AutomationRequest
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:state
     // End of user code
-    private Set<Link> state = new HashSet<Link>();
+    private Set<Link> state = new HashSet<>();
     // Start of user code attributeAnnotation:desiredState
     // End of user code
     private Link desiredState;
     // Start of user code attributeAnnotation:inputParameter
     // End of user code
-    private Set<Link> inputParameter = new HashSet<Link>();
+    private Set<Link> inputParameter = new HashSet<>();
     // Start of user code attributeAnnotation:executesAutomationPlan
     // End of user code
     private Link executesAutomationPlan;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -132,38 +132,38 @@ public class AutomationRequest
     public AutomationRequest()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public AutomationRequest(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_autoDomainConstants.AUTOMATIONREQUEST_PATH,
         AutomationRequest.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local AutomationRequest Resource} - update AutomationRequest.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -172,49 +172,49 @@ public class AutomationRequest
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addState(final Link state)
     {
         this.state.add(state);
     }
-    
+
     public void addInputParameter(final Link inputParameter)
     {
         this.inputParameter.add(inputParameter);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationResult.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/AutomationResult.java
@@ -85,13 +85,13 @@ public class AutomationResult
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:identifier
     // End of user code
     private String identifier;
@@ -100,44 +100,44 @@ public class AutomationResult
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:state
     // End of user code
-    private Set<Link> state = new HashSet<Link>();
+    private Set<Link> state = new HashSet<>();
     // Start of user code attributeAnnotation:desiredState
     // End of user code
     private Link desiredState;
     // Start of user code attributeAnnotation:verdict
     // End of user code
-    private Set<Link> verdict = new HashSet<Link>();
+    private Set<Link> verdict = new HashSet<>();
     // Start of user code attributeAnnotation:contribution
     // End of user code
-    private Set<Link> contribution = new HashSet<Link>();
+    private Set<Link> contribution = new HashSet<>();
     // Start of user code attributeAnnotation:inputParameter
     // End of user code
-    private Set<Link> inputParameter = new HashSet<Link>();
+    private Set<Link> inputParameter = new HashSet<>();
     // Start of user code attributeAnnotation:outputParameter
     // End of user code
-    private Set<Link> outputParameter = new HashSet<Link>();
+    private Set<Link> outputParameter = new HashSet<>();
     // Start of user code attributeAnnotation:producedByAutomationRequest
     // End of user code
     private Link producedByAutomationRequest;
     // Start of user code attributeAnnotation:reportsOnAutomationPlan
     // End of user code
     private Link reportsOnAutomationPlan;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -145,38 +145,38 @@ public class AutomationResult
     public AutomationResult()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public AutomationResult(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_autoDomainConstants.AUTOMATIONRESULT_PATH,
         AutomationResult.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local AutomationResult Resource} - update AutomationResult.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -185,69 +185,69 @@ public class AutomationResult
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addState(final Link state)
     {
         this.state.add(state);
     }
-    
+
     public void addVerdict(final Link verdict)
     {
         this.verdict.add(verdict);
     }
-    
+
     public void addContribution(final Link contribution)
     {
         this.contribution.add(contribution);
     }
-    
+
     public void addInputParameter(final Link inputParameter)
     {
         this.inputParameter.add(inputParameter);
     }
-    
+
     public void addOutputParameter(final Link outputParameter)
     {
         this.outputParameter.add(outputParameter);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/ParameterInstance.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/auto/ParameterInstance.java
@@ -90,14 +90,14 @@ public class ParameterInstance
     private String description;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
-    
+    private Set<Link> serviceProvider = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -105,38 +105,38 @@ public class ParameterInstance
     public ParameterInstance()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public ParameterInstance(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_autoDomainConstants.PARAMETERINSTANCE_PATH,
         ParameterInstance.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local ParameterInstance Resource} - update ParameterInstance.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -145,29 +145,29 @@ public class ParameterInstance
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:name
     // End of user code
     @OslcName("name")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ChangeRequest.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/cm/ChangeRequest.java
@@ -104,13 +104,13 @@ public class ChangeRequest
     private String identifier;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
@@ -119,10 +119,10 @@ public class ChangeRequest
     private Date modified;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:discussedBy
     // End of user code
     private Link discussedBy;
@@ -152,38 +152,38 @@ public class ChangeRequest
     private Boolean verified;
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private Set<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:affectsPlanItem
     // End of user code
-    private Set<Link> affectsPlanItem = new HashSet<Link>();
+    private Set<Link> affectsPlanItem = new HashSet<>();
     // Start of user code attributeAnnotation:affectedByDefect
     // End of user code
-    private Set<Link> affectedByDefect = new HashSet<Link>();
+    private Set<Link> affectedByDefect = new HashSet<>();
     // Start of user code attributeAnnotation:tracksRequirement
     // End of user code
-    private Set<Link> tracksRequirement = new HashSet<Link>();
+    private Set<Link> tracksRequirement = new HashSet<>();
     // Start of user code attributeAnnotation:implementsRequirement
     // End of user code
-    private Set<Link> implementsRequirement = new HashSet<Link>();
+    private Set<Link> implementsRequirement = new HashSet<>();
     // Start of user code attributeAnnotation:affectsRequirement
     // End of user code
-    private Set<Link> affectsRequirement = new HashSet<Link>();
+    private Set<Link> affectsRequirement = new HashSet<>();
     // Start of user code attributeAnnotation:tracksChangeSet
     // End of user code
-    private Set<Link> tracksChangeSet = new HashSet<Link>();
+    private Set<Link> tracksChangeSet = new HashSet<>();
     // Start of user code attributeAnnotation:parent
     // End of user code
-    private Set<Link> parent = new HashSet<Link>();
+    private Set<Link> parent = new HashSet<>();
     // Start of user code attributeAnnotation:priority
     // End of user code
-    private Set<Link> priority = new HashSet<Link>();
+    private Set<Link> priority = new HashSet<>();
     // Start of user code attributeAnnotation:state
     // End of user code
     private Link state;
     // Start of user code attributeAnnotation:authorizer
     // End of user code
-    private Set<Link> authorizer = new HashSet<Link>();
-    
+    private Set<Link> authorizer = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -191,38 +191,38 @@ public class ChangeRequest
     public ChangeRequest()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public ChangeRequest(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_cmDomainConstants.CHANGEREQUEST_PATH,
         ChangeRequest.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local ChangeRequest Resource} - update ChangeRequest.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -231,90 +231,90 @@ public class ChangeRequest
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         result = String.format("[%s]: %s (Change Request; id=%s)", this.getShortTitle(), this.getTitle(), this.getIdentifier());
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addRelatedChangeRequest(final Link relatedChangeRequest)
     {
         this.relatedChangeRequest.add(relatedChangeRequest);
     }
-    
+
     public void addAffectsPlanItem(final Link affectsPlanItem)
     {
         this.affectsPlanItem.add(affectsPlanItem);
     }
-    
+
     public void addAffectedByDefect(final Link affectedByDefect)
     {
         this.affectedByDefect.add(affectedByDefect);
     }
-    
+
     public void addTracksRequirement(final Link tracksRequirement)
     {
         this.tracksRequirement.add(tracksRequirement);
     }
-    
+
     public void addImplementsRequirement(final Link implementsRequirement)
     {
         this.implementsRequirement.add(implementsRequirement);
     }
-    
+
     public void addAffectsRequirement(final Link affectsRequirement)
     {
         this.affectsRequirement.add(affectsRequirement);
     }
-    
+
     public void addTracksChangeSet(final Link tracksChangeSet)
     {
         this.tracksChangeSet.add(tracksChangeSet);
     }
-    
+
     public void addParent(final Link parent)
     {
         this.parent.add(parent);
     }
-    
+
     public void addPriority(final Link priority)
     {
         this.priority.add(priority);
     }
-    
+
     public void addAuthorizer(final Link authorizer)
     {
         this.authorizer.add(authorizer);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:shortTitle
     // End of user code
     @OslcName("shortTitle")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Baseline.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Baseline.java
@@ -91,14 +91,14 @@ public class Baseline
     private Date committed;
     // Start of user code attributeAnnotation:committer
     // End of user code
-    private Set<Link> committer = new HashSet<Link>();
+    private Set<Link> committer = new HashSet<>();
     // Start of user code attributeAnnotation:previousBaseline
     // End of user code
     private Link previousBaseline;
     // Start of user code attributeAnnotation:wasDerivedFrom
     // End of user code
-    private Set<Link> wasDerivedFrom = new HashSet<Link>();
-    
+    private Set<Link> wasDerivedFrom = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -106,38 +106,38 @@ public class Baseline
     public Baseline()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public Baseline(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_configDomainConstants.BASELINE_PATH,
         Baseline.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local Baseline Resource} - update Baseline.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -146,24 +146,24 @@ public class Baseline
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addCommitter(final Link committer)
     {
         this.committer.add(committer);
     }
-    
+
     public void addWasDerivedFrom(final Link wasDerivedFrom)
     {
         this.wasDerivedFrom.add(wasDerivedFrom);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:baselineOfStream
     // End of user code
     @OslcName("baselineOfStream")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/ChangeSet.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/ChangeSet.java
@@ -83,11 +83,11 @@ public class ChangeSet
 {
     // Start of user code attributeAnnotation:accepts
     // End of user code
-    private Set<Link> accepts = new HashSet<Link>();
+    private Set<Link> accepts = new HashSet<>();
     // Start of user code attributeAnnotation:overrides
     // End of user code
     private Link overrides;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -95,38 +95,38 @@ public class ChangeSet
     public ChangeSet()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public ChangeSet(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_configDomainConstants.CHANGESET_PATH,
         ChangeSet.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local ChangeSet Resource} - update ChangeSet.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -135,19 +135,19 @@ public class ChangeSet
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addAccepts(final Link accepts)
     {
         this.accepts.add(accepts);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:accepts
     // End of user code
     @OslcName("accepts")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Component.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Component.java
@@ -84,13 +84,13 @@ public class Component
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:identifier
     // End of user code
     private String identifier;
@@ -102,7 +102,7 @@ public class Component
     private Date modified;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
@@ -111,20 +111,20 @@ public class Component
     private Link configurations;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:modifiedBy
     // End of user code
-    private Set<Link> modifiedBy = new HashSet<Link>();
+    private Set<Link> modifiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:shortId
     // End of user code
     private String shortId;
     // Start of user code attributeAnnotation:shortTitle
     // End of user code
     private String shortTitle;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -132,38 +132,38 @@ public class Component
     public Component()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public Component(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_configDomainConstants.COMPONENT_PATH,
         Component.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local Component Resource} - update Component.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -172,44 +172,44 @@ public class Component
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addModifiedBy(final Link modifiedBy)
     {
         this.modifiedBy.add(modifiedBy);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Configuration.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Configuration.java
@@ -87,13 +87,13 @@ public class Configuration
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -105,7 +105,7 @@ public class Configuration
     private Date modified;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
@@ -123,29 +123,29 @@ public class Configuration
     private Link contribution;
     // Start of user code attributeAnnotation:selections
     // End of user code
-    private Set<Link> selections = new HashSet<Link>();
+    private Set<Link> selections = new HashSet<>();
     // Start of user code attributeAnnotation:archived
     // End of user code
     private Boolean archived;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:modifiedBy
     // End of user code
-    private Set<Link> modifiedBy = new HashSet<Link>();
+    private Set<Link> modifiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:release
     // End of user code
-    private Set<Link> release = new HashSet<Link>();
+    private Set<Link> release = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:shortId
     // End of user code
     private String shortId;
     // Start of user code attributeAnnotation:shortTitle
     // End of user code
     private String shortTitle;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -153,38 +153,38 @@ public class Configuration
     public Configuration()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public Configuration(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_configDomainConstants.CONFIGURATION_PATH,
         Configuration.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local Configuration Resource} - update Configuration.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -193,54 +193,54 @@ public class Configuration
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addSelections(final Link selections)
     {
         this.selections.add(selections);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addModifiedBy(final Link modifiedBy)
     {
         this.modifiedBy.add(modifiedBy);
     }
-    
+
     public void addRelease(final Link release)
     {
         this.release.add(release);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Stream.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/Stream.java
@@ -86,7 +86,7 @@ public class Stream
 {
     // Start of user code attributeAnnotation:accepts
     // End of user code
-    private Set<Link> accepts = new HashSet<Link>();
+    private Set<Link> accepts = new HashSet<>();
     // Start of user code attributeAnnotation:baselines
     // End of user code
     private Link baselines;
@@ -95,8 +95,8 @@ public class Stream
     private Link previousBaseline;
     // Start of user code attributeAnnotation:wasDerivedFrom
     // End of user code
-    private Set<Link> wasDerivedFrom = new HashSet<Link>();
-    
+    private Set<Link> wasDerivedFrom = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -104,38 +104,38 @@ public class Stream
     public Stream()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public Stream(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_configDomainConstants.STREAM_PATH,
         Stream.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local Stream Resource} - update Stream.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -144,24 +144,24 @@ public class Stream
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addAccepts(final Link accepts)
     {
         this.accepts.add(accepts);
     }
-    
+
     public void addWasDerivedFrom(final Link wasDerivedFrom)
     {
         this.wasDerivedFrom.add(wasDerivedFrom);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:accepts
     // End of user code
     @OslcName("accepts")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/VersionResource.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/config/VersionResource.java
@@ -86,13 +86,13 @@ public class VersionResource
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -107,7 +107,7 @@ public class VersionResource
     private Date modified;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
@@ -116,7 +116,7 @@ public class VersionResource
     private Date committed;
     // Start of user code attributeAnnotation:committer
     // End of user code
-    private Set<Link> committer = new HashSet<Link>();
+    private Set<Link> committer = new HashSet<>();
     // Start of user code attributeAnnotation:component
     // End of user code
     private Link component;
@@ -128,13 +128,13 @@ public class VersionResource
     private Boolean archived;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:modifiedBy
     // End of user code
-    private Set<Link> modifiedBy = new HashSet<Link>();
+    private Set<Link> modifiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:shortId
     // End of user code
     private String shortId;
@@ -143,11 +143,11 @@ public class VersionResource
     private String shortTitle;
     // Start of user code attributeAnnotation:wasDerivedFrom
     // End of user code
-    private Set<Link> wasDerivedFrom = new HashSet<Link>();
+    private Set<Link> wasDerivedFrom = new HashSet<>();
     // Start of user code attributeAnnotation:wasRevisionOf
     // End of user code
-    private Set<Link> wasRevisionOf = new HashSet<Link>();
-    
+    private Set<Link> wasRevisionOf = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -155,38 +155,38 @@ public class VersionResource
     public VersionResource()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public VersionResource(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_configDomainConstants.VERSIONRESOURCE_PATH,
         VersionResource.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local VersionResource Resource} - update VersionResource.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -195,59 +195,59 @@ public class VersionResource
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addCommitter(final Link committer)
     {
         this.committer.add(committer);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addModifiedBy(final Link modifiedBy)
     {
         this.modifiedBy.add(modifiedBy);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addWasDerivedFrom(final Link wasDerivedFrom)
     {
         this.wasDerivedFrom.add(wasDerivedFrom);
     }
-    
+
     public void addWasRevisionOf(final Link wasRevisionOf)
     {
         this.wasRevisionOf.add(wasRevisionOf);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestCase.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestCase.java
@@ -89,13 +89,13 @@ public class TestCase
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -107,32 +107,32 @@ public class TestCase
     private Date modified;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private Set<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:testsChangeRequest
     // End of user code
-    private Set<Link> testsChangeRequest = new HashSet<Link>();
+    private Set<Link> testsChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:usesTestScript
     // End of user code
-    private Set<Link> usesTestScript = new HashSet<Link>();
+    private Set<Link> usesTestScript = new HashSet<>();
     // Start of user code attributeAnnotation:validatesRequirement
     // End of user code
-    private Set<Link> validatesRequirement = new HashSet<Link>();
-    
+    private Set<Link> validatesRequirement = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -140,38 +140,38 @@ public class TestCase
     public TestCase()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public TestCase(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_qmDomainConstants.TESTCASE_PATH,
         TestCase.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local TestCase Resource} - update TestCase.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -180,65 +180,65 @@ public class TestCase
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         result = String.format("%s (TestCase; id=%s)", this.getTitle(), this.getIdentifier());
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addRelatedChangeRequest(final Link relatedChangeRequest)
     {
         this.relatedChangeRequest.add(relatedChangeRequest);
     }
-    
+
     public void addTestsChangeRequest(final Link testsChangeRequest)
     {
         this.testsChangeRequest.add(testsChangeRequest);
     }
-    
+
     public void addUsesTestScript(final Link usesTestScript)
     {
         this.usesTestScript.add(usesTestScript);
     }
-    
+
     public void addValidatesRequirement(final Link validatesRequirement)
     {
         this.validatesRequirement.add(validatesRequirement);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestExecutionRecord.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestExecutionRecord.java
@@ -88,13 +88,13 @@ public class TestExecutionRecord
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:identifier
     // End of user code
     private String identifier;
@@ -103,22 +103,22 @@ public class TestExecutionRecord
     private Date modified;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:blockedByChangeRequest
     // End of user code
-    private Set<Link> blockedByChangeRequest = new HashSet<Link>();
+    private Set<Link> blockedByChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private Set<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:reportsOnTestPlan
     // End of user code
     private Link reportsOnTestPlan;
@@ -128,7 +128,7 @@ public class TestExecutionRecord
     // Start of user code attributeAnnotation:runsTestCase
     // End of user code
     private Link runsTestCase;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -136,38 +136,38 @@ public class TestExecutionRecord
     public TestExecutionRecord()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public TestExecutionRecord(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_qmDomainConstants.TESTEXECUTIONRECORD_PATH,
         TestExecutionRecord.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local TestExecutionRecord Resource} - update TestExecutionRecord.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -176,49 +176,49 @@ public class TestExecutionRecord
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addBlockedByChangeRequest(final Link blockedByChangeRequest)
     {
         this.blockedByChangeRequest.add(blockedByChangeRequest);
     }
-    
+
     public void addRelatedChangeRequest(final Link relatedChangeRequest)
     {
         this.relatedChangeRequest.add(relatedChangeRequest);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestPlan.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestPlan.java
@@ -89,13 +89,13 @@ public class TestPlan
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -107,29 +107,29 @@ public class TestPlan
     private Date modified;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:usesTestCase
     // End of user code
-    private Set<Link> usesTestCase = new HashSet<Link>();
+    private Set<Link> usesTestCase = new HashSet<>();
     // Start of user code attributeAnnotation:validatesRequirementCollection
     // End of user code
-    private Set<Link> validatesRequirementCollection = new HashSet<Link>();
+    private Set<Link> validatesRequirementCollection = new HashSet<>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private Set<Link> relatedChangeRequest = new HashSet<Link>();
-    
+    private Set<Link> relatedChangeRequest = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -137,38 +137,38 @@ public class TestPlan
     public TestPlan()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public TestPlan(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_qmDomainConstants.TESTPLAN_PATH,
         TestPlan.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local TestPlan Resource} - update TestPlan.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -177,60 +177,60 @@ public class TestPlan
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         result = String.format("%s (TestPlan; id=%s)", this.getTitle(), this.getIdentifier());
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addUsesTestCase(final Link usesTestCase)
     {
         this.usesTestCase.add(usesTestCase);
     }
-    
+
     public void addValidatesRequirementCollection(final Link validatesRequirementCollection)
     {
         this.validatesRequirementCollection.add(validatesRequirementCollection);
     }
-    
+
     public void addRelatedChangeRequest(final Link relatedChangeRequest)
     {
         this.relatedChangeRequest.add(relatedChangeRequest);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestResult.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestResult.java
@@ -97,22 +97,22 @@ public class TestResult
     private Date modified;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:status
     // End of user code
     private String status;
     // Start of user code attributeAnnotation:affectedByChangeRequest
     // End of user code
-    private Set<Link> affectedByChangeRequest = new HashSet<Link>();
+    private Set<Link> affectedByChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:executesTestScript
     // End of user code
     private Link executesTestScript;
@@ -125,7 +125,7 @@ public class TestResult
     // Start of user code attributeAnnotation:reportsOnTestPlan
     // End of user code
     private Link reportsOnTestPlan;
-    
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -133,38 +133,38 @@ public class TestResult
     public TestResult()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public TestResult(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_qmDomainConstants.TESTRESULT_PATH,
         TestResult.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local TestResult Resource} - update TestResult.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -173,34 +173,34 @@ public class TestResult
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addAffectedByChangeRequest(final Link affectedByChangeRequest)
     {
         this.affectedByChangeRequest.add(affectedByChangeRequest);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:created
     // End of user code
     @OslcName("created")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestScript.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/qm/TestScript.java
@@ -88,13 +88,13 @@ public class TestScript
 {
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:description
     // End of user code
     private String description;
@@ -106,26 +106,26 @@ public class TestScript
     private Date modified;
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:title
     // End of user code
     private String title;
     // Start of user code attributeAnnotation:type
     // End of user code
-    private Set<Link> type = new HashSet<Link>();
+    private Set<Link> type = new HashSet<>();
     // Start of user code attributeAnnotation:executionInstructions
     // End of user code
-    private Set<Link> executionInstructions = new HashSet<Link>();
+    private Set<Link> executionInstructions = new HashSet<>();
     // Start of user code attributeAnnotation:relatedChangeRequest
     // End of user code
-    private Set<Link> relatedChangeRequest = new HashSet<Link>();
+    private Set<Link> relatedChangeRequest = new HashSet<>();
     // Start of user code attributeAnnotation:validatesRequirement
     // End of user code
-    private Set<Link> validatesRequirement = new HashSet<Link>();
-    
+    private Set<Link> validatesRequirement = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -133,38 +133,38 @@ public class TestScript
     public TestScript()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public TestScript(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_qmDomainConstants.TESTSCRIPT_PATH,
         TestScript.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local TestScript Resource} - update TestScript.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -173,54 +173,54 @@ public class TestScript
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addType(final Link type)
     {
         this.type.add(type);
     }
-    
+
     public void addExecutionInstructions(final Link executionInstructions)
     {
         this.executionInstructions.add(executionInstructions);
     }
-    
+
     public void addRelatedChangeRequest(final Link relatedChangeRequest)
     {
         this.relatedChangeRequest.add(relatedChangeRequest);
     }
-    
+
     public void addValidatesRequirement(final Link validatesRequirement)
     {
         this.validatesRequirement.add(validatesRequirement);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:contributor
     // End of user code
     @OslcName("contributor")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Requirement.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/Requirement.java
@@ -94,13 +94,13 @@ public class Requirement
     private String shortTitle;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
@@ -109,53 +109,53 @@ public class Requirement
     private Date modified;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:elaboratedBy
     // End of user code
-    private Set<Link> elaboratedBy = new HashSet<Link>();
+    private Set<Link> elaboratedBy = new HashSet<>();
     // Start of user code attributeAnnotation:elaborates
     // End of user code
-    private Set<Link> elaborates = new HashSet<Link>();
+    private Set<Link> elaborates = new HashSet<>();
     // Start of user code attributeAnnotation:specifiedBy
     // End of user code
-    private Set<Link> specifiedBy = new HashSet<Link>();
+    private Set<Link> specifiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:specifies
     // End of user code
-    private Set<Link> specifies = new HashSet<Link>();
+    private Set<Link> specifies = new HashSet<>();
     // Start of user code attributeAnnotation:affectedBy
     // End of user code
-    private Set<Link> affectedBy = new HashSet<Link>();
+    private Set<Link> affectedBy = new HashSet<>();
     // Start of user code attributeAnnotation:trackedBy
     // End of user code
-    private Set<Link> trackedBy = new HashSet<Link>();
+    private Set<Link> trackedBy = new HashSet<>();
     // Start of user code attributeAnnotation:implementedBy
     // End of user code
-    private Set<Link> implementedBy = new HashSet<Link>();
+    private Set<Link> implementedBy = new HashSet<>();
     // Start of user code attributeAnnotation:validatedBy
     // End of user code
-    private Set<Link> validatedBy = new HashSet<Link>();
+    private Set<Link> validatedBy = new HashSet<>();
     // Start of user code attributeAnnotation:satisfiedBy
     // End of user code
-    private Set<Link> satisfiedBy = new HashSet<Link>();
+    private Set<Link> satisfiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:satisfies
     // End of user code
-    private Set<Link> satisfies = new HashSet<Link>();
+    private Set<Link> satisfies = new HashSet<>();
     // Start of user code attributeAnnotation:decomposedBy
     // End of user code
-    private Set<Link> decomposedBy = new HashSet<Link>();
+    private Set<Link> decomposedBy = new HashSet<>();
     // Start of user code attributeAnnotation:decomposes
     // End of user code
-    private Set<Link> decomposes = new HashSet<Link>();
+    private Set<Link> decomposes = new HashSet<>();
     // Start of user code attributeAnnotation:constrainedBy
     // End of user code
-    private Set<Link> constrainedBy = new HashSet<Link>();
+    private Set<Link> constrainedBy = new HashSet<>();
     // Start of user code attributeAnnotation:constrains
     // End of user code
-    private Set<Link> constrains = new HashSet<Link>();
-    
+    private Set<Link> constrains = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -163,38 +163,38 @@ public class Requirement
     public Requirement()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public Requirement(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_rmDomainConstants.REQUIREMENT_PATH,
         Requirement.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local Requirement Resource} - update Requirement.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -203,111 +203,111 @@ public class Requirement
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         result = String.format("%s: %s (Requirement; id=%s)", this.getShortTitle(), this.getTitle(), this.getIdentifier());
 
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addElaboratedBy(final Link elaboratedBy)
     {
         this.elaboratedBy.add(elaboratedBy);
     }
-    
+
     public void addElaborates(final Link elaborates)
     {
         this.elaborates.add(elaborates);
     }
-    
+
     public void addSpecifiedBy(final Link specifiedBy)
     {
         this.specifiedBy.add(specifiedBy);
     }
-    
+
     public void addSpecifies(final Link specifies)
     {
         this.specifies.add(specifies);
     }
-    
+
     public void addAffectedBy(final Link affectedBy)
     {
         this.affectedBy.add(affectedBy);
     }
-    
+
     public void addTrackedBy(final Link trackedBy)
     {
         this.trackedBy.add(trackedBy);
     }
-    
+
     public void addImplementedBy(final Link implementedBy)
     {
         this.implementedBy.add(implementedBy);
     }
-    
+
     public void addValidatedBy(final Link validatedBy)
     {
         this.validatedBy.add(validatedBy);
     }
-    
+
     public void addSatisfiedBy(final Link satisfiedBy)
     {
         this.satisfiedBy.add(satisfiedBy);
     }
-    
+
     public void addSatisfies(final Link satisfies)
     {
         this.satisfies.add(satisfies);
     }
-    
+
     public void addDecomposedBy(final Link decomposedBy)
     {
         this.decomposedBy.add(decomposedBy);
     }
-    
+
     public void addDecomposes(final Link decomposes)
     {
         this.decomposes.add(decomposes);
     }
-    
+
     public void addConstrainedBy(final Link constrainedBy)
     {
         this.constrainedBy.add(constrainedBy);
     }
-    
+
     public void addConstrains(final Link constrains)
     {
         this.constrains.add(constrains);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")

--- a/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/RequirementCollection.java
+++ b/domains/oslc-domains/src/main/java/org/eclipse/lyo/oslc/domains/rm/RequirementCollection.java
@@ -94,13 +94,13 @@ public class RequirementCollection
     private String shortTitle;
     // Start of user code attributeAnnotation:subject
     // End of user code
-    private Set<String> subject = new HashSet<String>();
+    private Set<String> subject = new HashSet<>();
     // Start of user code attributeAnnotation:creator
     // End of user code
-    private Set<Link> creator = new HashSet<Link>();
+    private Set<Link> creator = new HashSet<>();
     // Start of user code attributeAnnotation:contributor
     // End of user code
-    private Set<Link> contributor = new HashSet<Link>();
+    private Set<Link> contributor = new HashSet<>();
     // Start of user code attributeAnnotation:created
     // End of user code
     private Date created;
@@ -109,56 +109,56 @@ public class RequirementCollection
     private Date modified;
     // Start of user code attributeAnnotation:serviceProvider
     // End of user code
-    private Set<Link> serviceProvider = new HashSet<Link>();
+    private Set<Link> serviceProvider = new HashSet<>();
     // Start of user code attributeAnnotation:instanceShape
     // End of user code
-    private Set<Link> instanceShape = new HashSet<Link>();
+    private Set<Link> instanceShape = new HashSet<>();
     // Start of user code attributeAnnotation:elaboratedBy
     // End of user code
-    private Set<Link> elaboratedBy = new HashSet<Link>();
+    private Set<Link> elaboratedBy = new HashSet<>();
     // Start of user code attributeAnnotation:elaborates
     // End of user code
-    private Set<Link> elaborates = new HashSet<Link>();
+    private Set<Link> elaborates = new HashSet<>();
     // Start of user code attributeAnnotation:specifiedBy
     // End of user code
-    private Set<Link> specifiedBy = new HashSet<Link>();
+    private Set<Link> specifiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:specifies
     // End of user code
-    private Set<Link> specifies = new HashSet<Link>();
+    private Set<Link> specifies = new HashSet<>();
     // Start of user code attributeAnnotation:affectedBy
     // End of user code
-    private Set<Link> affectedBy = new HashSet<Link>();
+    private Set<Link> affectedBy = new HashSet<>();
     // Start of user code attributeAnnotation:trackedBy
     // End of user code
-    private Set<Link> trackedBy = new HashSet<Link>();
+    private Set<Link> trackedBy = new HashSet<>();
     // Start of user code attributeAnnotation:implementedBy
     // End of user code
-    private Set<Link> implementedBy = new HashSet<Link>();
+    private Set<Link> implementedBy = new HashSet<>();
     // Start of user code attributeAnnotation:validatedBy
     // End of user code
-    private Set<Link> validatedBy = new HashSet<Link>();
+    private Set<Link> validatedBy = new HashSet<>();
     // Start of user code attributeAnnotation:satisfiedBy
     // End of user code
-    private Set<Link> satisfiedBy = new HashSet<Link>();
+    private Set<Link> satisfiedBy = new HashSet<>();
     // Start of user code attributeAnnotation:satisfies
     // End of user code
-    private Set<Link> satisfies = new HashSet<Link>();
+    private Set<Link> satisfies = new HashSet<>();
     // Start of user code attributeAnnotation:decomposedBy
     // End of user code
-    private Set<Link> decomposedBy = new HashSet<Link>();
+    private Set<Link> decomposedBy = new HashSet<>();
     // Start of user code attributeAnnotation:decomposes
     // End of user code
-    private Set<Link> decomposes = new HashSet<Link>();
+    private Set<Link> decomposes = new HashSet<>();
     // Start of user code attributeAnnotation:constrainedBy
     // End of user code
-    private Set<Link> constrainedBy = new HashSet<Link>();
+    private Set<Link> constrainedBy = new HashSet<>();
     // Start of user code attributeAnnotation:constrains
     // End of user code
-    private Set<Link> constrains = new HashSet<Link>();
+    private Set<Link> constrains = new HashSet<>();
     // Start of user code attributeAnnotation:uses
     // End of user code
-    private Set<Link> uses = new HashSet<Link>();
-    
+    private Set<Link> uses = new HashSet<>();
+
     // Start of user code classAttributes
     // End of user code
     // Start of user code classMethods
@@ -166,38 +166,38 @@ public class RequirementCollection
     public RequirementCollection()
     {
         super();
-    
+
         // Start of user code constructor1
         // End of user code
     }
-    
+
     public RequirementCollection(final URI about)
     {
         super(about);
-    
+
         // Start of user code constructor2
         // End of user code
     }
-    
+
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
         Oslc_rmDomainConstants.REQUIREMENTCOLLECTION_PATH,
         RequirementCollection.class);
     }
-    
-    
+
+
     public String toString()
     {
         return toString(false);
     }
-    
+
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local RequirementCollection Resource} - update RequirementCollection.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -206,114 +206,114 @@ public class RequirementCollection
         else {
             result = String.valueOf(getAbout());
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
     public void addSubject(final String subject)
     {
         this.subject.add(subject);
     }
-    
+
     public void addCreator(final Link creator)
     {
         this.creator.add(creator);
     }
-    
+
     public void addContributor(final Link contributor)
     {
         this.contributor.add(contributor);
     }
-    
+
     public void addServiceProvider(final Link serviceProvider)
     {
         this.serviceProvider.add(serviceProvider);
     }
-    
+
     public void addInstanceShape(final Link instanceShape)
     {
         this.instanceShape.add(instanceShape);
     }
-    
+
     public void addElaboratedBy(final Link elaboratedBy)
     {
         this.elaboratedBy.add(elaboratedBy);
     }
-    
+
     public void addElaborates(final Link elaborates)
     {
         this.elaborates.add(elaborates);
     }
-    
+
     public void addSpecifiedBy(final Link specifiedBy)
     {
         this.specifiedBy.add(specifiedBy);
     }
-    
+
     public void addSpecifies(final Link specifies)
     {
         this.specifies.add(specifies);
     }
-    
+
     public void addAffectedBy(final Link affectedBy)
     {
         this.affectedBy.add(affectedBy);
     }
-    
+
     public void addTrackedBy(final Link trackedBy)
     {
         this.trackedBy.add(trackedBy);
     }
-    
+
     public void addImplementedBy(final Link implementedBy)
     {
         this.implementedBy.add(implementedBy);
     }
-    
+
     public void addValidatedBy(final Link validatedBy)
     {
         this.validatedBy.add(validatedBy);
     }
-    
+
     public void addSatisfiedBy(final Link satisfiedBy)
     {
         this.satisfiedBy.add(satisfiedBy);
     }
-    
+
     public void addSatisfies(final Link satisfies)
     {
         this.satisfies.add(satisfies);
     }
-    
+
     public void addDecomposedBy(final Link decomposedBy)
     {
         this.decomposedBy.add(decomposedBy);
     }
-    
+
     public void addDecomposes(final Link decomposes)
     {
         this.decomposes.add(decomposes);
     }
-    
+
     public void addConstrainedBy(final Link constrainedBy)
     {
         this.constrainedBy.add(constrainedBy);
     }
-    
+
     public void addConstrains(final Link constrains)
     {
         this.constrains.add(constrains);
     }
-    
+
     public void addUses(final Link uses)
     {
         this.uses.add(uses);
     }
-    
-    
+
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.release>11</maven.compiler.release>
 

--- a/server/oauth-consumer-store/src/main/java/org/eclipse/lyo/server/oauth/consumerstore/FileSystemConsumerStore.java
+++ b/server/oauth-consumer-store/src/main/java/org/eclipse/lyo/server/oauth/consumerstore/FileSystemConsumerStore.java
@@ -161,12 +161,10 @@ public class FileSystemConsumerStore extends AbstractConsumerStore {
 			writeModel();
 			return retConsumer;
 
-		} catch (UnsupportedEncodingException ue) {
+		} catch (UnsupportedEncodingException | FileNotFoundException ue) {
 			throw new ConsumerStoreException(ue);
-		} catch (FileNotFoundException fe) {
-			throw new ConsumerStoreException(fe);
 		}
-	}
+    }
 
 	@Override
 	public synchronized LyoOAuthConsumer removeConsumer(final String consumerKey)

--- a/server/oauth-consumer-store/src/main/java/org/eclipse/lyo/server/oauth/consumerstore/RdfConsumerStore.java
+++ b/server/oauth-consumer-store/src/main/java/org/eclipse/lyo/server/oauth/consumerstore/RdfConsumerStore.java
@@ -159,9 +159,7 @@ public class RdfConsumerStore extends AbstractConsumerStore {
 
         try {
 			model.enterCriticalSection(Lock.WRITE);
-            model.executeInTxn(() -> {
-                removeProperties(consumerKey);
-            });
+            model.executeInTxn(() -> removeProperties(consumerKey));
 
             return remove(consumerKey);
 		} catch (JenaException e) {

--- a/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
+++ b/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
@@ -482,8 +482,7 @@ abstract public class AbstractAdapterCredentialsFilter<Credentials, Connection> 
 	 */
 	private void throwInvalidExpiredException(OAuthProblemException e) throws OAuthProblemException {
 		OAuthProblemException ope = new OAuthProblemException(JAZZ_INVALID_EXPIRED_TOKEN_OAUTH_PROBLEM);
-		ope.setParameter(HttpMessage.STATUS_CODE, new Integer(
-				HttpServletResponse.SC_UNAUTHORIZED));
+		ope.setParameter(HttpMessage.STATUS_CODE, HttpServletResponse.SC_UNAUTHORIZED);
 		throw ope;
 	}
 

--- a/server/oauth-webapp/src/main/java/org/eclipse/lyo/server/oauth/webapp/services/OAuthService.java
+++ b/server/oauth-webapp/src/main/java/org/eclipse/lyo/server/oauth/webapp/services/OAuthService.java
@@ -138,7 +138,7 @@ public class OAuthService {
             httpRequest.setAttribute("consumerName", consumer.getName());
             httpRequest.setAttribute("callback", getCallbackURL(message, consumer));
             boolean callbackConfirmed = consumer.getOAuthVersion() == LyoOAuthConsumer.OAuthVersion.OAUTH_1_0A;
-            httpRequest.setAttribute("callbackConfirmed", new Boolean(callbackConfirmed));
+            httpRequest.setAttribute("callbackConfirmed", callbackConfirmed);
 
             // The application name is displayed on the OAuth login page.
             httpRequest.setAttribute("applicationName", config.getApplication().getName());

--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/Link.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/Link.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.util.Objects;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "link",
@@ -116,7 +118,7 @@ public class Link {
             return false;
         }
         Link rhs = ((Link) other);
-        return (((this.link == rhs.link)||((this.link!= null)&&this.link.equals(rhs.link)))&&((this.title == rhs.title)||((this.title!= null)&&this.title.equals(rhs.title))));
+        return ((Objects.equals(this.link, rhs.link))&&(Objects.equals(this.title, rhs.title)));
     }
 
 }

--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/Preview.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/Preview.java
@@ -15,6 +15,8 @@ package org.eclipse.lyo.server.ui.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -85,7 +87,7 @@ public class Preview {
             return false;
         }
         Preview rhs = ((Preview) other);
-        return ((this.properties == rhs.properties)||((this.properties!= null)&&this.properties.equals(rhs.properties)));
+        return (Objects.equals(this.properties, rhs.properties));
     }
 
 }

--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PreviewFactory.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PreviewFactory.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 public class PreviewFactory {
 
@@ -118,11 +119,7 @@ public class PreviewFactory {
         PropertyValue value = new PropertyValue();
         value.setRepresentationType(representationType);
         value.setRepresentAsList(representAsList);
-        if (null == data) {
-            value.setData("<not set>");
-        } else {
-            value.setData(data);
-        }
+        value.setData(Objects.requireNonNullElse(data, "<not set>"));
         return value;
     }
 

--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/Property.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/Property.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.util.Objects;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "propertyDefintion",
@@ -116,7 +118,7 @@ public class Property {
             return false;
         }
         Property rhs = ((Property) other);
-        return (((this.propertyValue == rhs.propertyValue)||((this.propertyValue!= null)&&this.propertyValue.equals(rhs.propertyValue)))&&((this.propertyDefintion == rhs.propertyDefintion)||((this.propertyDefintion!= null)&&this.propertyDefintion.equals(rhs.propertyDefintion))));
+        return ((Objects.equals(this.propertyValue, rhs.propertyValue))&&(Objects.equals(this.propertyDefintion, rhs.propertyDefintion)));
     }
 
 }

--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PropertyDefintion.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PropertyDefintion.java
@@ -15,6 +15,8 @@ package org.eclipse.lyo.server.ui.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -120,7 +122,7 @@ public class PropertyDefintion {
             return false;
         }
         PropertyDefintion rhs = ((PropertyDefintion) other);
-        return (((this.data == rhs.data)||((this.data!= null)&&this.data.equals(rhs.data)))&&((this.representationType == rhs.representationType)||((this.representationType!= null)&&this.representationType.equals(rhs.representationType))));
+        return ((Objects.equals(this.data, rhs.data))&&(Objects.equals(this.representationType, rhs.representationType)));
     }
 
     public enum RepresentationType {

--- a/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PropertyValue.java
+++ b/server/oslc-ui-model/src/main/java/org/eclipse/lyo/server/ui/model/PropertyValue.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.util.Objects;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "data",
@@ -134,7 +136,7 @@ public class PropertyValue {
             return false;
         }
         PropertyValue rhs = ((PropertyValue) other);
-        return ((((this.representationType == rhs.representationType)||((this.representationType!= null)&&this.representationType.equals(rhs.representationType)))&&((this.data == rhs.data)||((this.data!= null)&&this.data.equals(rhs.data))))&&((this.representAsList == rhs.representAsList)||((this.representAsList!= null)&&this.representAsList.equals(rhs.representAsList))));
+        return (((Objects.equals(this.representationType, rhs.representationType))&&(Objects.equals(this.data, rhs.data)))&&(Objects.equals(this.representAsList, rhs.representAsList)));
     }
 
 }

--- a/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
+++ b/store/store-core/src/main/java/org/eclipse/lyo/store/internals/SparqlStoreImpl.java
@@ -175,13 +175,13 @@ public class SparqlStoreImpl implements Store {
     @Override
     public void deleteResources(final URI namedGraphUri, final URI... subjectUris) {
         final QuerySolutionMap map = new QuerySolutionMap();
-        for (int i = 0; i < subjectUris.length; i++) {
+        for (URI uris : subjectUris) {
             map.clear();
             map.add("graph", new ResourceImpl(String.valueOf(namedGraphUri)));
-            map.add("subject", new ResourceImpl(String.valueOf(subjectUris[i])));
+            map.add("subject", new ResourceImpl(String.valueOf(uris)));
             final ParameterizedSparqlString sparqlString = new ParameterizedSparqlString(
-                    "WITH ?graph DELETE  { ?s ?p ?v } WHERE {?s ?p ?v . FILTER(?s = ?subject)}",
-                    map);
+                "WITH ?graph DELETE  { ?s ?p ?v } WHERE {?s ?p ?v . FILTER(?s = ?subject)}",
+                map);
             final String query = sparqlString.toString();
             final UpdateProcessor updateProcessor = queryExecutor.prepareSparqlUpdate(query);
             updateProcessor.execute();
@@ -625,16 +625,15 @@ public class SparqlStoreImpl implements Store {
             if (!StringUtils.isEmpty(where)) {
                 whereClause = QueryUtils.parseWhere(where, prefixesMap);
                 List<SimpleTerm> parseChildren = whereClause.children();
-                for (Iterator<SimpleTerm> iterator = parseChildren.iterator(); iterator.hasNext();) {
-                    SimpleTerm simpleTerm = iterator.next();
+                for (SimpleTerm simpleTerm : parseChildren) {
                     Type termType = simpleTerm.type();
                     PName property = simpleTerm.property();
 
-                    if (!termType.equals(Type.COMPARISON)){
+                    if (!termType.equals(Type.COMPARISON)) {
                         throw new UnsupportedOperationException("only support for terms of type Comparisons");
                     }
                     ComparisonTerm aComparisonTerm = (ComparisonTerm) simpleTerm;
-                    if (!aComparisonTerm.operator().equals(Operator.EQUALS)){
+                    if (!aComparisonTerm.operator().equals(Operator.EQUALS)) {
                         throw new UnsupportedOperationException(
                             "only support for terms of type Comparisons, where the operator is 'EQUALS'");
                     }
@@ -644,27 +643,26 @@ public class SparqlStoreImpl implements Store {
                     String predicate;
                     if (property.local.equals("*")) {
                         predicate = "?p";
-                    }
-                    else {
+                    } else {
                         predicate = property.toString();
                     }
 
                     switch (operandType) {
-                    case DECIMAL:
-                        DecimalValue decimalOperand = (DecimalValue) comparisonOperand;
-                        distinctResourcesQuery.addWhere( "?s", predicate, decimalOperand.value());
-                        break;
-                    case STRING:
-                        StringValue stringOperand = (StringValue) comparisonOperand;
-                        distinctResourcesQuery.addWhere( "?s", predicate, "\"" + stringOperand.value() + "\"");
-                        break;
-                    case URI_REF:
-                        UriRefValue uriOperand = (UriRefValue) comparisonOperand;
-                        distinctResourcesQuery.addWhere( "?s", predicate,  new ResourceImpl(uriOperand.value()));
-                        break;
-                    default:
-                        throw new UnsupportedOperationException("only support for terms of type Comparisons," +
-                            " where the operator is 'EQUALS', and the operand is either a String, an Integer or a URI");
+                        case DECIMAL:
+                            DecimalValue decimalOperand = (DecimalValue) comparisonOperand;
+                            distinctResourcesQuery.addWhere("?s", predicate, decimalOperand.value());
+                            break;
+                        case STRING:
+                            StringValue stringOperand = (StringValue) comparisonOperand;
+                            distinctResourcesQuery.addWhere("?s", predicate, "\"" + stringOperand.value() + "\"");
+                            break;
+                        case URI_REF:
+                            UriRefValue uriOperand = (UriRefValue) comparisonOperand;
+                            distinctResourcesQuery.addWhere("?s", predicate, new ResourceImpl(uriOperand.value()));
+                            break;
+                        default:
+                            throw new UnsupportedOperationException("only support for terms of type Comparisons," +
+                                " where the operator is 'EQUALS', and the operand is either a String, an Integer or a URI");
                     }
                 }
             }

--- a/trs/client/trs-client/src/test/java/org/eclipse/lyo/trs/client/handlers/TrsProviderHandlerTest.java
+++ b/trs/client/trs-client/src/test/java/org/eclipse/lyo/trs/client/handlers/TrsProviderHandlerTest.java
@@ -18,6 +18,8 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
 import org.apache.jena.vocabulary.RDF;
 import org.eclipse.lyo.core.trs.Base;
 import org.eclipse.lyo.core.trs.ChangeEvent;
@@ -270,11 +272,7 @@ public class TrsProviderHandlerTest {
 
         cl.getChange().addAll(changeEvents_p1);
 
-        if (previous != null)
-            cl.setPrevious(previous);
-        else {
-            cl.setPrevious(RDF_NIL);
-        }
+        cl.setPrevious(Objects.requireNonNullElse(previous, RDF_NIL));
     }
 
     private void initBase(Base base, URI previous) throws URISyntaxException {

--- a/trs/client/trs-client/src/test/java/org/eclipse/lyo/trs/client/handlers/TrsProviderTest.java
+++ b/trs/client/trs-client/src/test/java/org/eclipse/lyo/trs/client/handlers/TrsProviderTest.java
@@ -18,6 +18,8 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
 import org.apache.jena.vocabulary.RDF;
 import org.eclipse.lyo.core.trs.Base;
 import org.eclipse.lyo.core.trs.ChangeEvent;
@@ -258,11 +260,7 @@ public class TrsProviderTest {
 
         cl.getChange().addAll(changeEvents_p1);
 
-        if (previous != null) {
-            cl.setPrevious(previous);
-        } else {
-            cl.setPrevious(RDF_NIL);
-        }
+        cl.setPrevious(Objects.requireNonNullElse(previous, RDF_NIL));
     }
 
 }


### PR DESCRIPTION
## Description

Set source code level to Java 11, match bytecode target.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #314 
