### PR TITLE
fix: Consistently save Credentials, Connector & admin_session values under session attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Consistently save Credentials, Connector & admin_session values under session attribute, in the oauth-core AbstractAdapterCredentialsFilter class.
 - Apache Jena depency was updated from 4.5.0 to 4.8.0 due to [CVE-2023-22665](https://lists.apache.org/thread/m7lg8m88cqpjjx8g75d8kbqcrjysdhb9).
 - OSLC Domains are based on latest LyoDesigner, and for `lyoVersion="5.0.1-SNAPSHOT"`.
 - The `oslc4j-core` artifact (group `org.eclipse.lyo.oslc4j.core`) was refactored, extracting some essential model classes into `lyo-core-model` and legacy Wink-dependent code into `oslc4j-core-wink`. _This allows to eliminate all dependencies on Wink. Also, applications that don't need `oslc4j-core`, can eliminate the dependency on JAX-RS by replacing your dependency on `oslc4j-core` with `lyo-core-model`._ **No breaking changes were made.**

--- a/server/oauth-core/pom.xml
+++ b/server/oauth-core/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
+++ b/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
@@ -410,8 +410,6 @@ abstract public class AbstractAdapterCredentialsFilter<Credentials, Connection> 
 	 * This means chain.doFilter() is not called, and no filters in the chain are called.
 	 * @param response 
 	 * @param request 
-	 * @param servletResponse 
-	 * @param servletRequest 
      * @return true if the filter is to interrupt the chain of filters. 
      * that is, the current doFilter() method should simply return, without calling chain.doFilter().
 	 *

--- a/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
+++ b/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
@@ -362,7 +362,7 @@ abstract public class AbstractAdapterCredentialsFilter<Credentials, Connection> 
 					{
 						sendUnauthorizedResponse(response, e);
 						//TODO: Change to a log message.
-			            log.info("UnauthorizedException occured while checking for Basic authentication: {}", e.getMessage());
+			            log.debug("UnauthorizedException occured while checking for Basic authentication: {}");
 						//Do not call chain.doFilter().
 						return;
 					} catch (ServletException ce)

--- a/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
+++ b/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
@@ -362,7 +362,7 @@ abstract public class AbstractAdapterCredentialsFilter<Credentials, Connection> 
 					{
 						sendUnauthorizedResponse(response, e);
 						//TODO: Change to a log message.
-			            log.debug("UnauthorizedException occured while checking for Basic authentication: {}");
+			            log.debug("UnauthorizedException occured while checking for Basic authentication");
 						//Do not call chain.doFilter().
 						return;
 					} catch (ServletException ce)


### PR DESCRIPTION
## Description

Currently, the CredentialsFilter saves 3 attributes CONNECTOR_ATTRIBUTE, CREDENTIALS_ATTRIBUTE & ADMIN_SESSION_ATTRIBUTE.

CREDENTIALS_ATTRIBUTE & ADMIN_SESSION_ATTRIBUTE are always saved as a Session attribute.
Yet, CONNECTOR_ATTRIBUTE is sometimes saved as a request attribute, or a session attribute. (or maybe ultimatly, it is saved in both session and request, but this is hard to guess from the code).

Consistently save the CONNECTOR_ATTRIBUT under session attribute, like all other attributes.

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [x] This PR does NOT break the API

