### PR TITLE
Update NOTICES.md; fixes #397

### DIFF
--- a/NOTICES.md
+++ b/NOTICES.md
@@ -16,12 +16,9 @@ source code repository logs.
 
 ## Declared Project Licenses
 
-This program and the accompanying materials are made available under the terms
-of the Eclipse Public License v1.0 which is available at
-https://www.eclipse.org/legal/epl-v10.html, or the Eclipse Distribution License
-v1.0 which is available at https://www.eclipse.org/org/documents/edl-v10.php.
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which is available at http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License 1.0 which is available at http://www.eclipse.org/org/documents/edl-v10.php
 
-SPDX-License-Identifier: EPL-1.0 OR BSD-3-Clause
+SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
 ## Source Code
 


### PR DESCRIPTION
## Description

Update the license notice in the NOTICE file to reflect the EPL 2.0 relicensing done in Lyo 4.1.0.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [ ] This PR does NOT break the API

## Issues

Closes #397


