### PR TITLE
handling scenario when getPathInfo() returns null

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,7 +30,7 @@ jobs:
           - jdk: '20'
             distribution: zulu
             experimental: true
-          - jdk: '21-ea'
+          - jdk: '21'
             distribution: zulu
             experimental: true
     continue-on-error: ${{ matrix.experimental }}

--- a/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
+++ b/server/oauth-core/src/main/java/org/eclipse/lyo/server/oauth/core/utils/AbstractAdapterCredentialsFilter.java
@@ -203,9 +203,9 @@ abstract public class AbstractAdapterCredentialsFilter<Credentials, Connection> 
      * @return true - the resource is protected, otherwise false
      */
     protected boolean isProtectedResource(HttpServletRequest request) {
-        return !request.getPathInfo().startsWith("/oauth");
+        return (null != request.getPathInfo()) && 
+                !request.getPathInfo().startsWith("/oauth");
     }
-
 
     /**
      * set Connector for this session


### PR DESCRIPTION
## Description

When getPathInfo() returns null (user calls the domain, without any extra relative path), isProtectedResource() gets an exception.
Introduce logic to handle this scenario

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [X] This PR does NOT break the API

