### PR TITLE
changed scope of dependencies in oauth-webapp to avoid inclusion multiple times during runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Kotlin 1.9.0 is used; `kotlin-stdlib-jdk8` dependency was replaced with `kotlin-stdlib` due to [Kotlin updates](https://kotlinlang.org/docs/whatsnew18.html#updated-jvm-compilation-target).
 - Allow application to reset the oauth token cached within the server, when it deems that it is no longer valid
 - 🧨Corrected cardinality and range of the oslc_config:acceptedBy property (from String[0..1] to Resource[0..*])
+- changed scope of dependencies in oauth-webapp to avoid inclusion multiple times during runtime.
 
 ### Deprecated
 

--- a/server/oauth-webapp/pom.xml
+++ b/server/oauth-webapp/pom.xml
@@ -21,10 +21,12 @@
         <dependency>
             <groupId>net.oauth.core</groupId>
             <artifactId>oauth</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.oauth.core</groupId>
             <artifactId>oauth-provider</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Other Lyo modules -->
@@ -32,6 +34,7 @@
             <groupId>org.eclipse.lyo.server</groupId>
             <artifactId>oauth-core</artifactId>
             <version>${v.lyo}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Generic dependencies -->
@@ -55,10 +58,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.wink</groupId>
             <artifactId>wink-json4j</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
changed scope of dependencies in oauth-webapp to avoid inclusion multiple times during runtime

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [x] This PR does NOT break the API

