### PR TITLE
deprecated dependency on Response in OslcQueryResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ This release does not contain new features.
 
 ### Changed
 
-- Deprecate OslcQueryResult constructors that take a Response object. Use the new constructor accepting an InputStream instead.
+- InputStream is now the preferred interface for initializing OslcQueryResult
 
 ### Deprecated
 
-This release does not introduce deprecations.
+- Deprecate OslcQueryResult constructors that take a Response object. Use the new constructor accepting an InputStream instead.
 
 ### Removed
 

--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/query/OslcQueryResult.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/query/OslcQueryResult.java
@@ -120,7 +120,7 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
   private OslcQueryResult(OslcQueryResult prev) {
     this.query = new OslcQuery(prev);
     this.response = this.query.getResponse();
-    this.inputStream = this.query.getResponse().readEntity(InputStream.class);
+    this.inputStream = this.response.readEntity(InputStream.class);
     this.membersResource = prev.membersResource;
     this.memberProperty = prev.memberProperty;
 
@@ -322,7 +322,7 @@ public class OslcQueryResult implements Iterator<OslcQueryResult> {
 
   /**
    * @deprecated
-   * Get the raw Wink client response to a query - if such a response was provided when creating this instance.
+   * Get the raw Jakarta REST reponse to a query - if such a response was provided when creating this instance.
    * <p>
    * NOTE:  Using this method and consuming the response will make other methods
    * which examine the response unavailable (Examples:  getMemberUrls(), next() and hasNext()).


### PR DESCRIPTION
## Description

Deprecate the dependency on Response in OslcQueryResult. 
Instead, OslcQueryResult should be constructed with InputStream.

## Checklist

- [X] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [X] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [X] This PR does NOT break the API
