### PR TITLE
build: apply cache  before any mvn build step

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -115,6 +115,12 @@ jobs:
         with:
           distribution: zulu
           java-version: 25
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-lint-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-lint-
       - name: Run Spotless (Maven plugin)
         run: |
           mvn -B spotless:apply -P!enforcer --file pom.xml
@@ -132,9 +138,3 @@ jobs:
           else
             echo "rewrite FAIL; run `mvn org.openrewrite.maven:rewrite-maven-plugin:run` locally" >&2
           fi
-      - uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-lint-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-lint-


### PR DESCRIPTION
## Description

Apply cache  before any mvn build step

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (e.g. manual workflow on [Lyo Sample](https://github.com/OSLC/lyo-samples/actions/workflows/maven-smoke-manual.yml) and [OSLC RefImpl](https://github.com/oslc-op/refimpl/actions/workflows/maven-acceptance-manual.yml)) or adds unit/integration tests.
- [x] This PR does NOT break the API

## Issues

Closes #0; Closes #00

_(use exactly this syntax to link to issues, one issue per statement only!)_
