### PR TITLE
fix: ensure that HTTP requests append /rootservices at the end

### DIFF
--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/RootServicesHelper.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/RootServicesHelper.java
@@ -82,7 +82,6 @@ public class RootServicesHelper {
       throws RootServicesException {
     this.baseUrl = url;
     this.rootServicesUrl = UriBuilder.fromUri(this.baseUrl).path("rootservices").build().toString();
-    logger.debug(String.format("Fetching rootservices document at URL <%s>", this.rootServicesUrl));
     this.catalogDomain = catalogDomain;
     logger.debug(String.format("Using catalog domain <%s>", this.catalogDomain));
 
@@ -141,6 +140,10 @@ public class RootServicesHelper {
     this(url, catalogDomain, getInputStreamFromClient(url, client));
   }
 
+  private static String getRootServicesUrl(String url) {
+    return UriBuilder.fromUri(url).path("rootservices").build().toString();
+  }
+
   /**
    * Get the OSLC Catalog URL
    *
@@ -150,8 +153,18 @@ public class RootServicesHelper {
     return catalogUrl;
   }
 
-  private static InputStream getInputStreamFromClient(String rootServicesUrl, OslcClient client) throws RootServicesException {
+  private static InputStream getInputStreamFromClient(String inputUrl, OslcClient client)
+      throws RootServicesException {
+    var rootServicesUrl = getRootServicesUrl(inputUrl);
+    logger.debug(String.format("Fetching rootservices document at URL <%s>", rootServicesUrl));
+
     Response response = client.getResource(rootServicesUrl, OSLCConstants.CT_RDF);
+    if (!response.getStatusInfo().getFamily().equals(Response.Status.Family.SUCCESSFUL)) {
+      throw new RootServicesException(
+          rootServicesUrl,
+          new IllegalStateException(
+              "Server returned an error: " + response.getStatusInfo().getStatusCode()));
+    }
     return response.readEntity(InputStream.class);
   }
 


### PR DESCRIPTION
Fixing a regression introduced by #811 

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [x] This PR was tested on at least one Lyo OSLC server (comment `@oslc-bot /test-all` if not sure) or adds unit/integration tests.
- [x] This PR does NOT break the API
- [x] Lint checks pass (run `mvn package org.openrewrite.maven:rewrite-maven-plugin:run spotless:apply -DskipTests -P'!enforcer'` if not, commit & push)

