### PR TITLE
Drop commons-lang v2 from the BOM

### DIFF
--- a/bom/lyo-bom/pom.xml
+++ b/bom/lyo-bom/pom.xml
@@ -290,11 +290,6 @@
         <version>${v.jersey}</version>
       </dependency>
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.20.0</version>


### PR DESCRIPTION
Removed deprecated commons-lang dependency from the BOM due to a CVE. The BOM already contains the updated commons-lang3.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (comment `@oslc-bot /test-all` if not sure) or adds unit/integration tests.
- [ ] This PR does NOT break the API
- [x] Lint checks pass (run `mvn package org.openrewrite.maven:rewrite-maven-plugin:run spotless:apply -DskipTests -P'!enforcer'` if not, commit & push)

