### PR TITLE
fix(trs): consume RefImpl and Jazz TRS feeds

### DIFF
--- a/trs/client/trs-client/pom.xml
+++ b/trs/client/trs-client/pom.xml
@@ -147,9 +147,26 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-netty</artifactId>
+      <version>5.15.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.diffplug.selfie</groupId>
+      <artifactId>selfie-runner-junit5</artifactId>
+      <version>2.5.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/trs/client/trs-client/pom.xml
+++ b/trs/client/trs-client/pom.xml
@@ -127,6 +127,31 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-junit-jupiter</artifactId>
+      <version>5.15.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/trs/client/trs-client/pom.xml
+++ b/trs/client/trs-client/pom.xml
@@ -133,28 +133,21 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>5.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>5.11.0</version>
+      <version>5.21.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-junit-jupiter</artifactId>
-      <version>5.15.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
+
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/ConcurrentTrsProviderHandler.java
+++ b/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/ConcurrentTrsProviderHandler.java
@@ -120,7 +120,7 @@ public class ConcurrentTrsProviderHandler implements IProviderHandler {
     private void pollAndProcessChanges() {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
         Date processingDateStart = new Date();
-        log.info("started dealing with TRS Provider: " + trsUriBase);
+        log.debug("started dealing with TRS Provider: " + trsUriBase);
 
         TrackedResourceSet updatedTrs = trsClient.extractRemoteTrs(trsUriBase);
         boolean indexingStage = false;

--- a/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/ConcurrentTrsProviderHandler.java
+++ b/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/ConcurrentTrsProviderHandler.java
@@ -120,7 +120,7 @@ public class ConcurrentTrsProviderHandler implements IProviderHandler {
     private void pollAndProcessChanges() {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
         Date processingDateStart = new Date();
-        log.debug("started dealing with TRS Provider: " + trsUriBase);
+        log.debug("started dealing with TRS Provider: {}", trsUriBase);
 
         TrackedResourceSet updatedTrs = trsClient.extractRemoteTrs(trsUriBase);
         boolean indexingStage = false;

--- a/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/TrsProviderHandler.java
+++ b/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/TrsProviderHandler.java
@@ -79,9 +79,10 @@ public class TrsProviderHandler implements IProviderHandler {
             pollAndProcessChanges();
         } catch (Exception e) {
             // FIXME Andrew@2019-07-15: can get stuck in the loop
-            log.warn("Force rebase");
+            log.warn("Force rebase", e);
             lastProcessedChangeEventUri = null;
             handler.rebase();
+            throw new RuntimeException("Failed to update TRS", e);
         }
     }
 

--- a/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/TrsProviderHandler.java
+++ b/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/TrsProviderHandler.java
@@ -262,21 +262,27 @@ public class TrsProviderHandler implements IProviderHandler {
      */
     private boolean fetchRemoteChangeLogs(ChangeLog currentChangeLog, List<ChangeLog> changeLogs) {
         boolean foundChangeEvent = false;
-        URI previousChangeLog;
-        do {
-            if (currentChangeLog != null) {
-                changeLogs.add(currentChangeLog);
+        if (lastProcessedChangeEventUri == null || RDF.nil.getURI().equals(lastProcessedChangeEventUri.toString())) {
+            foundChangeEvent = true;
+        }
+        
+        while (currentChangeLog != null) {
+            changeLogs.add(currentChangeLog);
+            if (lastProcessedChangeEventUri != null && !RDF.nil.getURI().equals(lastProcessedChangeEventUri.toString())) {
                 if (ProviderUtil.changeLogContainsEvent(lastProcessedChangeEventUri,
                         currentChangeLog)) {
                     foundChangeEvent = true;
                     break;
                 }
-                previousChangeLog = currentChangeLog.getPrevious();
-                currentChangeLog = trsClient.fetchRemoteChangeLog(previousChangeLog);
-            } else {
+            }
+            
+            URI previousChangeLog = currentChangeLog.getPrevious();
+            if (previousChangeLog == null || RDF.nil.getURI().equals(previousChangeLog.toString())) {
                 break;
             }
-        } while (!RDF.nil.getURI().equals(previousChangeLog.toString()));
+            
+            currentChangeLog = trsClient.fetchRemoteChangeLog(previousChangeLog);
+        }
         return foundChangeEvent;
     }
 

--- a/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/TrsProviderHandler.java
+++ b/trs/client/trs-client/src/main/java/org/eclipse/lyo/trs/client/handlers/TrsProviderHandler.java
@@ -80,13 +80,14 @@ public class TrsProviderHandler implements IProviderHandler {
         } catch (Exception e) {
             // FIXME Andrew@2019-07-15: can get stuck in the loop
             log.warn("Force rebase");
-            log.debug("Force rebase exception: {}", e);
+            log.debug("Force rebase exception", e);
             lastProcessedChangeEventUri = null;
             try {
                 handler.rebase();
             } catch (Exception rebaseException) {
                 log.error("Error during rebase", rebaseException);
-                throw new RuntimeException("Failed to update TRS", e);
+                rebaseException.addSuppressed(e);
+                throw new RuntimeException("Failed to update TRS", rebaseException);
             }
         }
     }
@@ -122,7 +123,7 @@ public class TrsProviderHandler implements IProviderHandler {
      */
     private void pollAndProcessChanges() {
 
-        log.debug("started dealing with TRS Provider: " + trsUriBase);
+        log.debug("started dealing with TRS Provider: {}", trsUriBase);
 
         TrackedResourceSet updatedTrs = trsClient.extractRemoteTrs(trsUriBase);
         boolean indexingStage = false;
@@ -289,7 +290,7 @@ public class TrsProviderHandler implements IProviderHandler {
             } else {
                 break;
             }
-        } while (previousChangeLog != null && !RDF.nil.getURI().equals(previousChangeLog.toString()));
+        } while (!RDF.nil.getURI().equals(previousChangeLog.toString()));
         return foundChangeEvent;
     }
 

--- a/trs/client/trs-client/src/test/java/org/eclipse/lyo/trs/client/handlers/ConcurrentTrsProviderHandlerTest.java
+++ b/trs/client/trs-client/src/test/java/org/eclipse/lyo/trs/client/handlers/ConcurrentTrsProviderHandlerTest.java
@@ -1,0 +1,74 @@
+package org.eclipse.lyo.trs.client.handlers;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.vocabulary.RDF;
+import org.eclipse.lyo.core.trs.ChangeLog;
+import org.eclipse.lyo.trs.client.util.ITrackedResourceClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ConcurrentTrsProviderHandlerTest {
+
+    @Mock
+    private ITrackedResourceClient trsClient;
+    @Mock
+    private IProviderEventHandler handler;
+
+    @BeforeAll
+    public static void initJena() {
+        JenaSystem.init();
+    }
+
+    @Test
+    public void testFetchRemoteChangeLogs_HitNil_Found() {
+        URI trsUri = URI.create("http://example.com/trs");
+        ConcurrentTrsProviderHandler provider = new ConcurrentTrsProviderHandler(trsUri, trsClient, handler);
+
+        try {
+            java.lang.reflect.Field field = ConcurrentTrsProviderHandler.class.getDeclaredField("lastProcessedChangeEventUri");
+            field.setAccessible(true);
+            field.set(provider, URI.create(RDF.nil.getURI()));
+        } catch (Exception e) {
+            Assertions.fail("Failed to set private field", e);
+        }
+
+        ChangeLog currentLog = new ChangeLog();
+        currentLog.setPrevious(URI.create(RDF.nil.getURI()));
+        
+        List<ChangeLog> changeLogs = new ArrayList<>();
+        boolean found = provider.fetchRemoteChangeLogs(currentLog, changeLogs);
+        
+        Assertions.assertTrue(found, "Should find sync event when hitting nil and last processed is nil");
+        Assertions.assertEquals(1, changeLogs.size());
+    }
+    
+    @Test
+    public void testFetchRemoteChangeLogs_HitNil_NotFound() {
+        URI trsUri = URI.create("http://example.com/trs");
+        ConcurrentTrsProviderHandler provider = new ConcurrentTrsProviderHandler(trsUri, trsClient, handler);
+
+        try {
+            java.lang.reflect.Field field = ConcurrentTrsProviderHandler.class.getDeclaredField("lastProcessedChangeEventUri");
+            field.setAccessible(true);
+            field.set(provider, URI.create("http://example.com/event/1"));
+        } catch (Exception e) {
+            Assertions.fail("Failed to set private field", e);
+        }
+
+        ChangeLog currentLog = new ChangeLog();
+        currentLog.setPrevious(URI.create(RDF.nil.getURI()));
+        
+        List<ChangeLog> changeLogs = new ArrayList<>();
+        boolean found = provider.fetchRemoteChangeLogs(currentLog, changeLogs);
+        
+        Assertions.assertFalse(found, "Should NOT find sync event if we hit nil but were looking for specific event");
+    }
+}

--- a/trs/client/trs-client/src/test/java/org/eclipse/lyo/trs/client/util/ClientUtilTest.java
+++ b/trs/client/trs-client/src/test/java/org/eclipse/lyo/trs/client/util/ClientUtilTest.java
@@ -1,0 +1,207 @@
+package org.eclipse.lyo.trs.client.util;
+
+import static com.diffplug.selfie.Selfie.expectSelfie;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.eclipse.lyo.core.trs.Base;
+import org.eclipse.lyo.core.trs.ChangeEvent;
+import org.eclipse.lyo.core.trs.ChangeLog;
+import org.eclipse.lyo.core.trs.TrackedResourceSet;
+import org.eclipse.lyo.trs.client.exceptions.TrsEndpointConfigException;
+import org.eclipse.lyo.trs.client.exceptions.TrsEndpointErrorException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.MediaType;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+
+class ClientUtilTest {
+
+    private static ClientAndServer mockServer;
+    private static MockServerClient mockServerClient;
+    private static String baseUri;
+    private static Client jaxrsClient;
+
+    static {
+        JenaSystem.init();
+    }
+
+    @BeforeAll
+    static void startServer() {
+        mockServer = startClientAndServer(0);
+        mockServerClient = new MockServerClient("localhost", mockServer.getPort());
+        baseUri = "http://localhost:" + mockServer.getPort();
+        jaxrsClient = ClientBuilder.newClient();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        mockServer.stop();
+        jaxrsClient.close();
+    }
+
+    @Test
+    void testExtractTrsFromRdfModel() throws Exception {
+        Model model = loadModel("01-trs-main.rdf");
+        TrackedResourceSet trs = ClientUtil.extractTrsFromRdfModel(model);
+        
+        StringBuilder sb = new StringBuilder();
+        sb.append("TRS About: ").append(trs.getAbout()).append("\n");
+        sb.append("TRS Base: ").append(trs.getBase()).append("\n");
+        sb.append("TRS ChangeLog About: ").append(trs.getChangeLog().getAbout()).append("\n");
+        sb.append("TRS ChangeLog Changes count: ").append(trs.getChangeLog().getChange().size()).append("\n");
+        
+        expectSelfie(stabilize(sb.toString())).toMatchDisk();
+    }
+
+    @Test
+    void testExtractBaseFromRdfModelDirectContainer() throws Exception {
+        Model model = loadModel("02-trs-base.rdf");
+        Base base = ClientUtil.extractBaseFromRdfModel(model);
+        
+        StringBuilder sb = new StringBuilder();
+        sb.append("Base About: ").append(base.getAbout()).append("\n");
+        sb.append("Base CutoffEvent: ").append(base.getCutoffEvent()).append("\n");
+        sb.append("Base Members count: ").append(base.getMembers().size()).append("\n");
+        for (URI member : base.getMembers()) {
+            sb.append("  Member: ").append(member).append("\n");
+        }
+        
+        expectSelfie(stabilize(sb.toString())).toMatchDisk();
+    }
+
+    @Test
+    void testExtractBaseFromRdfModelStandardContainer() throws Exception {
+        Model model = ModelFactory.createDefaultModel();
+        String trsNs = "http://open-services.net/ns/core/trs#";
+        String ldpNs = "http://www.w3.org/ns/ldp#";
+        
+        Resource baseRes = model.createResource(baseUri + "/base");
+        baseRes.addProperty(RDF.type, model.createResource(ldpNs + "Container"));
+        baseRes.addProperty(model.createProperty(trsNs + "cutoffEvent"), model.createResource(baseUri + "/event1"));
+        baseRes.addProperty(RDFS.member, model.createResource(baseUri + "/res1"));
+        baseRes.addProperty(RDFS.member, model.createResource(baseUri + "/res2"));
+
+        Base base = ClientUtil.extractBaseFromRdfModel(model);
+        
+        StringBuilder sb = new StringBuilder();
+        sb.append("Base About: ").append(base.getAbout()).append("\n");
+        sb.append("Base CutoffEvent: ").append(base.getCutoffEvent()).append("\n");
+        sb.append("Base Members count: ").append(base.getMembers().size()).append("\n");
+        for (URI member : base.getMembers()) {
+            sb.append("  Member: ").append(member).append("\n");
+        }
+        
+        expectSelfie(stabilize(sb.toString())).toMatchDisk();
+    }
+
+    @Test
+    void testExtractBaseFromRdfModelDirectContainerRdfsMember() throws Exception {
+        Model model = ModelFactory.createDefaultModel();
+        String ldpNs = "http://www.w3.org/ns/ldp#";
+        
+        Resource baseRes = model.createResource(baseUri + "/base");
+        baseRes.addProperty(RDF.type, model.createResource(ldpNs + "DirectContainer"));
+        baseRes.addProperty(RDFS.member, model.createResource(baseUri + "/res1"));
+
+        Base base = ClientUtil.extractBaseFromRdfModel(model);
+        
+        StringBuilder sb = new StringBuilder();
+        sb.append("Base About: ").append(base.getAbout()).append("\n");
+        sb.append("Base Members count: ").append(base.getMembers().size()).append("\n");
+        sb.append("  Member: ").append(base.getMembers().get(0)).append("\n");
+        
+        expectSelfie(stabilize(sb.toString())).toMatchDisk();
+    }
+
+    @Test
+    void testExtractChangeLogFromRdfModel() throws Exception {
+        Model model = loadModel("01-trs-main.rdf");
+        ChangeLog cl = ClientUtil.extractChangeLogFromRdfModel(model);
+        
+        expectSelfie("Change count: " + cl.getChange().size()).toMatchDisk();
+        List<ChangeEvent> changes = cl.getChange();
+        if (!changes.isEmpty()) {
+            expectSelfie(stabilize("First change about: " + changes.get(0).getAbout())).toMatchDisk("firstChange");
+        }
+    }
+
+    @Test
+    void testExtractResourceFromResponse() throws Exception {
+        String rdfBody = getFixtureBody("01-trs-main.rdf");
+        mockServerClient
+                .when(request().withPath("/trs"))
+                .respond(response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.parse("application/rdf+xml"))
+                        .withBody(rdfBody));
+
+        try (Response response = jaxrsClient.target(baseUri + "/trs").request().get()) {
+            Model model = (Model) ClientUtil.extractResourceFromResponse(response, Model.class);
+            expectSelfie(String.valueOf(model.size())).toMatchDisk("modelSize");
+        }
+    }
+
+    @Test
+    void testExtractResourceFromResponseClientError() {
+        mockServerClient
+                .when(request().withPath("/404"))
+                .respond(response().withStatusCode(404));
+
+        try (Response response = jaxrsClient.target(baseUri + "/404").request().get()) {
+            assertThrows(TrsEndpointConfigException.class, () -> 
+                ClientUtil.extractResourceFromResponse(response, Model.class)
+            );
+        }
+    }
+
+    @Test
+    void testExtractResourceFromResponseServerError() {
+        mockServerClient
+                .when(request().withPath("/500"))
+                .respond(response().withStatusCode(500));
+
+        try (Response response = jaxrsClient.target(baseUri + "/500").request().get()) {
+            assertThrows(TrsEndpointErrorException.class, () -> 
+                ClientUtil.extractResourceFromResponse(response, Model.class)
+            );
+        }
+    }
+
+    private Model loadModel(String fixtureName) throws IOException {
+        String body = getFixtureBody(fixtureName);
+        Model model = ModelFactory.createDefaultModel();
+        model.read(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)), null, "RDF/XML");
+        return model;
+    }
+
+    private String getFixtureBody(String fixtureName) throws IOException {
+        Path path = Path.of("src/test/resources/fixtures", fixtureName);
+        return Files.readString(path).replace("http://localhost:8080", baseUri);
+    }
+
+    private String stabilize(String content) {
+        return content.replace(baseUri, "http://localhost:PORT");
+    }
+}

--- a/trs/client/trs-client/src/test/java/org/eclipse/lyo/trs/client/util/ClientUtilTest.ss
+++ b/trs/client/trs-client/src/test/java/org/eclipse/lyo/trs/client/util/ClientUtilTest.ss
@@ -1,0 +1,31 @@
+╔═ testExtractBaseFromRdfModelDirectContainer ═╗
+Base About: http://localhost:PORT/qm/trs2/base
+Base CutoffEvent: http://www.w3.org/1999/02/22-rdf-syntax-ns#nil
+Base Members count: 1
+  Member: http://localhost:PORT/qm/oslc_config/resourceShapes/com.ibm.team.vvc.Component
+
+╔═ testExtractBaseFromRdfModelDirectContainerRdfsMember ═╗
+Base About: http://localhost:PORT/base
+Base Members count: 1
+  Member: http://localhost:PORT/res1
+
+╔═ testExtractBaseFromRdfModelStandardContainer ═╗
+Base About: http://localhost:PORT/base
+Base CutoffEvent: http://localhost:PORT/event1
+Base Members count: 2
+  Member: http://localhost:PORT/res2
+  Member: http://localhost:PORT/res1
+
+╔═ testExtractChangeLogFromRdfModel ═╗
+Change count: 25
+╔═ testExtractChangeLogFromRdfModel/firstChange ═╗
+First change about: urn:com.ibm.rqm.history:TrsChangeEvent:_9DSiYPiOEfCemrqJG70qgA
+╔═ testExtractResourceFromResponse/modelSize ═╗
+130
+╔═ testExtractTrsFromRdfModel ═╗
+TRS About: http://localhost:PORT/qm/trs2
+TRS Base: http://localhost:PORT/qm/trs2/base
+TRS ChangeLog About: null
+TRS ChangeLog Changes count: 25
+
+╔═ [end of file] ═╗

--- a/trs/client/trs-client/src/test/resources/fixtures/01-trs-main.rdf
+++ b/trs/client/trs-client/src/test/resources/fixtures/01-trs-main.rdf
@@ -1,0 +1,195 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:lqe="http://jazz.net/ns/lqe#"
+    xmlns:trs1="http://jazz.net/ns/trs#"
+    xmlns:jazz="http://jazz.net/ns/jazz#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:trspatch="http://open-services.net/ns/core/trspatch#"
+    xmlns:trs2="http://open-services.net/ns/core/trs#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#" > 
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_8_oKYPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">792A240181439462AEF7204FA0F7DA119D638A6DBD0AC0C10B8C8E44E6AD6F4F</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">32</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9Ct6oPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B9E1681C3C1B5DC8BDDA3AD04BB64212C1ABED5E41CD6C98BDF769388E4682F1</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">46</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionElementResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9DCqwPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">792A240181439462AEF7204FA0F7DA119D638A6DBD0AC0C10B8C8E44E6AD6F4F</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">47</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9CppMPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6F9973834AD320F896A1D602236A3D4BBA669B2ECC9D1FB452E100EC1DF2D3F8</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">45</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResultGroup"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9BfyoPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">792A240181439462AEF7204FA0F7DA119D638A6DBD0AC0C10B8C8E44E6AD6F4F</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">41</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9Ano4PiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6F9973834AD320F896A1D602236A3D4BBA669B2ECC9D1FB452E100EC1DF2D3F8</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">36</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResultGroup"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9BHYIPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6F9973834AD320F896A1D602236A3D4BBA669B2ECC9D1FB452E100EC1DF2D3F8</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">39</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResultGroup"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9DSiYPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6F9973834AD320F896A1D602236A3D4BBA669B2ECC9D1FB452E100EC1DF2D3F8</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">48</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResultGroup"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9ERZ0PiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">792A240181439462AEF7204FA0F7DA119D638A6DBD0AC0C10B8C8E44E6AD6F4F</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">53</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9DVlsPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B9E1681C3C1B5DC8BDDA3AD04BB64212C1ABED5E41CD6C98BDF769388E4682F1</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">49</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionElementResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9B5bQPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B9E1681C3C1B5DC8BDDA3AD04BB64212C1ABED5E41CD6C98BDF769388E4682F1</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">43</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionElementResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://localhost:8080/qm/trs2">
+    <trs2:changeLog rdf:nodeID="A0"/>
+    <trs2:base rdf:resource="http://localhost:8080/qm/trs2/base"/>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#TrackedResourceSet"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9BMQoPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B9E1681C3C1B5DC8BDDA3AD04BB64212C1ABED5E41CD6C98BDF769388E4682F1</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">40</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionElementResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="A0">
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9ERZ0PiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9B5bQPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9EkUwPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9EgDUPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9Ano4PiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9A7x8PiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_8_-IoPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9CX8YPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9AaNgPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9BMQoPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9D6NcPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_8_Gl8PiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9Ct6oPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9CppMPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9DuAMPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9AqsMPiOEfCemrqJG70qgA"/>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#ChangeLog"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9DSiYPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9BHYIPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_8_oKYPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_8_53MPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9B1J0PiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9BfyoPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9DCqwPiOEfCemrqJG70qgA"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9DVlsPiOEfCemrqJG70qgA"/>
+    <trs2:previous rdf:resource="http://localhost:8080/qm/trs2/changeLog/31"/>
+    <trs2:change rdf:resource="urn:com.ibm.rqm.history:TrsChangeEvent:_9D9QwPiOEfCemrqJG70qgA"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_8_53MPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6F9973834AD320F896A1D602236A3D4BBA669B2ECC9D1FB452E100EC1DF2D3F8</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">33</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResultGroup"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9AaNgPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">792A240181439462AEF7204FA0F7DA119D638A6DBD0AC0C10B8C8E44E6AD6F4F</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">35</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9B1J0PiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6F9973834AD320F896A1D602236A3D4BBA669B2ECC9D1FB452E100EC1DF2D3F8</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">42</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResultGroup"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9DuAMPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">792A240181439462AEF7204FA0F7DA119D638A6DBD0AC0C10B8C8E44E6AD6F4F</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">50</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9EkUwPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B9E1681C3C1B5DC8BDDA3AD04BB64212C1ABED5E41CD6C98BDF769388E4682F1</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">55</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionElementResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9CX8YPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">792A240181439462AEF7204FA0F7DA119D638A6DBD0AC0C10B8C8E44E6AD6F4F</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">44</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9A7x8PiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">792A240181439462AEF7204FA0F7DA119D638A6DBD0AC0C10B8C8E44E6AD6F4F</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">38</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_8_-IoPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B9E1681C3C1B5DC8BDDA3AD04BB64212C1ABED5E41CD6C98BDF769388E4682F1</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">34</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionElementResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9D6NcPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6F9973834AD320F896A1D602236A3D4BBA669B2ECC9D1FB452E100EC1DF2D3F8</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">51</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResultGroup"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9AqsMPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B9E1681C3C1B5DC8BDDA3AD04BB64212C1ABED5E41CD6C98BDF769388E4682F1</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">37</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionElementResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9D9QwPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B9E1681C3C1B5DC8BDDA3AD04BB64212C1ABED5E41CD6C98BDF769388E4682F1</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">52</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionElementResult"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_9EgDUPiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6F9973834AD320F896A1D602236A3D4BBA669B2ECC9D1FB452E100EC1DF2D3F8</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">54</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionResultGroup"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:com.ibm.rqm.history:TrsChangeEvent:_8_Gl8PiOEfCemrqJG70qgA">
+    <trspatch:afterEtag rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B9E1681C3C1B5DC8BDDA3AD04BB64212C1ABED5E41CD6C98BDF769388E4682F1</trspatch:afterEtag>
+    <trs2:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int">31</trs2:order>
+    <rdf:type rdf:resource="http://open-services.net/ns/core/trs#Modification"/>
+    <trs2:changed rdf:resource="http://localhost:8080/qm/oslc_qm/contexts/_7Wg3gPiOEfCemrqJG70qgA/shape/resource/com.ibm.rqm.execution.ExecutionElementResult"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/trs/client/trs-client/src/test/resources/fixtures/02-trs-base.rdf
+++ b/trs/client/trs-client/src/test/resources/fixtures/02-trs-base.rdf
@@ -1,0 +1,21 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:lqe="http://jazz.net/ns/lqe#"
+    xmlns:trs1="http://jazz.net/ns/trs#"
+    xmlns:jazz="http://jazz.net/ns/jazz#"
+    xmlns:ldp="http://www.w3.org/ns/ldp#"
+    xmlns:trspatch="http://open-services.net/ns/core/trspatch#"
+    xmlns:trs2="http://open-services.net/ns/core/trs#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#" > 
+  <rdf:Description rdf:about="http://localhost:8080/qm/trs2/base">
+    <ldp:member rdf:resource="http://localhost:8080/qm/oslc_config/resourceShapes/com.ibm.team.vvc.Component"/>
+    <trs2:cutoffEvent rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+    <ldp:hasMemberRelation rdf:resource="http://www.w3.org/ns/ldp#member"/>
+    <ldp:membershipResource rdf:resource="http://localhost:8080/qm/trs2/base"/>
+    <rdf:type rdf:resource="http://www.w3.org/ns/ldp#DirectContainer"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://localhost:8080/qm/trs2/base/_BrxtQPiLEfCemrqJG70qgA?pageNum=0">
+    <ldp:nextPage rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+  </rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
For RefImpl:

Do not treat a nil base cutoff as a rebase reason if it has been fetched before and had the same `rdf:nil` value.

This could happen if a server starts with an empty base (legit, afaik) and keeps adding change events to the log, never rebasing on the server side (legit, afaik). The PR prevents an endless rebase loop that continues until the server base becomes non-empty.

For Jazz:

Handle ldp:DirectContainer, not just ldp:Container.

The handling is quite hacky and should be refactored.


## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (comment `@oslc-bot /test-all` if not sure) or adds unit/integration tests.
- [ ] This PR does NOT break the API
- [ ] Lint checks pass (run `mvn package org.openrewrite.maven:rewrite-maven-plugin:run spotless:apply -DskipTests -P'!enforcer'` if not, commit & push)

