### PR TITLE
feat: Refactor configuration to use Jakarta Config in lyo-server-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,11 @@
         <version>3.0.2</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.lyo.server</groupId>
+        <artifactId>lyo-server-common</artifactId>
+        <version>${v.lyo}</version>
+      </dependency>
+      <dependency>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core</artifactId>
         <version>${v.lyo}</version>

--- a/server/lyo-server-common/pom.xml
+++ b/server/lyo-server-common/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.lyo.oslc4j.server</groupId>
+        <artifactId>lyo-server-build</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <groupId>org.eclipse.lyo.server</groupId>
+    <artifactId>lyo-server-common</artifactId>
+    <packaging>jar</packaging>
+    <name>Lyo :: Server :: Common</name>
+    <description>Common components for Lyo Server</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>3.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <version>3.4.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/server/lyo-server-common/src/main/java/org/eclipse/lyo/server/common/LyoAppConfiguration.java
+++ b/server/lyo-server-common/src/main/java/org/eclipse/lyo/server/common/LyoAppConfiguration.java
@@ -1,0 +1,61 @@
+package org.eclipse.lyo.server.common;
+
+import jakarta.servlet.ServletContext;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+/**
+ * Utility class for retrieving configuration properties.
+ * <p>
+ * This class uses MicroProfile Config (Jakarta Config) as the primary source of configuration,
+ * falling back to ServletContext init parameters if the property is not found in the Config sources.
+ */
+public class LyoAppConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(LyoAppConfiguration.class);
+
+    private LyoAppConfiguration() {
+        // Utility class
+    }
+
+    /**
+     * Retrieves a configuration property using MicroProfile Config and falls back to ServletContext init parameters.
+     * <p>
+     * The search order is determined by the MicroProfile Config implementation (typically System Properties > Environment Variables > microprofile-config.properties),
+     * followed by ServletContext init parameters.
+     *
+     * @param context the ServletContext to check for fallback (can be null)
+     * @param key     the configuration key
+     * @return the property value, or null if not found
+     */
+    public static String getOslcConfigProperty(ServletContext context, String key) {
+        // 1. Check MicroProfile Config
+        try {
+            Config config = ConfigProvider.getConfig();
+            Optional<String> value = config.getOptionalValue(key, String.class);
+            if (value.isPresent()) {
+                logger.debug("Found property '{}' in MicroProfile Config", key);
+                return value.get();
+            }
+        } catch (Exception e) {
+            // ConfigProvider might fail if no implementation is available
+            logger.debug("MicroProfile Config not available or failed for key '{}': {}", key, e.getMessage());
+        }
+
+        // 2. Check Servlet Context
+        if (context != null) {
+            String initParam = context.getInitParameter(key);
+            if (initParam != null) {
+                logger.debug("Found property '{}' in ServletContext", key);
+                return initParam;
+            }
+        }
+
+        logger.debug("Property '{}' not found in configuration or ServletContext", key);
+        return null;
+    }
+}

--- a/server/lyo-server-common/src/test/java/org/eclipse/lyo/server/common/LyoAppConfigurationTest.java
+++ b/server/lyo-server-common/src/test/java/org/eclipse/lyo/server/common/LyoAppConfigurationTest.java
@@ -1,0 +1,63 @@
+package org.eclipse.lyo.server.common;
+
+import jakarta.servlet.ServletContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+public class LyoAppConfigurationTest {
+
+    private static final String TEST_KEY = "test.property";
+    private static final String SYSTEM_VAL = "systemValue";
+    private static final String CONTEXT_VAL = "contextValue";
+
+    @Before
+    public void setUp() {
+        System.clearProperty(TEST_KEY);
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty(TEST_KEY);
+    }
+
+    @Test
+    public void testSystemPropertyOverride() {
+        System.setProperty(TEST_KEY, SYSTEM_VAL);
+        ServletContext context = Mockito.mock(ServletContext.class);
+        when(context.getInitParameter(TEST_KEY)).thenReturn(CONTEXT_VAL);
+
+        String value = LyoAppConfiguration.getOslcConfigProperty(context, TEST_KEY);
+        assertEquals("System property should override context param", SYSTEM_VAL, value);
+    }
+
+    @Test
+    public void testContextFallback() {
+        ServletContext context = Mockito.mock(ServletContext.class);
+        when(context.getInitParameter(TEST_KEY)).thenReturn(CONTEXT_VAL);
+
+        String value = LyoAppConfiguration.getOslcConfigProperty(context, TEST_KEY);
+        assertEquals("Should fall back to context param", CONTEXT_VAL, value);
+    }
+
+    @Test
+    public void testNotFound() {
+        ServletContext context = Mockito.mock(ServletContext.class);
+        when(context.getInitParameter(TEST_KEY)).thenReturn(null);
+
+        String value = LyoAppConfiguration.getOslcConfigProperty(context, TEST_KEY);
+        assertNull("Should return null if not found", value);
+    }
+
+    @Test
+    public void testNullContext() {
+        System.setProperty(TEST_KEY, SYSTEM_VAL);
+        String value = LyoAppConfiguration.getOslcConfigProperty(null, TEST_KEY);
+        assertEquals("Should work with null context", SYSTEM_VAL, value);
+    }
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,6 +23,7 @@
     <module>net.oauth.core-oauth-consumer-jakarta</module>
     <module>net.oauth.core-oauth-provider-jakarta</module>
     <module>net.oauth.core-oauth-httpclient4-jakarta</module>
+    <module>lyo-server-common</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
Introduces a new `lyo-server-common` module to handle configuration property retrieval using the MicroProfile Config (Jakarta Config) API. This replaces the previous manual priority logic (Env > System > Context) with the standard Config precedence (System > Env > Properties) while maintaining a fallback to `ServletContext` init parameters.

Changes:
- Created `server/lyo-server-common` module.
- Added `microprofile-config-api` dependency.
- Implemented `LyoAppConfiguration` utility class.
- Added unit tests for `LyoAppConfiguration`.
- Registered module in parent POMs.

This refactoring aligns with Jakarta Config standards and separates server-specific configuration logic from core modules.

**This PR supersedes #220**

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (comment `@oslc-bot /test-all` if not sure) or adds unit/integration tests.
- [ ] This PR does NOT break the API
- [ ] Lint checks pass (run `mvn package org.openrewrite.maven:rewrite-maven-plugin:run spotless:apply -DskipTests -P'!enforcer'` if not, commit & push)

