### PR TITLE
Cleanup rdf4j-repository-sparql dependency management

### DIFF
--- a/trs/client/pom.xml
+++ b/trs/client/pom.xml
@@ -18,17 +18,7 @@
     <module>trs-client</module>
     <module>client-source-mqtt</module>
   </modules>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.eclipse.rdf4j</groupId>
-        <artifactId>rdf4j-repository-sparql</artifactId>
-        <version>5.3.2</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
+  
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Removed dependency management for rdf4j-repository-sparql.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (comment `@oslc-bot /test-all` if not sure) or adds unit/integration tests.
- [x] This PR does NOT break the API
- [ ] Lint checks pass (run `mvn package org.openrewrite.maven:rewrite-maven-plugin:run spotless:apply -DskipTests -P'!enforcer'` if not, commit & push)

