### PR TITLE
client: refactor RmUtil into a general shape client

### DIFF
--- a/client/oslc-client/pom.xml
+++ b/client/oslc-client/pom.xml
@@ -97,6 +97,11 @@
       <version>${v.lyo}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.lyo</groupId>
+      <artifactId>oslc-domains</artifactId>
+      <version>${v.lyo}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.lyo.oslc4j.core</groupId>
       <artifactId>oslc4j-jena-provider</artifactId>
       <version>${v.lyo}</version>

--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/resources/ResourceShapeClient.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/resources/ResourceShapeClient.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License 1.0
+ * which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.lyo.client.resources;
+
+import static java.util.Objects.requireNonNull;
+
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import net.oauth.OAuthException;
+import org.eclipse.lyo.client.OSLCConstants;
+import org.eclipse.lyo.client.OslcClient;
+import org.eclipse.lyo.client.exception.ResourceNotFoundException;
+import org.eclipse.lyo.oslc.domains.am.Oslc_amDomainConstants;
+import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
+import org.eclipse.lyo.oslc.domains.qm.Oslc_qmDomainConstants;
+import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
+import org.eclipse.lyo.oslc4j.core.model.CreationFactory;
+import org.eclipse.lyo.oslc4j.core.model.ResourceShape;
+import org.eclipse.lyo.oslc4j.core.model.Service;
+import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
+
+/**
+ * Discovers resource shapes advertised by OSLC creation factories.
+ *
+ * <p>The client can optionally be bound to an OSLC configuration context:
+ *
+ * <pre>{@code
+ * var shapes = new ResourceShapeClient(oslcClient, configurationUri);
+ *
+ * var shape = shapes.lookupRequirementShape(
+ *         serviceProviderUri,
+ *         "System Requirement");
+ * }</pre>
+ */
+public final class ResourceShapeClient {
+  private final OslcClient client;
+  private final URI configurationContext;
+
+  public ResourceShapeClient(OslcClient client) {
+    this(client, null);
+  }
+
+  public ResourceShapeClient(OslcClient client, URI configurationContext) {
+
+    this.client = requireNonNull(client, "client");
+    this.configurationContext = configurationContext;
+  }
+
+  /**
+   * Looks up a resource shape advertised by a matching creation factory.
+   *
+   * <p>{@code shapeIdentifier} may be either:
+   *
+   * <ul>
+   *   <li>the resource shape URI, or</li>
+   *   <li>the resource shape title, matched case-insensitively.</li>
+   * </ul>
+   */
+  public ResourceShape lookupShape(
+      URI serviceProviderUri, URI domain, URI resourceType, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    requireNonNull(serviceProviderUri, "serviceProviderUri");
+    requireNonNull(domain, "domain");
+    requireNonNull(resourceType, "resourceType");
+    requireNonBlank(shapeIdentifier, "shapeIdentifier");
+
+    var serviceProvider = readResource(serviceProviderUri, ServiceProvider.class);
+
+    var services = serviceProvider.getServices();
+    if (services != null) {
+      for (var service : services) {
+        var shape = lookupInService(service, domain, resourceType, shapeIdentifier);
+
+        if (shape != null) {
+          return shape;
+        }
+      }
+    }
+
+    throw new ResourceNotFoundException(
+        serviceProviderUri.toString(), "ResourceShape[" + shapeIdentifier + "]");
+  }
+
+  public ResourceShape lookupRequirementShape(URI serviceProviderUri, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    return lookupShape(
+        serviceProviderUri,
+        URI.create(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE),
+        URI.create(Oslc_rmDomainConstants.REQUIREMENT_TYPE),
+        shapeIdentifier);
+  }
+
+  public ResourceShape lookupRequirementCollectionShape(
+      URI serviceProviderUri, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    return lookupShape(
+        serviceProviderUri,
+        URI.create(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE),
+        URI.create(Oslc_rmDomainConstants.REQUIREMENTCOLLECTION_TYPE),
+        shapeIdentifier);
+  }
+
+  public ResourceShape lookupChangeRequestShape(URI serviceProviderUri, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    return lookupShape(
+        serviceProviderUri,
+        URI.create(Oslc_cmDomainConstants.CHANGE_MANAGEMENT_SHAPES_NAMSPACE),
+        URI.create(Oslc_cmDomainConstants.CHANGEREQUEST_TYPE),
+        shapeIdentifier);
+  }
+
+  public ResourceShape lookupTestPlanShape(URI serviceProviderUri, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    return lookupShape(
+        serviceProviderUri,
+        URI.create(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE),
+        URI.create(Oslc_qmDomainConstants.TESTPLAN_TYPE),
+        shapeIdentifier);
+  }
+
+  public ResourceShape lookupTestCaseShape(URI serviceProviderUri, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    return lookupShape(
+        serviceProviderUri,
+        URI.create(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE),
+        URI.create(Oslc_qmDomainConstants.TESTCASE_TYPE),
+        shapeIdentifier);
+  }
+
+  public ResourceShape lookupTestScriptShape(URI serviceProviderUri, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    return lookupShape(
+        serviceProviderUri,
+        URI.create(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE),
+        URI.create(Oslc_qmDomainConstants.TESTSCRIPT_TYPE),
+        shapeIdentifier);
+  }
+
+  public ResourceShape lookupTestExecutionRecordShape(
+      URI serviceProviderUri, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    return lookupShape(
+        serviceProviderUri,
+        URI.create(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE),
+        URI.create(Oslc_qmDomainConstants.TESTEXECUTIONRECORD_TYPE),
+        shapeIdentifier);
+  }
+
+  public ResourceShape lookupTestResultShape(URI serviceProviderUri, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    return lookupShape(
+        serviceProviderUri,
+        URI.create(Oslc_qmDomainConstants.QUALITY_MANAGEMENT_NAMSPACE),
+        URI.create(Oslc_qmDomainConstants.TESTRESULT_TYPE),
+        shapeIdentifier);
+  }
+
+  public ResourceShape lookupArchitectureResourceShape(
+      URI serviceProviderUri, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    return lookupShape(
+        serviceProviderUri,
+        URI.create(Oslc_amDomainConstants.ARCHITECTURE_MANAGEMENT_NAMSPACE),
+        URI.create(Oslc_amDomainConstants.RESOURCE_TYPE),
+        shapeIdentifier);
+  }
+
+  private ResourceShape lookupInService(
+      Service service, URI expectedDomain, URI expectedResourceType, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    if (service == null || !expectedDomain.equals(service.getDomain())) {
+      return null;
+    }
+
+    var creationFactories = service.getCreationFactories();
+    if (creationFactories == null) {
+      return null;
+    }
+
+    for (var creationFactory : creationFactories) {
+      if (creationFactory == null || !supportsResourceType(creationFactory, expectedResourceType)) {
+        continue;
+      }
+
+      var shape = lookupInCreationFactory(creationFactory, shapeIdentifier);
+
+      if (shape != null) {
+        return shape;
+      }
+    }
+
+    return null;
+  }
+
+  private ResourceShape lookupInCreationFactory(
+      CreationFactory creationFactory, String shapeIdentifier)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    var shapeUris = creationFactory.getResourceShapes();
+    if (shapeUris == null) {
+      return null;
+    }
+
+    for (var shapeUri : shapeUris) {
+      if (shapeUri == null) {
+        continue;
+      }
+
+      var resourceShape = readResource(shapeUri, ResourceShape.class);
+
+      if (matches(resourceShape, shapeUri, shapeIdentifier)) {
+        return resourceShape;
+      }
+    }
+
+    return null;
+  }
+
+  private static boolean supportsResourceType(
+      CreationFactory creationFactory, URI expectedResourceType) {
+
+    var resourceTypes = creationFactory.getResourceTypes();
+    if (resourceTypes == null) {
+      return false;
+    }
+
+    for (var resourceType : resourceTypes) {
+      if (expectedResourceType.equals(resourceType)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private static boolean matches(
+      ResourceShape resourceShape, URI advertisedShapeUri, String shapeIdentifier) {
+
+    /*
+     * The advertised shape URI normally identifies the fetched shape,
+     * so check it before examining its representation.
+     */
+    if (shapeIdentifier.equals(advertisedShapeUri.toString())) {
+      return true;
+    }
+
+    var about = resourceShape.getAbout();
+    if (about != null && shapeIdentifier.equals(about.toString())) {
+      return true;
+    }
+
+    var title = resourceShape.getTitle();
+    return title != null && shapeIdentifier.equalsIgnoreCase(title);
+  }
+
+  private <T> T readResource(URI resourceUri, Class<T> entityType)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+
+    try (Response response =
+        client.getResource(
+            resourceUri.toString(), null, OSLCConstants.CT_RDF, configurationContextValue())) {
+
+      var entity = response.readEntity(entityType);
+
+      if (entity == null) {
+        throw new ResourceNotFoundException(resourceUri.toString(), entityType.getSimpleName());
+      }
+
+      return entity;
+    }
+  }
+
+  private String configurationContextValue() {
+    return configurationContext == null ? null : configurationContext.toString();
+  }
+
+  private static String requireNonBlank(String value, String name) {
+
+    requireNonNull(value, name);
+
+    if (value.isBlank()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+
+    return value;
+  }
+}

--- a/client/oslc-client/src/main/java/org/eclipse/lyo/client/resources/RmUtil.java
+++ b/client/oslc-client/src/main/java/org/eclipse/lyo/client/resources/RmUtil.java
@@ -13,10 +13,11 @@
  */
 package org.eclipse.lyo.client.resources;
 
+import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-
+import net.oauth.OAuthException;
 import org.eclipse.lyo.client.OSLCConstants;
 import org.eclipse.lyo.client.OslcClient;
 import org.eclipse.lyo.client.exception.ResourceNotFoundException;
@@ -25,52 +26,81 @@ import org.eclipse.lyo.oslc4j.core.model.ResourceShape;
 import org.eclipse.lyo.oslc4j.core.model.Service;
 import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
 
-import jakarta.ws.rs.core.Response;
-import net.oauth.OAuthException;
-
-@Deprecated
+/**
+ * @deprecated Use {@link ResourceShapeClient} instead.
+ */
+@Deprecated(since = "4.0.0")
 public final class RmUtil {
-	public static ResourceShape lookupRequirementsInstanceShapes(final String serviceProviderUrl, final String oslcDomain, final String oslcResourceType, OslcClient client, String requiredInstanceShape)
-			throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException{
-		return lookupRequirementsInstanceShapes(serviceProviderUrl, oslcDomain, oslcResourceType, client, requiredInstanceShape,null);
-	}
-	public static ResourceShape lookupRequirementsInstanceShapes(final String serviceProviderUrl, final String oslcDomain, final String oslcResourceType, OslcClient client, String requiredInstanceShape, String configurationContext)
-			throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException
-	{
+  /**
+   * @deprecated Use {@link ResourceShapeClient#lookupShape(URI, URI, URI, String)} instead.
+   *             For RM requirements, use
+   *             {@link ResourceShapeClient#lookupRequirementShape(URI, String)}.
+   */
+  @Deprecated(since = "4.0.0")
+  public static ResourceShape lookupRequirementsInstanceShapes(
+      final String serviceProviderUrl,
+      final String oslcDomain,
+      final String oslcResourceType,
+      OslcClient client,
+      String requiredInstanceShape)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
+    return lookupRequirementsInstanceShapes(
+        serviceProviderUrl, oslcDomain, oslcResourceType, client, requiredInstanceShape, null);
+  }
 
-		Response response = client.getResource(serviceProviderUrl,null, OSLCConstants.CT_RDF, configurationContext);
-		ServiceProvider serviceProvider = response.readEntity(ServiceProvider.class);
-		if (serviceProvider != null) {
-			for (Service service:serviceProvider.getServices()) {
-				URI domain = service.getDomain();
-				if (domain != null  && domain.toString().equals(oslcDomain)) {
-					CreationFactory [] creationFactories = service.getCreationFactories();
-					if (creationFactories != null && creationFactories.length > 0) {
-						for (CreationFactory creationFactory:creationFactories) {
-							for (URI resourceType:creationFactory.getResourceTypes()) {
-								if (resourceType.toString() != null && resourceType.toString().equals(oslcResourceType)) {
-									URI[] instanceShapes = creationFactory.getResourceShapes();
-									if (instanceShapes != null ){
-										for ( URI typeURI : instanceShapes) {
-											response = client.getResource(typeURI.toString(), null, OSLCConstants.CT_RDF, configurationContext);
-											ResourceShape resourceShape =  response.readEntity(ResourceShape.class);
-											String typeTitle = resourceShape.getTitle();
-											String typeAbout = resourceShape.getAbout().toString();
-											if ( ( typeTitle != null) && (typeTitle.equalsIgnoreCase(requiredInstanceShape)) ||
-													(typeAbout != null && typeAbout.equalsIgnoreCase(requiredInstanceShape)) ) {
-												return resourceShape;
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+  /**
+   * @deprecated Use {@link ResourceShapeClient#lookupShape(URI, URI, URI, String)} with a
+   *             {@link ResourceShapeClient#ResourceShapeClient(OslcClient, URI)} instance when a
+   *             configuration context is required. For RM requirements, use
+   *             {@link ResourceShapeClient#lookupRequirementShape(URI, String)}.
+   */
+  @Deprecated(since = "4.0.0")
+  public static ResourceShape lookupRequirementsInstanceShapes(
+      final String serviceProviderUrl,
+      final String oslcDomain,
+      final String oslcResourceType,
+      OslcClient client,
+      String requiredInstanceShape,
+      String configurationContext)
+      throws IOException, URISyntaxException, ResourceNotFoundException, OAuthException {
 
+    Response response =
+        client.getResource(serviceProviderUrl, null, OSLCConstants.CT_RDF, configurationContext);
+    ServiceProvider serviceProvider = response.readEntity(ServiceProvider.class);
+    if (serviceProvider != null) {
+      for (Service service : serviceProvider.getServices()) {
+        URI domain = service.getDomain();
+        if (domain != null && domain.toString().equals(oslcDomain)) {
+          CreationFactory[] creationFactories = service.getCreationFactories();
+          if (creationFactories != null && creationFactories.length > 0) {
+            for (CreationFactory creationFactory : creationFactories) {
+              for (URI resourceType : creationFactory.getResourceTypes()) {
+                if (resourceType.toString() != null
+                    && resourceType.toString().equals(oslcResourceType)) {
+                  URI[] instanceShapes = creationFactory.getResourceShapes();
+                  if (instanceShapes != null) {
+                    for (URI typeURI : instanceShapes) {
+                      response =
+                          client.getResource(
+                              typeURI.toString(), null, OSLCConstants.CT_RDF, configurationContext);
+                      ResourceShape resourceShape = response.readEntity(ResourceShape.class);
+                      String typeTitle = resourceShape.getTitle();
+                      String typeAbout = resourceShape.getAbout().toString();
+                      if ((typeTitle != null) && (typeTitle.equalsIgnoreCase(requiredInstanceShape))
+                          || (typeAbout != null
+                              && typeAbout.equalsIgnoreCase(requiredInstanceShape))) {
+                        return resourceShape;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
 
-		throw new ResourceNotFoundException(serviceProviderUrl, "InstanceShapes");
-	}
+    throw new ResourceNotFoundException(serviceProviderUrl, "InstanceShapes");
+  }
 }

--- a/client/oslc-client/src/test/java/org/eclipse/lyo/client/resources/ResourceShapeClientTest.java
+++ b/client/oslc-client/src/test/java/org/eclipse/lyo/client/resources/ResourceShapeClientTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License 1.0
+ * which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package org.eclipse.lyo.client.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.lyo.oslc4j.core.model.OslcConstants.OSLC_CORE_NAMESPACE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.lyo.client.OSLCConstants;
+import org.eclipse.lyo.client.OslcClient;
+import org.eclipse.lyo.client.exception.ResourceNotFoundException;
+import org.eclipse.lyo.oslc.domains.cm.Oslc_cmDomainConstants;
+import org.eclipse.lyo.oslc.domains.rm.Oslc_rmDomainConstants;
+import org.eclipse.lyo.oslc4j.core.model.CreationFactory;
+import org.eclipse.lyo.oslc4j.core.model.ResourceShape;
+import org.eclipse.lyo.oslc4j.core.model.Service;
+import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
+import org.junit.jupiter.api.Test;
+
+class ResourceShapeClientTest {
+
+  private static final URI SERVICE_PROVIDER_URI =
+      URI.create("https://example.test/providers/requirements");
+  private static final URI SHAPE_URI = URI.create("https://example.test/shapes/system-requirement");
+  private static final URI OTHER_SHAPE_URI = URI.create("https://example.test/shapes/other");
+
+  @Test
+  void lookupShapeMatchesShapeTitleAndFiltersServicesAndFactories() throws Exception {
+    var client = mock(OslcClient.class);
+    var responses = new HashMap<URI, Response>();
+
+    var ignoredService =
+        new Service(URI.create(Oslc_cmDomainConstants.CHANGE_MANAGEMENT_SHAPES_NAMSPACE));
+    var ignoredFactory = new CreationFactory();
+    ignoredFactory.setResourceTypes(
+        new URI[] {URI.create(Oslc_rmDomainConstants.REQUIREMENT_TYPE)});
+    ignoredFactory.setResourceShapes(new URI[] {SHAPE_URI});
+    ignoredService.setCreationFactories(new CreationFactory[] {ignoredFactory});
+
+    var matchingService =
+        new Service(URI.create(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE));
+    var wrongFactory = new CreationFactory();
+    wrongFactory.setResourceTypes(new URI[] {URI.create(OSLCConstants.CM_CHANGE_REQUEST_TYPE)});
+    wrongFactory.setResourceShapes(new URI[] {OTHER_SHAPE_URI});
+    var matchingFactory = new CreationFactory();
+    matchingFactory.setResourceTypes(
+        new URI[] {URI.create(Oslc_rmDomainConstants.REQUIREMENT_TYPE)});
+    matchingFactory.setResourceShapes(new URI[] {OTHER_SHAPE_URI, SHAPE_URI});
+    matchingService.setCreationFactories(new CreationFactory[] {wrongFactory, matchingFactory});
+
+    var serviceProvider = new ServiceProvider();
+    serviceProvider.setServices(new Service[] {ignoredService, matchingService});
+    responses.put(SERVICE_PROVIDER_URI, responseFor(ServiceProvider.class, serviceProvider));
+
+    var otherShape = new ResourceShape(OTHER_SHAPE_URI);
+    otherShape.setTitle("Other Shape");
+    responses.put(OTHER_SHAPE_URI, responseFor(ResourceShape.class, otherShape));
+    var matchingShape = new ResourceShape(SHAPE_URI);
+    matchingShape.setTitle("System Requirement");
+    responses.put(SHAPE_URI, responseFor(ResourceShape.class, matchingShape));
+    stubResponses(client, responses);
+
+    var result =
+        new ResourceShapeClient(client)
+            .lookupShape(
+                SERVICE_PROVIDER_URI,
+                URI.create(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE),
+                URI.create(Oslc_rmDomainConstants.REQUIREMENT_TYPE),
+                "system requirement");
+
+    assertThat(result).isSameAs(matchingShape);
+    verify(client).getResource(SERVICE_PROVIDER_URI.toString(), null, OSLCConstants.CT_RDF, null);
+  }
+
+  @Test
+  void lookupShapeMatchesAdvertisedUriAndPassesConfigurationContext() throws Exception {
+    var client = mock(OslcClient.class);
+    var responses = new HashMap<URI, Response>();
+    var factory = new CreationFactory();
+    factory.setResourceTypes(new URI[] {URI.create(Oslc_rmDomainConstants.REQUIREMENT_TYPE)});
+    factory.setResourceShapes(new URI[] {SHAPE_URI});
+    var service =
+        new Service(URI.create(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE));
+    service.setCreationFactories(new CreationFactory[] {factory});
+    var serviceProvider = new ServiceProvider();
+    serviceProvider.setServices(new Service[] {service});
+    responses.put(SERVICE_PROVIDER_URI, responseFor(ServiceProvider.class, serviceProvider));
+    responses.put(SHAPE_URI, responseFor(ResourceShape.class, new ResourceShape()));
+    stubResponses(client, responses);
+
+    var result =
+        new ResourceShapeClient(client, URI.create("https://example.test/configurations/main"))
+            .lookupRequirementShape(SERVICE_PROVIDER_URI, SHAPE_URI.toString());
+
+    assertThat(result).isNotNull();
+    verify(client)
+        .getResource(
+            SERVICE_PROVIDER_URI.toString(),
+            null,
+            OSLCConstants.CT_RDF,
+            "https://example.test/configurations/main");
+    verify(client)
+        .getResource(
+            SHAPE_URI.toString(),
+            null,
+            OSLCConstants.CT_RDF,
+            "https://example.test/configurations/main");
+  }
+
+  @Test
+  void lookupShapeReportsMissingShape() throws Exception {
+    var client = mock(OslcClient.class);
+    var serviceProviderResponse = responseFor(ServiceProvider.class, new ServiceProvider());
+    stubResponses(client, Map.of(SERVICE_PROVIDER_URI, serviceProviderResponse));
+
+    assertThatThrownBy(
+            () ->
+                new ResourceShapeClient(client)
+                    .lookupShape(
+                        SERVICE_PROVIDER_URI,
+                        URI.create(Oslc_rmDomainConstants.REQUIREMENTS_MANAGEMENT_SHAPES_NAMSPACE),
+                        URI.create(Oslc_rmDomainConstants.REQUIREMENT_TYPE),
+                        "missing"))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasFieldOrPropertyWithValue("resource", SERVICE_PROVIDER_URI.toString())
+        .hasFieldOrPropertyWithValue("value", "ResourceShape[missing]");
+  }
+
+  @Test
+  void constructorAndLookupRejectInvalidArguments() {
+    assertThatThrownBy(() -> new ResourceShapeClient(null))
+        .isInstanceOf(NullPointerException.class);
+
+    var client = new ResourceShapeClient(mock(OslcClient.class));
+    var domain = URI.create(OSLC_CORE_NAMESPACE);
+    var type = URI.create(OSLC_CORE_NAMESPACE + "Resource");
+
+    assertThatThrownBy(() -> client.lookupShape(null, domain, type, "shape"))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> client.lookupShape(SERVICE_PROVIDER_URI, null, type, "shape"))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> client.lookupShape(SERVICE_PROVIDER_URI, domain, null, "shape"))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> client.lookupShape(SERVICE_PROVIDER_URI, domain, type, " "))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private static <T> Response responseFor(Class<T> entityType, T entity) {
+    var response = mock(Response.class);
+    when(response.readEntity(entityType)).thenReturn(entity);
+    return response;
+  }
+
+  private static void stubResponses(OslcClient client, Map<URI, Response> responses) {
+    when(client.getResource(
+            anyString(), isNull(), eq(OSLCConstants.CT_RDF), nullable(String.class)))
+        .thenAnswer(
+            invocation -> responses.get(URI.create(invocation.getArgument(0, String.class))));
+  }
+}


### PR DESCRIPTION
refactor RmUtil into a general shape client

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt._
- [ ] This PR was tested on at least one Lyo OSLC server (comment `@oslc-bot /test-all` if not sure) or adds unit/integration tests.
- [x] This PR does NOT break the API
- [x] Lint checks pass (run `mvn package org.openrewrite.maven:rewrite-maven-plugin:run spotless:apply -DskipTests -P'!enforcer'` if not, commit & push)

