### PR TITLE
bom: fix Jena BOM

### DIFF
--- a/bom/lyo-bom-consumer-test/pom.xml
+++ b/bom/lyo-bom-consumer-test/pom.xml
@@ -28,6 +28,13 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Third-party coordinates promised by the Lyo BOM. -->
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-tdb1</artifactId>
+    </dependency>
+
+    <!-- Lyo coordinates. -->
     <dependency>
       <groupId>org.eclipse.lyo.oslc4j.core</groupId>
       <artifactId>oslc4j-core</artifactId>

--- a/bom/lyo-bom/pom.xml
+++ b/bom/lyo-bom/pom.xml
@@ -239,7 +239,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.jena</groupId>
-        <artifactId>apache-jena-libs</artifactId>
+        <artifactId>jena-bom</artifactId>
         <version>${v.jena}</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## What changed

- import `org.apache.jena:jena-bom` from the Lyo BOM instead of importing `apache-jena-libs`
- add a versionless `jena-tdb1` dependency to the standalone BOM consumer test

## Why

`apache-jena-libs` is an aggregate dependency POM. Its Jena modules are declared under `dependencies`, not `dependencyManagement`, so importing it does not manage versions for consumers. As a result, a consumer declaring `org.apache.jena:jena-tdb1` without a version fails while processing its POM.

`jena-bom` is the Jena dependency-management BOM and manages `jena-tdb1` and the other Jena modules at the configured `${v.jena}` version.

## Impact

Consumers importing `org.eclipse.lyo:lyo-bom` can declare `org.apache.jena:jena-tdb1` without specifying a separate version.

## Validation

Before the BOM fix, the new consumer dependency reproduces the reported failure:

```text
'dependencies.dependency.version' for org.apache.jena:jena-tdb1:jar is missing
```

After the fix:

```bash
mvn -B -pl bom/lyo-bom -am install -DskipTests -P'!spotbugs'
mvn -B -Drevision=7.0.0.Alpha11 -f bom/lyo-bom-consumer-test/pom.xml verify
```

Both commands pass, and `jena-tdb1` resolves to `6.1.0`.
